### PR TITLE
Pr/ (FIX) ros2 warnings clean

### DIFF
--- a/ros2/src/mowgli_hardware/src/packet_handler.cpp
+++ b/ros2/src/mowgli_hardware/src/packet_handler.cpp
@@ -17,6 +17,8 @@
 #include "mowgli_hardware/packet_handler.hpp"
 
 #include <cstring>
+#include <limits>
+#include <stdexcept>
 
 #include "mowgli_hardware/cobs.hpp"
 #include "mowgli_hardware/crc16.hpp"
@@ -99,17 +101,35 @@ void PacketHandler::dispatch_frame()
 
 std::vector<uint8_t> PacketHandler::encode_packet(const uint8_t* data, std::size_t len) const
 {
+  // Reject invalid input.
+  if (len > 0 && data == nullptr) {
+    throw std::invalid_argument("encode_packet: data is null while len > 0");
+  }
+
   // Assemble payload + 2-byte CRC placeholder.
+  if (len > std::numeric_limits<std::size_t>::max() - 2u) {
+    throw std::overflow_error("encode_packet: payload size overflow");
+  }
+
   const std::size_t payload_len = len + 2u;
   std::vector<uint8_t> payload(payload_len);
-  std::memcpy(payload.data(), data, len);
+
+  if (len > 0) {
+    std::memcpy(payload.data(), data, len);
+  }
+
   append_crc(payload.data(), payload_len);
 
   // COBS-encode.
-  std::vector<uint8_t> encoded(cobs_max_encoded_size(payload_len));
+  const std::size_t encoded_cap = cobs_max_encoded_size(payload_len);
+  std::vector<uint8_t> encoded(encoded_cap);
   const std::size_t encoded_len = cobs_encode(payload.data(), payload_len, encoded.data());
 
   // Frame: 0x00 + COBS bytes + 0x00.
+  if (encoded_len > std::numeric_limits<std::size_t>::max() - 2u) {
+    throw std::overflow_error("encode_packet: frame size overflow");
+  }
+
   std::vector<uint8_t> frame;
   frame.reserve(encoded_len + 2u);
   frame.push_back(0x00);

--- a/ros2/src/mowgli_hardware/src/packet_handler.cpp
+++ b/ros2/src/mowgli_hardware/src/packet_handler.cpp
@@ -102,19 +102,22 @@ void PacketHandler::dispatch_frame()
 std::vector<uint8_t> PacketHandler::encode_packet(const uint8_t* data, std::size_t len) const
 {
   // Reject invalid input.
-  if (len > 0 && data == nullptr) {
+  if (len > 0 && data == nullptr)
+  {
     throw std::invalid_argument("encode_packet: data is null while len > 0");
   }
 
   // Assemble payload + 2-byte CRC placeholder.
-  if (len > std::numeric_limits<std::size_t>::max() - 2u) {
+  if (len > std::numeric_limits<std::size_t>::max() - 2u)
+  {
     throw std::overflow_error("encode_packet: payload size overflow");
   }
 
   const std::size_t payload_len = len + 2u;
   std::vector<uint8_t> payload(payload_len);
 
-  if (len > 0) {
+  if (len > 0)
+  {
     std::memcpy(payload.data(), data, len);
   }
 
@@ -126,7 +129,8 @@ std::vector<uint8_t> PacketHandler::encode_packet(const uint8_t* data, std::size
   const std::size_t encoded_len = cobs_encode(payload.data(), payload_len, encoded.data());
 
   // Frame: 0x00 + COBS bytes + 0x00.
-  if (encoded_len > std::numeric_limits<std::size_t>::max() - 2u) {
+  if (encoded_len > std::numeric_limits<std::size_t>::max() - 2u)
+  {
     throw std::overflow_error("encode_packet: frame size overflow");
   }
 

--- a/ros2/src/mowgli_map/src/obstacle_tracker_node.cpp
+++ b/ros2/src/mowgli_map/src/obstacle_tracker_node.cpp
@@ -1291,7 +1291,7 @@ void ObstacleTrackerNode::load_from_file()
         tracked_.push_back(current);
         max_id = std::max(max_id, current.id);
       }
-      current = TrackedObstacle{};
+      current = TrackedObstacle();
       in_obstacle = true;
       in_hull = false;
       current.id = static_cast<uint32_t>(std::stoul(trimmed.substr(5)));

--- a/ros2/src/mowgli_nav2_plugins/src/ftc_controller.cpp
+++ b/ros2/src/mowgli_nav2_plugins/src/ftc_controller.cpp
@@ -472,7 +472,7 @@ void FTCController::setSpeedLimit(const double& speed_limit, const bool& percent
 // ── computeVelocityCommands ───────────────────────────────────────────────────
 
 geometry_msgs::msg::TwistStamped FTCController::computeVelocityCommands(
-    const geometry_msgs::msg::PoseStamped& pose,
+    const geometry_msgs::msg::PoseStamped& /*pose*/,
     const geometry_msgs::msg::Twist& /*velocity*/,
     nav2_core::GoalChecker* goal_checker)
 {
@@ -512,7 +512,7 @@ geometry_msgs::msg::TwistStamped FTCController::computeVelocityCommands(
   RCLCPP_INFO_THROTTLE(logger_,
                        *clock_,
                        2000,
-                       "FTCController: state=%d idx=%zu/%zu dt=%.4f "
+                       "FTCController: state=%d idx=%u/%zu dt=%.4f "
                        "lat=%.3f lon=%.3f ang=%.3f(deg=%.1f) pos=(%.2f,%.2f)",
                        static_cast<int>(current_state_),
                        current_index_,
@@ -530,7 +530,7 @@ geometry_msgs::msg::TwistStamped FTCController::computeVelocityCommands(
   if (new_state != current_state_)
   {
     RCLCPP_INFO(logger_,
-                "FTCController: state transition %d -> %d (idx=%zu, angle_err=%.3f deg).",
+                "FTCController: state transition %d -> %d (idx=%u, angle_err=%.3f deg).",
                 static_cast<int>(current_state_),
                 static_cast<int>(new_state),
                 current_index_,


### PR DESCRIPTION
## Summary

Fix several GCC warnings in ROS2 packages and apply formatting cleanups.

## Changes

- Fix packet encoding safety checks in `mowgli_hardware`
- Fix `TrackedObstacle` reinitialization warning in `mowgli_map`
- Fix format specifiers and unused parameter warning in `mowgli_nav2_plugins`
- Apply formatting adjustments required by CI

## Component

- [x] ROS2 Stack (`ros2/`)
- [ ] GUI (`gui/`)
- [ ] Docker (`docker/`)
- [ ] Sensors (`sensors/`)
- [ ] Firmware (`firmware/`)
- [ ] Documentation (`docs/`)
- [ ] CI/CD (`.github/`)

## Testing

- [x] Built successfully
- [ ] Tested on hardware
- [ ] Tested in simulation
- [ ] Unit tests pass
- [x] Manual testing

## Checklist

- [x] Follows conventional commit format
- [ ] Documentation updated (if user-facing)
- [x] No hardcoded secrets or credentials
- [x] No unrelated changes