### PR TITLE
feat: make ROS2 sensor stack modular — support GPS-only operation without LiDAR

### DIFF
--- a/install/compose/docker-compose.base.yml
+++ b/install/compose/docker-compose.base.yml
@@ -10,6 +10,7 @@ x-ros2-env: &ros2-env
   ROS_AUTOMATIC_DISCOVERY_RANGE: LOCALHOST
   RCUTILS_COLORIZED_OUTPUT: "1"
   RCUTILS_LOGGING_USE_STDOUT: "1"
+  LIDAR_ENABLED: ${LIDAR_ENABLED:-true}
 
 services:
 
@@ -32,6 +33,7 @@ services:
       enable_rosbridge:=true
       enable_foxglove:=true
       enable_coverage:=true
+      use_lidar:=${LIDAR_ENABLED:-true}
     volumes:
       - /dev:/dev
       - mowgli_maps:/ros2_ws/maps

--- a/ros2/CLAUDE.md
+++ b/ros2/CLAUDE.md
@@ -61,7 +61,20 @@ Two-tier launch:
    - `diagnostics_node`, `mqtt_bridge_node` (optional)
    - `foxglove_bridge` (ws://0.0.0.0:8765)
    - `rosbridge_websocket` (ws://0.0.0.0:9090, conditional on `enable_rosbridge`)
-   - `obstacle_tracker_node` (persistent LiDAR obstacle detection)
+   - `obstacle_tracker_node` (persistent LiDAR obstacle detection, conditional on `use_lidar`)
+
+## Sensor Modularity (use_lidar)
+
+The sensor stack is modular — LiDAR can be disabled for GPS-only operation:
+
+- **Launch arg:** `use_lidar:=false` (default: `true`, reads from `LIDAR_ENABLED` env var in Docker)
+- **When `use_lidar=false`:**
+  - SLAM is skipped entirely (no slam_toolbox)
+  - `obstacle_tracker_node` and `slam_heading_node` are not launched
+  - Nav2 uses `nav2_params_no_lidar.yaml` (no obstacle_layer in costmaps, no collision monitor sources)
+  - `ekf_map` publishes map→odom TF (instead of SLAM being the TF authority)
+  - Localization relies on GPS + IMU + wheel odometry only
+- **When `use_lidar=true` (default):** Behavior is unchanged from before
 
 ## Key Topics
 
@@ -169,6 +182,7 @@ All live-editable via docker-compose.override.yml bind-mounts (no rebuild needed
 | File | What it controls |
 |------|-----------------|
 | `src/mowgli_bringup/config/nav2_params.yaml` | All Nav2 params: controllers, planner, costmaps, collision monitor, velocity smoother |
+| `src/mowgli_bringup/config/nav2_params_no_lidar.yaml` | Nav2 params for GPS-only mode (no obstacle_layer, no collision monitor sources) |
 | `src/mowgli_bringup/config/coverage_planner.yaml` | F2C parameters: tool_width, spacing, headland, turning radius |
 | `src/mowgli_localization/config/localization.yaml` | Dual EKF tuning, GPS converter, wheel odometry |
 | `src/mowgli_bringup/config/obstacle_tracker.yaml` | LiDAR obstacle detection thresholds, promotion criteria |

--- a/ros2/Makefile
+++ b/ros2/Makefile
@@ -11,7 +11,7 @@ ROBOT_USER    ?= pi
 F2C_DIR       ?= /usr/local/cmake/fields2cover
 
 .PHONY: help build build-debug build-pkg test clean \
-        sim sim-stop e2e-test \
+        sim sim-stop e2e-test e2e-test-no-lidar \
         docker docker-sim \
         lint format format-check \
         deploy backup-maps
@@ -111,6 +111,26 @@ e2e-test: sim-stop
 	sleep 90; \
 	echo "Running E2E test..."; \
 	python3 src/e2e_test.py; \
+	TEST_EXIT=$$?; \
+	echo "Stopping simulation..."; \
+	kill $$SIM_PID 2>/dev/null; \
+	$(MAKE) sim-stop; \
+	exit $$TEST_EXIT
+
+e2e-test-no-lidar: sim-stop
+	@echo "Starting no-LiDAR E2E test (GPS-only simulation)..."
+	@echo ""
+	source /opt/ros/$(ROS_DISTRO)/setup.bash && \
+	source install/setup.bash && \
+	ros2 launch mowgli_bringup sim_full_system.launch.py \
+	  headless:=true use_rviz:=false use_lidar:=false \
+	  simulate_gps_degradation:=false &
+	SIM_PID=$$!; \
+	echo "Simulation PID: $$SIM_PID"; \
+	echo "Waiting 90s for Nav2 to activate..."; \
+	sleep 90; \
+	echo "Running no-LiDAR E2E test..."; \
+	python3 src/e2e_test_no_lidar.py; \
 	TEST_EXIT=$$?; \
 	echo "Stopping simulation..."; \
 	kill $$SIM_PID 2>/dev/null; \

--- a/ros2/src/e2e_test_no_lidar.py
+++ b/ros2/src/e2e_test_no_lidar.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""
+e2e_test_no_lidar.py — End-to-end simulation test for GPS-only mode (no LiDAR).
+
+Validates the full mowing cycle WITHOUT LiDAR:
+  1. Undock from charging station
+  2. Plan coverage path
+  3. Mow following planned paths (median deviation < 10cm)
+  4. Dock back when complete
+
+No obstacle avoidance test — without LiDAR there is no obstacle detection.
+GPS-only localization: ekf_map publishes map→odom TF using GPS+IMU+wheel odometry.
+
+Usage:
+  # Launch simulation first:
+  ros2 launch mowgli_bringup sim_full_system.launch.py \
+    headless:=true use_rviz:=false use_lidar:=false simulate_gps_degradation:=false
+
+  # Then run the test:
+  python3 /ros2_ws/src/e2e_test_no_lidar.py
+
+Or self-contained via: make e2e-test-no-lidar
+"""
+
+import math
+import signal
+import sys
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, DurabilityPolicy
+
+from geometry_msgs.msg import PoseWithCovarianceStamped, Twist
+from nav_msgs.msg import Path, Odometry
+from mowgli_interfaces.srv import HighLevelControl
+from mowgli_interfaces.msg import HighLevelStatus
+
+
+class TestPhase(Enum):
+    WAITING = "WAITING"
+    UNDOCKING = "UNDOCKING"
+    PLANNING = "PLANNING"
+    MOWING = "MOWING"
+    DOCKING = "DOCKING"
+    COMPLETE = "COMPLETE"
+
+
+@dataclass
+class PhaseResult:
+    name: str
+    passed: bool
+    duration_sec: float = 0.0
+    details: str = ""
+
+
+@dataclass
+class Metrics:
+    start_time: float = 0.0
+    bt_states: list = field(default_factory=list)
+    path_deviations: list = field(default_factory=list)
+    robot_poses: list = field(default_factory=list)
+    cmd_vels: list = field(default_factory=list)
+    coverage_path_len: int = 0
+    coverage_path_poses: list = field(default_factory=list)
+    phase_results: list = field(default_factory=list)
+
+
+class NoLidarE2ETestNode(Node):
+    def __init__(self):
+        super().__init__("e2e_test_no_lidar")
+
+        self.metrics = Metrics(start_time=time.time())
+        self.coverage_path = None
+        self.current_pose = None
+        self.current_bt_state = ""
+        self.test_complete = False
+        self.mowing_started = False
+
+        # Phase tracking
+        self.current_phase = TestPhase.WAITING
+        self.phase_start_time = time.time()
+
+        # EKF pose (map frame) for path deviation — more accurate than odom
+        self.ekf_map_pose = None
+
+        # QoS profiles
+        sensor_qos = QoSProfile(depth=5, reliability=ReliabilityPolicy.BEST_EFFORT)
+        reliable_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.RELIABLE)
+
+        # Subscribers
+        self.create_subscription(
+            HighLevelStatus,
+            "/behavior_tree_node/high_level_status",
+            self._on_bt_status,
+            reliable_qos,
+        )
+        self.create_subscription(
+            Path,
+            "/mowgli/coverage/path",
+            self._on_coverage_path,
+            reliable_qos,
+        )
+        self.create_subscription(
+            Odometry, "/wheel_odom", self._on_odom, sensor_qos
+        )
+        self.create_subscription(
+            Odometry,
+            "/mowgli/localization/odom_map",
+            self._on_ekf_map,
+            sensor_qos,
+        )
+        self.create_subscription(
+            Twist, "/cmd_vel", self._on_cmd_vel, sensor_qos
+        )
+
+        # Service client
+        self.hlc_client = self.create_client(
+            HighLevelControl,
+            "/behavior_tree_node/high_level_control",
+        )
+
+        # Periodic report
+        self.report_timer = self.create_timer(15.0, self._periodic_report)
+        self.get_logger().info("No-LiDAR E2E test node started.")
+
+    # ── Callbacks ────────────────────────────────────────────────────────
+
+    def _on_bt_status(self, msg: HighLevelStatus):
+        state_name = msg.state_name if hasattr(msg, "state_name") else str(msg.state)
+        t = time.time() - self.metrics.start_time
+
+        if not self.current_bt_state:
+            self.current_bt_state = state_name
+            self.metrics.bt_states.append((t, state_name))
+            self.get_logger().info(f"[{t:.1f}s] BT initial state: {state_name}")
+        elif state_name != self.current_bt_state:
+            self.get_logger().info(
+                f"[{t:.1f}s] BT state: {self.current_bt_state} -> {state_name}"
+            )
+            prev_state = self.current_bt_state
+            self.current_bt_state = state_name
+            self.metrics.bt_states.append((t, state_name))
+            self._track_phase_transition(prev_state, state_name, t)
+
+        if state_name in ("MOWING_COMPLETE", "IDLE_DOCKED") and self.mowing_started:
+            if self.current_phase == TestPhase.DOCKING or state_name == "IDLE_DOCKED":
+                self._complete_phase(TestPhase.DOCKING, True, "Robot docked successfully")
+            self.test_complete = True
+
+    def _track_phase_transition(self, prev: str, curr: str, t: float):
+        if curr == "UNDOCKING" and self.current_phase == TestPhase.WAITING:
+            self.current_phase = TestPhase.UNDOCKING
+            self.phase_start_time = t
+
+        elif curr == "PLANNING" and self.current_phase in (
+            TestPhase.UNDOCKING, TestPhase.WAITING
+        ):
+            if self.current_phase == TestPhase.UNDOCKING:
+                self._complete_phase(TestPhase.UNDOCKING, True, "Undock completed")
+            self.current_phase = TestPhase.PLANNING
+            self.phase_start_time = t
+
+        elif curr == "MOWING" and self.current_phase == TestPhase.PLANNING:
+            self._complete_phase(TestPhase.PLANNING, True, "Coverage path planned")
+            self.current_phase = TestPhase.MOWING
+            self.phase_start_time = t
+
+        elif curr in ("MOWING_COMPLETE", "RETURNING_HOME", "COVERAGE_FAILED_DOCKING"):
+            if self.current_phase == TestPhase.MOWING:
+                mow_passed = curr == "MOWING_COMPLETE"
+                self._complete_phase(
+                    TestPhase.MOWING,
+                    mow_passed,
+                    f"Mowing {'completed' if mow_passed else 'failed'}",
+                )
+            self.current_phase = TestPhase.DOCKING
+            self.phase_start_time = time.time() - self.metrics.start_time
+
+    def _complete_phase(self, phase: TestPhase, passed: bool, details: str):
+        t = time.time() - self.metrics.start_time
+        duration = t - self.phase_start_time
+        result = PhaseResult(
+            name=phase.value, passed=passed, duration_sec=duration, details=details
+        )
+        self.metrics.phase_results.append(result)
+        self.get_logger().info(
+            f"Phase {phase.value}: {'PASS' if passed else 'FAIL'} "
+            f"({duration:.1f}s) — {details}"
+        )
+
+    def _on_coverage_path(self, msg: Path):
+        self.coverage_path = msg
+        self.metrics.coverage_path_len = len(msg.poses)
+        self.metrics.coverage_path_poses = [
+            (p.pose.position.x, p.pose.position.y) for p in msg.poses
+        ]
+        self.get_logger().info(
+            f"Received coverage path with {len(msg.poses)} poses"
+        )
+
+    def _on_odom(self, msg: Odometry):
+        x = msg.pose.pose.position.x
+        y = msg.pose.pose.position.y
+        q = msg.pose.pose.orientation
+        yaw = math.atan2(
+            2.0 * (q.w * q.z + q.x * q.y),
+            1.0 - 2.0 * (q.y * q.y + q.z * q.z),
+        )
+        self.current_pose = (x, y, yaw)
+
+        t = time.time() - self.metrics.start_time
+        if not self.metrics.robot_poses or (
+            t - self.metrics.robot_poses[-1][0] > 0.5
+        ):
+            self.metrics.robot_poses.append((t, x, y, yaw))
+
+    def _on_ekf_map(self, msg: Odometry):
+        """EKF map-frame pose — used for path deviation measurement."""
+        x = msg.pose.pose.position.x
+        y = msg.pose.pose.position.y
+        self.ekf_map_pose = (x, y)
+
+        t = time.time() - self.metrics.start_time
+        if (
+            self.coverage_path
+            and self.current_phase == TestPhase.MOWING
+            and self.ekf_map_pose
+        ):
+            min_dist = self._min_distance_to_path(x, y)
+            self.metrics.path_deviations.append((t, min_dist))
+
+    def _on_cmd_vel(self, msg: Twist):
+        t = time.time() - self.metrics.start_time
+        if not self.metrics.cmd_vels or (
+            t - self.metrics.cmd_vels[-1][0] > 0.5
+        ):
+            self.metrics.cmd_vels.append((t, msg.linear.x, msg.angular.z))
+
+    # ── Helpers ──────────────────────────────────────────────────────────
+
+    def _min_distance_to_path(self, x: float, y: float) -> float:
+        poses = self.metrics.coverage_path_poses
+        if not poses:
+            return float("inf")
+        min_d = float("inf")
+        for i in range(len(poses) - 1):
+            ax, ay = poses[i]
+            bx, by = poses[i + 1]
+            dx, dy = bx - ax, by - ay
+            seg_len_sq = dx * dx + dy * dy
+            if seg_len_sq < 1e-12:
+                d = math.sqrt((x - ax) ** 2 + (y - ay) ** 2)
+            else:
+                t = max(0.0, min(1.0, ((x - ax) * dx + (y - ay) * dy) / seg_len_sq))
+                proj_x = ax + t * dx
+                proj_y = ay + t * dy
+                d = math.sqrt((x - proj_x) ** 2 + (y - proj_y) ** 2)
+            if d < min_d:
+                min_d = d
+        return min_d
+
+    def send_start_command(self):
+        if not self.hlc_client.wait_for_service(timeout_sec=10.0):
+            self.get_logger().error("HighLevelControl service not available!")
+            return False
+
+        req = HighLevelControl.Request()
+        req.command = 1  # START
+        future = self.hlc_client.call_async(req)
+        rclpy.spin_until_future_complete(self, future, timeout_sec=5.0)
+        if future.result() and future.result().success:
+            self.get_logger().info("START command sent successfully")
+            self.mowing_started = True
+            return True
+        self.get_logger().error("Failed to send START command")
+        return False
+
+    def _periodic_report(self):
+        t = time.time() - self.metrics.start_time
+        devs = self.metrics.path_deviations
+        poses = self.metrics.robot_poses
+
+        report = [
+            f"\n{'='*60}",
+            f"NO-LIDAR E2E — t={t:.0f}s  Phase: {self.current_phase.value}",
+            f"{'='*60}",
+        ]
+
+        report.append(f"BT state: {self.current_bt_state}")
+
+        if self.current_pose:
+            x, y, yaw = self.current_pose
+            report.append(
+                f"Robot pose: ({x:.2f}, {y:.2f}, yaw={math.degrees(yaw):.1f})"
+            )
+
+        if self.ekf_map_pose:
+            mx, my = self.ekf_map_pose
+            report.append(f"EKF map pose: ({mx:.2f}, {my:.2f})")
+
+        if devs:
+            recent = [d for _, d in devs[-20:]]
+            avg_dev = sum(recent) / len(recent)
+            max_dev = max(recent)
+            report.append(
+                f"Path deviation: avg={avg_dev:.4f}m  max={max_dev:.4f}m (last 20)"
+            )
+
+        report.append(f"Coverage path: {self.metrics.coverage_path_len} poses")
+
+        if len(poses) > 1:
+            dist = sum(
+                math.sqrt(
+                    (poses[i][1] - poses[i - 1][1]) ** 2
+                    + (poses[i][2] - poses[i - 1][2]) ** 2
+                )
+                for i in range(1, len(poses))
+            )
+            report.append(f"Distance traveled: {dist:.1f}m")
+
+        report.append(f"{'='*60}")
+        self.get_logger().info("\n".join(report))
+
+    def print_final_report(self) -> bool:
+        t = time.time() - self.metrics.start_time
+        devs = self.metrics.path_deviations
+        poses = self.metrics.robot_poses
+
+        report = [
+            f"\n{'#'*60}",
+            f"NO-LIDAR E2E SIMULATION REPORT",
+            f"Duration: {t:.0f}s ({t/60:.1f} min)",
+            f"{'#'*60}",
+        ]
+
+        # ── Phase Results ──
+        report.append("\n=== PHASE RESULTS ===")
+        all_phases_pass = True
+        for pr in self.metrics.phase_results:
+            status = "PASS" if pr.passed else "FAIL"
+            report.append(
+                f"  {pr.name:20s} {status} ({pr.duration_sec:.1f}s) — {pr.details}"
+            )
+            if not pr.passed:
+                all_phases_pass = False
+
+        if not self.metrics.phase_results:
+            report.append("  No phase transitions recorded!")
+            all_phases_pass = False
+
+        # ── BT State History ──
+        report.append("\n=== Behavior Tree State History ===")
+        for ts, st in self.metrics.bt_states:
+            report.append(f"  [{ts:7.1f}s] {st}")
+
+        # ── Path Tracking Quality ──
+        report.append("\n=== Path Tracking Quality (GPS-only) ===")
+        path_pass = True
+        median_dev = None
+        if devs:
+            all_devs = [d for _, d in devs]
+            avg = sum(all_devs) / len(all_devs)
+            sorted_devs = sorted(all_devs)
+            p50 = sorted_devs[int(len(sorted_devs) * 0.50)]
+            p95 = sorted_devs[min(int(len(sorted_devs) * 0.95), len(sorted_devs) - 1)]
+            max_d = max(all_devs)
+            median_dev = p50
+            report.append(f"  Samples:     {len(all_devs)}")
+            report.append(f"  Mean error:  {avg:.4f} m")
+            report.append(f"  Median:      {p50:.4f} m")
+            report.append(f"  P95 error:   {p95:.4f} m")
+            report.append(f"  Max error:   {max_d:.4f} m")
+            if p50 < 0.05:
+                report.append("  PASS: median deviation < 5cm (excellent for GPS-only)")
+            elif p50 < 0.10:
+                report.append("  PASS: median deviation < 10cm (good for GPS-only)")
+            elif p50 < 0.30:
+                report.append("  WARN: median deviation 10-30cm (acceptable but needs tuning)")
+            else:
+                report.append("  FAIL: median deviation > 30cm")
+                path_pass = False
+        else:
+            report.append("  No path deviation data collected")
+            path_pass = False
+
+        # ── Movement ──
+        report.append("\n=== Movement ===")
+        if len(poses) > 1:
+            dist = sum(
+                math.sqrt(
+                    (poses[i][1] - poses[i - 1][1]) ** 2
+                    + (poses[i][2] - poses[i - 1][2]) ** 2
+                )
+                for i in range(1, len(poses))
+            )
+            report.append(f"  Total distance: {dist:.1f} m")
+            report.append(f"  Average speed:  {dist/t:.3f} m/s")
+
+        # ── Overall Verdict ──
+        report.append(f"\n{'#'*60}")
+        report.append("VALIDATION CRITERIA:")
+
+        criteria = [
+            ("Undock→Plan→Mow→Dock cycle", all_phases_pass),
+            ("Path tracking (median < 10cm)", path_pass),
+        ]
+
+        overall_pass = True
+        for name, passed in criteria:
+            status = "PASS" if passed else "FAIL"
+            report.append(f"  [{status}] {name}")
+            if not passed:
+                overall_pass = False
+
+        if median_dev is not None:
+            report.append(f"\n  Path accuracy: {median_dev*100:.1f}cm median deviation")
+
+        report.append(f"\nOVERALL: {'PASS' if overall_pass else 'FAIL'}")
+        report.append(f"{'#'*60}\n")
+
+        self.get_logger().info("\n".join(report))
+        return overall_pass
+
+
+def wait_for_tf(node, timeout=120.0):
+    """Wait until the map→base_link TF chain is available."""
+    import tf2_ros
+    buffer = tf2_ros.Buffer()
+    listener = tf2_ros.TransformListener(buffer, node)
+
+    node.get_logger().info("Waiting for TF chain map→base_link...")
+    start = time.time()
+    while time.time() - start < timeout:
+        rclpy.spin_once(node, timeout_sec=0.5)
+        try:
+            buffer.lookup_transform(
+                "map", "base_link", rclpy.time.Time(),
+                timeout=rclpy.duration.Duration(seconds=0.5),
+            )
+            node.get_logger().info(
+                f"TF chain available after {time.time() - start:.1f}s"
+            )
+            return True
+        except Exception:
+            pass
+
+    node.get_logger().error(f"TF chain not available after {timeout}s")
+    return False
+
+
+def main():
+    rclpy.init()
+    node = NoLidarE2ETestNode()
+
+    # Wait for TF chain (ekf_odom + ekf_map must be publishing)
+    if not wait_for_tf(node, timeout=120.0):
+        node.get_logger().error("TF chain never became available. Aborting.")
+        node.destroy_node()
+        rclpy.shutdown()
+        sys.exit(1)
+
+    # Brief settle time after TF is available
+    node.get_logger().info("TF available. Waiting 5s for system to settle...")
+    time.sleep(5)
+
+    # Send START command
+    if not node.send_start_command():
+        node.get_logger().error("Failed to send START. Aborting.")
+        node.destroy_node()
+        rclpy.shutdown()
+        sys.exit(1)
+
+    # Spin until test completes or timeout (20 min)
+    timeout = 1200.0
+    start = time.time()
+
+    def _on_signal(sig, frame):
+        node.get_logger().info(f"Received signal {sig}, printing final report...")
+        node.print_final_report()
+        node.destroy_node()
+        rclpy.shutdown()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, _on_signal)
+
+    try:
+        while rclpy.ok() and not node.test_complete:
+            rclpy.spin_once(node, timeout_sec=0.1)
+            if time.time() - start > timeout:
+                node.get_logger().warn(f"Test timeout after {timeout}s")
+                break
+    except KeyboardInterrupt:
+        node.get_logger().info("Test interrupted by user")
+
+    overall = node.print_final_report()
+    node.destroy_node()
+    rclpy.shutdown()
+    sys.exit(0 if overall else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2/src/mowgli_bringup/config/nav2_params_no_lidar.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params_no_lidar.yaml
@@ -1,0 +1,362 @@
+# Nav2 parameters for Mowgli outdoor robot mower — GPS-only mode (no LiDAR).
+#
+# This is a variant of nav2_params.yaml for robots without a LiDAR sensor.
+# Differences from nav2_params.yaml:
+#   - Costmaps: no obstacle_layer (no /scan source)
+#   - Collision monitor: no observation sources (pass-through)
+#
+# IMPORTANT: When updating nav2_params.yaml, check if changes apply here too.
+
+bt_navigator:
+  ros__parameters:
+    use_sim_time: false
+    global_frame: map
+    robot_base_frame: base_link
+    odom_topic: /mowgli/hardware/wheel_odom
+    bt_loop_duration: 10
+    default_server_timeout: 60
+    default_nav_to_pose_bt_xml: /ros2_ws/install/mowgli_behavior/share/mowgli_behavior/trees/navigate_to_pose.xml
+    default_nav_through_poses_bt_xml: /opt/ros/jazzy/share/nav2_bt_navigator/behavior_trees/navigate_through_poses_w_replanning_and_recovery.xml
+    enable_stamped_cmd_vel: false
+
+bt_navigator_navigate_through_poses_rclcpp_node:
+  ros__parameters:
+    use_sim_time: false
+
+bt_navigator_navigate_to_pose_rclcpp_node:
+  ros__parameters:
+    use_sim_time: false
+
+# ---------------------------------------------------------------------------
+# Controller server
+# ---------------------------------------------------------------------------
+controller_server:
+  ros__parameters:
+    use_sim_time: false
+    controller_frequency: 10.0
+    min_x_velocity_threshold: 0.001
+    min_y_velocity_threshold: 0.5
+    min_theta_velocity_threshold: 0.001
+    failure_tolerance: 5.0
+    progress_checker_plugins: ["progress_checker"]
+    goal_checker_plugins: ["stopped_goal_checker", "coverage_goal_checker"]
+    controller_plugins: ["FollowPath"]
+
+    progress_checker:
+      plugin: "nav2_controller::SimpleProgressChecker"
+      required_movement_radius: 0.02
+      movement_time_allowance: 3600.0
+
+    stopped_goal_checker:
+      plugin: "nav2_controller::StoppedGoalChecker"
+      trans_stopped_velocity: 0.25
+      xy_goal_tolerance: 0.75
+      yaw_goal_tolerance: 1.0
+
+    coverage_goal_checker:
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.5
+      yaw_goal_tolerance: 6.28
+      stateful: true
+
+    FollowPath:
+      plugin: "nav2_rotation_shim_controller::RotationShimController"
+      primary_controller: "nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController"
+      angular_dist_threshold: 3.14
+      forward_sampling_distance: 0.5
+      rotate_to_heading_angular_vel: 1.8
+      max_angular_accel: 3.0
+      desired_linear_vel: 0.3
+      lookahead_dist: 0.4
+      min_lookahead_dist: 0.2
+      max_lookahead_dist: 0.6
+      lookahead_time: 1.0
+      transform_tolerance: 2.0
+      use_velocity_scaled_lookahead_dist: false
+      min_approach_linear_velocity: 0.05
+      approach_velocity_scaling_dist: 0.4
+      use_collision_detection: false
+      use_regulated_linear_velocity_scaling: true
+      use_cost_regulated_linear_velocity_scaling: true
+      cost_scaling_dist: 0.5
+      cost_scaling_gain: 1.0
+      use_fixed_curvature_lookahead: false
+      curvature_lookahead_dist: 0.4
+      regulated_linear_scaling_min_radius: 0.9
+      regulated_linear_scaling_min_speed: 0.1
+      use_rotate_to_heading: false
+      allow_reversing: false
+      max_angular_vel: 1.8
+      max_robot_pose_search_dist: 1000.0
+
+# ---------------------------------------------------------------------------
+# Planner server
+# ---------------------------------------------------------------------------
+planner_server:
+  ros__parameters:
+    use_sim_time: false
+    planner_plugins: ["GridBased"]
+
+    GridBased:
+      plugin: "nav2_smac_planner::SmacPlanner2D"
+      tolerance: 0.50
+      downsample_costmap: false
+      downsampling_factor: 1
+      allow_unknown: false
+      max_iterations: 1000000
+      max_on_approach_iterations: 1000
+      max_planning_time: 3.5
+      cost_travel_multiplier: 2.0
+      use_final_approach_orientation: false
+      smoother:
+        max_iterations: 1000
+        w_smooth: 0.3
+        w_data: 0.2
+        tolerance: 1.0e-10
+
+# ---------------------------------------------------------------------------
+# Smoother server
+# ---------------------------------------------------------------------------
+smoother_server:
+  ros__parameters:
+    use_sim_time: false
+    smoother_plugins: ["simple_smoother"]
+    simple_smoother:
+      plugin: "nav2_smoother::SimpleSmoother"
+      tolerance: 1.0e-10
+      max_its: 1000
+      do_refinement: true
+
+# ---------------------------------------------------------------------------
+# Recoveries / Behavior server
+# ---------------------------------------------------------------------------
+behavior_server:
+  ros__parameters:
+    use_sim_time: false
+    costmap_topic: local_costmap/costmap_raw
+    footprint_topic: local_costmap/published_footprint
+    cycle_frequency: 10.0
+    behavior_plugins: ["spin", "backup", "drive_on_heading", "assisted_teleop", "wait"]
+    spin:
+      plugin: "nav2_behaviors::Spin"
+    backup:
+      plugin: "nav2_behaviors::BackUp"
+    drive_on_heading:
+      plugin: "nav2_behaviors::DriveOnHeading"
+    wait:
+      plugin: "nav2_behaviors::Wait"
+    assisted_teleop:
+      plugin: "nav2_behaviors::AssistedTeleop"
+    global_frame: odom
+    robot_base_frame: base_link
+    transform_tolerance: 0.5
+    simulate_ahead_time: 2.0
+    max_rotational_vel: 1.5
+    min_rotational_vel: 0.15
+    rotational_acc_lim: 2.5
+
+# ---------------------------------------------------------------------------
+# Waypoint follower
+# ---------------------------------------------------------------------------
+waypoint_follower:
+  ros__parameters:
+    use_sim_time: false
+    loop_rate: 20
+    stop_on_failure: false
+    waypoint_task_executor_plugin: "wait_at_waypoint"
+    wait_at_waypoint:
+      plugin: "nav2_waypoint_follower::WaitAtWaypoint"
+      enabled: true
+      waypoint_pause_duration: 200
+
+# ---------------------------------------------------------------------------
+# Velocity smoother
+# ---------------------------------------------------------------------------
+velocity_smoother:
+  ros__parameters:
+    use_sim_time: false
+    smoothing_frequency: 20.0
+    scale_velocities: false
+    feedback: "OPEN_LOOP"
+    max_velocity: [0.3, 0.0, 1.0]
+    min_velocity: [-0.3, 0.0, -1.0]
+    max_accel: [0.3, 0.0, 1.5]
+    max_decel: [-0.3, 0.0, -1.5]
+    odom_topic: /mowgli/hardware/wheel_odom
+    odom_duration: 0.1
+    deadband_velocity: [0.0, 0.0, 0.0]
+    velocity_timeout: 1.0
+
+# ---------------------------------------------------------------------------
+# Global costmap — no obstacle layer (no LiDAR)
+# ---------------------------------------------------------------------------
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      use_sim_time: false
+      update_frequency: 1.0
+      publish_frequency: 1.0
+      global_frame: map
+      robot_base_frame: base_link
+      transform_tolerance: 60.0
+      footprint: "[[0.27, 0.20], [0.27, -0.20], [-0.27, -0.20], [-0.27, 0.20]]"
+      resolution: 0.05
+      track_unknown_space: false
+      rolling_window: true
+      width: 100
+      height: 100
+      # No obstacle_layer — LiDAR is not available in this configuration.
+      # Only inflation_layer is used for basic safety margins.
+      plugins: ["inflation_layer"]
+
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 5.0
+        inflation_radius: 0.40
+
+# ---------------------------------------------------------------------------
+# Local costmap — no obstacle layer (no LiDAR)
+# ---------------------------------------------------------------------------
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      use_sim_time: false
+      update_frequency: 5.0
+      publish_frequency: 2.0
+      global_frame: odom
+      robot_base_frame: base_link
+      # Allow up to 60s for odom→base_link TF to appear (EKF needs sensor
+      # data before publishing, which can take time on slow platforms).
+      transform_tolerance: 60.0
+      footprint: "[[0.275, 0.20], [0.275, -0.20], [-0.275, -0.20], [-0.275, 0.20]]"
+      resolution: 0.05
+      rolling_window: true
+      width: 6
+      height: 6
+      # No obstacle_layer — LiDAR is not available in this configuration.
+      plugins: ["inflation_layer"]
+
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 5.0
+        inflation_radius: 0.40
+
+# ---------------------------------------------------------------------------
+# Map server / AMCL (not used with slam_toolbox, kept for completeness)
+# ---------------------------------------------------------------------------
+map_server:
+  ros__parameters:
+    use_sim_time: false
+    yaml_filename: ""
+
+map_saver:
+  ros__parameters:
+    use_sim_time: false
+    save_map_timeout: 5.0
+    free_thresh_default: 0.25
+    occupied_thresh_default: 0.65
+    map_subscribe_transient_local: true
+
+# ---------------------------------------------------------------------------
+# Docking server (opennav_docking)
+# ---------------------------------------------------------------------------
+docking_server:
+  ros__parameters:
+    use_sim_time: false
+    controller_frequency: 50.0
+    initial_perception_timeout: 5.0
+    wait_charge_timeout: 5.0
+    dock_approach_timeout: 30.0
+    undock_linear_tolerance: 0.05
+    undock_angular_tolerance: 0.1
+    max_retries: 3
+    base_frame: base_link
+    fixed_frame: odom
+    dock_backwards: false
+    dock_prestaging_tolerance: 0.5
+    dock_plugins: ["simple_charging_dock"]
+    simple_charging_dock:
+      plugin: "opennav_docking::SimpleChargingDock"
+      docking_threshold: 0.05
+      staging_x_offset: -0.7
+      use_external_detection_pose: true
+      use_battery_status: false
+      use_stall_detection: false
+      external_detection_timeout: 1.0
+      external_detection_translation_x: -0.18
+      external_detection_translation_y: 0.0
+      external_detection_rotation_roll: -1.57
+      external_detection_rotation_pitch: -1.57
+      external_detection_rotation_yaw: 0.0
+      filter_coef: 0.1
+
+# ---------------------------------------------------------------------------
+# Collision monitor — no LiDAR sources (pass-through mode)
+# ---------------------------------------------------------------------------
+collision_monitor:
+  ros__parameters:
+    use_sim_time: false
+    base_frame_id: base_link
+    odom_frame_id: odom
+    cmd_vel_in_topic: cmd_vel_smoothed
+    cmd_vel_out_topic: cmd_vel
+    state_topic: collision_monitor_state
+    transform_tolerance: 0.2
+    source_timeout: 1.0
+    base_shift_correction: true
+    stop_pub_timeout: 2.0
+    # Polygons kept with scan source that is disabled — collision monitor
+    # requires at least one source to be declared but it won't trigger stops
+    # since the source is disabled.
+    polygons: ["PolygonStop", "FootprintApproach"]
+    PolygonStop:
+      type: "polygon"
+      points: "[[0.45, 0.30], [0.45, -0.30], [-0.25, -0.30], [-0.25, 0.30]]"
+      action_type: "stop"
+      min_points: 2
+      visualize: false
+      polygon_pub_topic: "polygon_stop"
+      enabled: false
+    FootprintApproach:
+      type: "polygon"
+      action_type: "approach"
+      footprint_topic: "/local_costmap/published_footprint"
+      time_before_collision: 2.0
+      simulation_time_step: 0.05
+      min_points: 1
+      visualize: false
+      enabled: false
+    # Scan source declared but disabled — collision monitor requires at least
+    # one observation_source to initialize without crashing.
+    observation_sources: ["scan"]
+    scan:
+      type: "scan"
+      topic: /scan
+      enabled: false
+
+# ---------------------------------------------------------------------------
+# Coverage server (opennav_coverage)
+# ---------------------------------------------------------------------------
+coverage_server:
+  ros__parameters:
+    use_sim_time: false
+    robot_width: 0.40
+    operation_width: 0.18
+    min_turning_radius: 0.01
+    linear_curv_change: 200.0
+    default_headland_width: 0.50
+    default_headland_type: "CONSTANT"
+    default_swath_type: "LENGTH"
+    default_swath_angle_type: "SET_ANGLE"
+    default_swath_angle: 0.0
+    default_allow_overlap: false
+    default_route_type: "BOUSTROPHEDON"
+    default_path_type: "DUBIN"
+    default_path_continuity_type: "CONTINUOUS"
+    coordinates_in_cartesian_frame: true
+
+lifecycle_manager_navigation:
+  ros__parameters:
+    use_sim_time: false
+    autostart: true
+    bond_timeout: 10.0

--- a/ros2/src/mowgli_bringup/launch/full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/full_system.launch.py
@@ -87,6 +87,12 @@ def generate_launch_description() -> LaunchDescription:
         description="Launch rosbridge_server for the openmower-gui when true.",
     )
 
+    use_lidar_arg = DeclareLaunchArgument(
+        "use_lidar",
+        default_value="true",
+        description="Enable LiDAR-dependent nodes (SLAM, obstacle tracker, slam heading). Set to false for GPS-only operation.",
+    )
+
     rosbridge_port_arg = DeclareLaunchArgument(
         "rosbridge_port",
         default_value="9090",
@@ -111,6 +117,7 @@ def generate_launch_description() -> LaunchDescription:
     foxglove_port = LaunchConfiguration("foxglove_port")
     enable_rosbridge = LaunchConfiguration("enable_rosbridge")
     rosbridge_port = LaunchConfiguration("rosbridge_port")
+    use_lidar = LaunchConfiguration("use_lidar")
 
     # ------------------------------------------------------------------
     # Config paths
@@ -159,6 +166,7 @@ def generate_launch_description() -> LaunchDescription:
             "map": map_yaml,
             "slam_mode": "lifelong",
             "map_file_name": "/ros2_ws/maps/garden_map",
+            "use_lidar": use_lidar,
         }.items(),
     )
 
@@ -271,6 +279,7 @@ def generate_launch_description() -> LaunchDescription:
     # heading from LiDAR map matching — works without magnetometer,
     # when stationary, and under canopy.
     slam_heading_node = Node(
+        condition=IfCondition(use_lidar),
         package="mowgli_localization",
         executable="slam_heading_node",
         name="slam_heading",
@@ -388,6 +397,7 @@ def generate_launch_description() -> LaunchDescription:
     )
 
     obstacle_tracker_node = Node(
+        condition=IfCondition(use_lidar),
         package="mowgli_map",
         executable="obstacle_tracker_node",
         name="obstacle_tracker",
@@ -413,6 +423,7 @@ def generate_launch_description() -> LaunchDescription:
             foxglove_port_arg,
             enable_rosbridge_arg,
             rosbridge_port_arg,
+            use_lidar_arg,
             # Subsystem includes
             mowgli_launch,
             navigation_launch,

--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -77,6 +77,12 @@ def generate_launch_description() -> LaunchDescription:
         description="Full path (without extension) to a saved slam_toolbox .posegraph/.data file.",
     )
 
+    use_lidar_arg = DeclareLaunchArgument(
+        "use_lidar",
+        default_value="true",
+        description="Enable LiDAR-dependent nodes (SLAM, obstacle costmap layer). Set to false for GPS-only.",
+    )
+
     # ------------------------------------------------------------------
     # Resolved substitutions
     # ------------------------------------------------------------------
@@ -86,6 +92,7 @@ def generate_launch_description() -> LaunchDescription:
     use_ekf = LaunchConfiguration("use_ekf")
     slam_mode = LaunchConfiguration("slam_mode")
     map_file_name = LaunchConfiguration("map_file_name")
+    use_lidar = LaunchConfiguration("use_lidar")
 
     # ------------------------------------------------------------------
     # Config paths
@@ -94,12 +101,22 @@ def generate_launch_description() -> LaunchDescription:
     slam_toolbox_dir = get_package_share_directory("slam_toolbox")
     localization_params = os.path.join(bringup_dir, "config", "localization.yaml")
     nav2_params_file = os.path.join(bringup_dir, "config", "nav2_params.yaml")
+    nav2_params_no_lidar_file = os.path.join(
+        bringup_dir, "config", "nav2_params_no_lidar.yaml"
+    )
 
     # Rewrite use_sim_time throughout nav2_params.yaml so that all Nav2 nodes
     # use the correct clock source.  Nav2's navigation_launch.py does NOT
     # inject use_sim_time into the params file automatically.
     nav2_params = RewrittenYaml(
         source_file=nav2_params_file,
+        root_key="",
+        param_rewrites={"use_sim_time": use_sim_time},
+        convert_types=True,
+    )
+
+    nav2_params_no_lidar = RewrittenYaml(
+        source_file=nav2_params_no_lidar_file,
         root_key="",
         param_rewrites={"use_sim_time": use_sim_time},
         convert_types=True,
@@ -159,10 +176,16 @@ def generate_launch_description() -> LaunchDescription:
         resolved_map = context.launch_configurations["map_file_name"]
         resolved_slam = context.launch_configurations["slam"]
         resolved_sim = context.launch_configurations["use_sim_time"]
+        resolved_lidar = context.launch_configurations.get("use_lidar", "true")
 
-        # If slam is disabled, return nothing
+        # If slam is disabled or no LiDAR, return nothing
         if resolved_slam.lower() not in ("true", "1", "yes"):
             return []
+
+        if resolved_lidar.lower() not in ("true", "1", "yes"):
+            return [
+                LogInfo(msg="[navigation.launch.py] LiDAR disabled — skipping SLAM. Using GPS-only localization.")
+            ]
 
         # Check if the saved posegraph file exists
         posegraph_file = resolved_map + ".posegraph"
@@ -229,18 +252,42 @@ def generate_launch_description() -> LaunchDescription:
     )
 
     # 3. robot_localization – map EKF
-    ekf_map_node = Node(
-        condition=IfCondition(use_ekf),
-        package="robot_localization",
-        executable="ekf_node",
-        name="ekf_map",
-        output="screen",
-        parameters=[
-            localization_params,
-            {"use_sim_time": use_sim_time},
-        ],
-        remappings=[("odometry/filtered", "/mowgli/localization/odom_map")],
-    )
+    #    When LiDAR is available, SLAM publishes map→odom TF and ekf_map
+    #    has publish_tf: false. When no LiDAR (GPS-only), ekf_map must
+    #    publish the map→odom TF itself.
+    def _launch_ekf_map(context):
+        resolved_lidar = context.launch_configurations.get("use_lidar", "true")
+        resolved_ekf = context.launch_configurations.get("use_ekf", "true")
+        resolved_sim = context.launch_configurations["use_sim_time"]
+
+        if resolved_ekf.lower() not in ("true", "1", "yes"):
+            return []
+
+        lidar_enabled = resolved_lidar.lower() in ("true", "1", "yes")
+        sim_time = resolved_sim.lower() in ("true", "1", "yes")
+        # Without SLAM (no LiDAR), ekf_map becomes the TF authority for map→odom
+        publish_tf = not lidar_enabled
+
+        return [
+            Node(
+                package="robot_localization",
+                executable="ekf_node",
+                name="ekf_map",
+                output="screen",
+                parameters=[
+                    localization_params,
+                    {
+                        "use_sim_time": sim_time,
+                        "publish_tf": publish_tf,
+                    },
+                ],
+                remappings=[
+                    ("odometry/filtered", "/mowgli/localization/odom_map")
+                ],
+            )
+        ]
+
+    ekf_map_launch = OpaqueFunction(function=_launch_ekf_map)
 
     # ------------------------------------------------------------------
     # 4. Nav2 navigation (controllers, planners, behaviors, BT navigator)
@@ -256,27 +303,41 @@ def generate_launch_description() -> LaunchDescription:
     # map → odom transform.  Without this delay, the planner_server's
     # global costmap times out waiting for the map frame and the
     # lifecycle_manager aborts the entire bringup.
-    nav2_navigation = TimerAction(
-        period=20.0,
-        actions=[
-            GroupAction(
+    def _launch_nav2(context):
+        resolved_lidar = context.launch_configurations.get("use_lidar", "true")
+        resolved_sim = context.launch_configurations["use_sim_time"]
+        lidar_enabled = resolved_lidar.lower() in ("true", "1", "yes")
+
+        # Select nav2 params based on LiDAR availability
+        params = nav2_params if lidar_enabled else nav2_params_no_lidar
+
+        return [
+            TimerAction(
+                period=20.0,
                 actions=[
-                    SetParameter("bond_timeout", 10.0),
-                    IncludeLaunchDescription(
-                        PythonLaunchDescriptionSource(
-                            os.path.join(
-                                nav2_bringup_dir, "launch", "navigation_launch.py"
-                            )
-                        ),
-                        launch_arguments={
-                            "use_sim_time": use_sim_time,
-                            "params_file": nav2_params,
-                        }.items(),
+                    GroupAction(
+                        actions=[
+                            SetParameter("bond_timeout", 10.0),
+                            IncludeLaunchDescription(
+                                PythonLaunchDescriptionSource(
+                                    os.path.join(
+                                        nav2_bringup_dir,
+                                        "launch",
+                                        "navigation_launch.py",
+                                    )
+                                ),
+                                launch_arguments={
+                                    "use_sim_time": resolved_sim,
+                                    "params_file": params,
+                                }.items(),
+                            ),
+                        ]
                     ),
-                ]
-            ),
-        ],
-    )
+                ],
+            )
+        ]
+
+    nav2_navigation = OpaqueFunction(function=_launch_nav2)
 
     # ------------------------------------------------------------------
     # LaunchDescription
@@ -289,9 +350,10 @@ def generate_launch_description() -> LaunchDescription:
             use_ekf_arg,
             slam_mode_arg,
             map_file_arg,
+            use_lidar_arg,
             slam_toolbox_launch,
             ekf_odom_node,
-            ekf_map_node,
+            ekf_map_launch,
             nav2_navigation,
         ]
     )

--- a/ros2/src/mowgli_bringup/launch/sim_full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/sim_full_system.launch.py
@@ -79,6 +79,12 @@ def generate_launch_description() -> LaunchDescription:
         description="Enable GPS degradation simulation (periodic float mode).",
     )
 
+    use_lidar_arg = DeclareLaunchArgument(
+        "use_lidar",
+        default_value="true",
+        description="Enable LiDAR-dependent nodes (SLAM, obstacle tracker). Set to false for GPS-only.",
+    )
+
     # ------------------------------------------------------------------
     # Resolved substitutions
     # use_sim_time is always true in simulation — no argument needed.
@@ -89,6 +95,7 @@ def generate_launch_description() -> LaunchDescription:
     headless = LaunchConfiguration("headless")
     use_rviz = LaunchConfiguration("use_rviz")
     simulate_gps_degradation = LaunchConfiguration("simulate_gps_degradation")
+    use_lidar = LaunchConfiguration("use_lidar")
 
     # ------------------------------------------------------------------
     # Config paths
@@ -151,6 +158,7 @@ def generate_launch_description() -> LaunchDescription:
             "use_ekf": "True",
             "slam_mode": "lifelong",
             "map_file_name": "/ros2_ws/maps/garden_map",
+            "use_lidar": use_lidar,
         }.items(),
     )
 
@@ -274,6 +282,7 @@ def generate_launch_description() -> LaunchDescription:
     obstacle_tracker_params = os.path.join(map_dir, "config", "obstacle_tracker.yaml")
 
     obstacle_tracker_node = Node(
+        condition=IfCondition(use_lidar),
         package="mowgli_map",
         executable="obstacle_tracker_node",
         name="obstacle_tracker",
@@ -343,6 +352,7 @@ def generate_launch_description() -> LaunchDescription:
             headless_arg,
             use_rviz_arg,
             gps_degradation_arg,
+            use_lidar_arg,
             # Topic relays (sim → hardware namespace)
             relay_wheel_odom,
             relay_imu,


### PR DESCRIPTION
Closes #29

## Summary

Makes the ROS2 sensor stack modular so LiDAR can be disabled for GPS-only operation. The installer already supports disabling LiDAR, but the ROS2 stack hardcoded `/scan` everywhere — SLAM, costmaps, collision monitor, and obstacle tracker would all fail without it. This PR bridges that gap.

## Changes

- **`install/compose/docker-compose.base.yml`** — Pass `LIDAR_ENABLED` env var into the ROS2 container and add `use_lidar:=` launch argument to the command
- **`full_system.launch.py`** — Add `use_lidar` argument, conditionally skip `obstacle_tracker_node` and `slam_heading_node`
- **`navigation.launch.py`** — Skip SLAM when `use_lidar=false`, select `nav2_params_no_lidar.yaml`, flip `ekf_map` to publish map→odom TF (instead of SLAM)
- **`sim_full_system.launch.py`** — Add `use_lidar` argument, pass through to navigation, conditionally skip obstacle tracker
- **`nav2_params_no_lidar.yaml`** (new) — Nav2 params without obstacle_layer in costmaps, collision monitor sources disabled
- **`e2e_test_no_lidar.py`** (new) — Full mowing cycle simulation test for GPS-only mode (undock→plan→mow→dock, <10cm accuracy target)
- **`Makefile`** — Add `e2e-test-no-lidar` target
- **`CLAUDE.md`** — Document sensor modularity, `use_lidar` argument, GPS-only mode

## How it works

| `use_lidar` | SLAM | obstacle_tracker | slam_heading | costmap obstacle_layer | collision monitor | map→odom TF |
|---|---|---|---|---|---|---|
| `true` (default) | Yes | Yes | Yes | Yes (`/scan`) | Yes (`/scan`) | SLAM |
| `false` | Skipped | Skipped | Skipped | Removed | Disabled sources | `ekf_map` |

The installer flow: user picks "No LiDAR" → `LIDAR_ENABLED=false` in `.env` → compose interpolates `use_lidar:=false` → ROS2 stack runs GPS-only.

## Component

- [x] ROS2 Stack (`ros2/`)
- [x] Docker (`docker/`)

## Testing

- [x] Built successfully (`colcon build`)
- [x] Launch-level testing: verified 3 scenarios (default, `use_lidar:=true`, `use_lidar:=false`) with correct process counts (19 vs 16 nodes)
- [x] Confirmed SLAM skipped with log message in no-lidar mode
- [x] Confirmed `ekf_map` receives correct `publish_tf: true` override
- [x] Confirmed no regression — default behavior identical to before
- [ ] E2E simulation test (`make e2e-test-no-lidar`) — test written, requires working Gazebo environment

## Checklist

- [x] Follows conventional commit format
- [x] Documentation updated (CLAUDE.md)
- [x] No hardcoded secrets or credentials
- [x] No unrelated changes