### PR TITLE
feat: add RPLiDAR sensor driver

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -76,6 +76,7 @@ services:
   #
   # Replace this service with a different driver image if you use a different
   # LiDAR (e.g., rplidar, sllidar), as long as it publishes /scan.
+  # For RPLiDAR, use: LIDAR_IMAGE=... with build context ../sensors/lidar-rplidar
   # -------------------------------------------------------------------------
   lidar:
     container_name: mowgli-lidar

--- a/install/compose/docker-compose.lidar-rplidar.yml
+++ b/install/compose/docker-compose.lidar-rplidar.yml
@@ -1,8 +1,12 @@
 # compose/docker-compose.lidar-rplidar.yml
+# RPLiDAR A1/A2/A3/S1/S2/S3/C1 driver — publishes /scan (LaserScan)
+#
+# Default launch file is for A2M8. For other models, override the command
+# with the appropriate launch file (e.g. rplidar_a1_launch.py, rplidar_s2_launch.py).
 
 x-ros2-env: &ros2-env
   ROS_DOMAIN_ID: ${ROS_DOMAIN_ID:-0}
-  RMW_IMPLEMENTATION: rmw_fastrtps_cpp
+  RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
   ROS_AUTOMATIC_DISCOVERY_RANGE: LOCALHOST
   RCUTILS_COLORIZED_OUTPUT: "1"
   RCUTILS_LOGGING_USE_STDOUT: "1"
@@ -10,9 +14,9 @@ x-ros2-env: &ros2-env
 services:
   lidar:
     container_name: mowgli-lidar
-    image: ${LIDAR_IMAGE}
+    image: ${LIDAR_IMAGE:-ghcr.io/cedbossneo/mowglinext/lidar-rplidar:main}
     build:
-      context: ./lidar
+      context: ../sensors/lidar-rplidar
     network_mode: host
     ipc: host
     privileged: true
@@ -21,10 +25,13 @@ services:
     environment:
       <<: *ros2-env
     command: >
-      ros2 launch rplidar_ros rplidar.launch.py
+      ros2 launch rplidar_ros rplidar_a2m8_launch.py
       serial_port:=${LIDAR_PORT:-/dev/lidar}
       serial_baudrate:=${LIDAR_BAUD:-115200}
       frame_id:=lidar_link
+      topic_name:=/scan
+    volumes:
+      - ../docker/config/cyclonedds.xml:/cyclonedds.xml:ro
     restart: unless-stopped
     logging:
       driver: json-file

--- a/sensors/lidar-rplidar/Dockerfile
+++ b/sensors/lidar-rplidar/Dockerfile
@@ -1,0 +1,58 @@
+# =============================================================================
+# Slamtec RPLiDAR driver for ROS2 Jazzy
+#
+# Supports RPLiDAR A1, A2, A3, S1, S2, S3, C1.
+# Publishes sensor_msgs/LaserScan on /scan with frame_id=lidar_link.
+#
+# To use this instead of the default LD19 driver, set in your .env:
+#   LIDAR_IMAGE=ghcr.io/cedbossneo/mowglinext/lidar-rplidar:main
+# or override the build context in docker-compose.override.yml.
+# =============================================================================
+FROM ros:jazzy-ros-base AS build
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-colcon-common-extensions \
+    ros-jazzy-ament-cmake \
+    build-essential \
+    cmake \
+    git \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /ros2_ws
+
+RUN git clone --depth 1 -b ros2 \
+      https://github.com/Slamtec/rplidar_ros.git \
+      src/rplidar_ros
+
+RUN /bin/bash -c "\
+    source /opt/ros/jazzy/setup.bash && \
+    colcon build \
+      --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF \
+      --parallel-workers \$(nproc) \
+    "
+
+# =============================================================================
+# Runtime — minimal image
+# =============================================================================
+FROM ros:jazzy-ros-base AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-jazzy-rmw-cyclonedds-cpp \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /ros2_ws
+
+COPY --from=build /ros2_ws/install/ install/
+
+COPY ros2_entrypoint.sh /ros2_entrypoint.sh
+RUN chmod +x /ros2_entrypoint.sh
+
+ENTRYPOINT ["/ros2_entrypoint.sh"]
+CMD ["ros2", "launch", "rplidar_ros", "rplidar_a2m8_launch.py", \
+     "frame_id:=lidar_link", \
+     "topic_name:=/scan", \
+     "serial_port:=/dev/ttyUSB0", \
+     "serial_baudrate:=115200"]

--- a/sensors/lidar-rplidar/ros2_entrypoint.sh
+++ b/sensors/lidar-rplidar/ros2_entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Source ROS2 and workspace
+source /opt/ros/jazzy/setup.bash
+source /ros2_ws/install/setup.bash
+
+exec "$@"


### PR DESCRIPTION
## Summary
- Add `sensors/lidar-rplidar/` with Dockerfile building `rplidar_ros` from source for ROS2 Jazzy
- Supports RPLiDAR A1, A2, A3, S1, S2, S3, C1 models
- Fix `install/compose/docker-compose.lidar-rplidar.yml`: use Cyclone DDS (was FastRTPS), correct build context, proper launch file, add CycloneDDS config volume

Closes #4

## Test plan
- [ ] Docker build succeeds: `docker build -t lidar-rplidar sensors/lidar-rplidar/`
- [ ] Container starts and publishes `/scan` with an RPLiDAR connected
- [ ] Install script option 2 (RPLiDAR) generates correct compose config

🤖 Generated with [Claude Code](https://claude.com/claude-code)