### PR TITLE
chore: add PlatformIO build CI for STM32 firmware

### DIFF
--- a/.github/workflows/firmware-ci.yml
+++ b/.github/workflows/firmware-ci.yml
@@ -1,0 +1,39 @@
+name: Firmware CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'firmware/**'
+  pull_request:
+    paths:
+      - 'firmware/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment:
+          - Yardforce500
+          - Yardforce500B
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.platformio
+          key: pio-${{ matrix.environment }}-${{ hashFiles('firmware/stm32/ros_usbnode/platformio.ini') }}
+          restore-keys: |
+            pio-${{ matrix.environment }}-
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Build firmware (${{ matrix.environment }})
+        run: pio run -e ${{ matrix.environment }}
+        working-directory: firmware/stm32/ros_usbnode


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to build STM32 firmware with PlatformIO
- Builds both Yardforce500 (F103) and Yardforce500B (F401) environments in a matrix
- Triggers on pushes to main and PRs touching `firmware/`
- Caches `~/.platformio` for faster builds

Closes #6

## Test plan
- [ ] Verify workflow triggers on this PR
- [ ] Confirm both matrix jobs (Yardforce500, Yardforce500B) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)