### PR TITLE
Feat/mavros compatibilty include ardupilot and px4 autopilot firmware

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,18 @@
+BasedOnStyle: Google
+
+IndentWidth: 2
+TabWidth: 2
+UseTab: Never
+
+ColumnLimit: 100
+
+BreakBeforeBraces: Attach
+
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+
+PointerAlignment: Left
+
+SortIncludes: true
+
+Standard: c++17

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -62,6 +62,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # ── Bridges ──
     ros-jazzy-foxglove-bridge \
     ros-jazzy-rosbridge-suite \
+    # ── MAVROS / Pixhawk ──
+    ros-jazzy-mavros \
+    ros-jazzy-mavros-msgs \
     # ── Message definitions ──
     ros-jazzy-ublox-msgs \
     ros-jazzy-nmea-msgs \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,16 @@
   "workspaceMount": "source=${localWorkspaceFolder},target=/ros2_ws/src/mowglinext,type=bind",
   "workspaceFolder": "/ros2_ws/src/mowglinext",
 
+  // Active serial port for testing mavros and other serial bridge
+  "runArgs": [
+    "--device=/dev/ttyACM0:/dev/ttyACM0",
+    "--device=/dev/ttyACM1:/dev/ttyACM1"
+  ],
+
+  "mounts": [
+    "source=/dev/serial,target=/dev/serial,type=bind"
+  ],
+  
   // Forward ports for visualization and debugging
   "forwardPorts": [
     8765,   // Foxglove Bridge WebSocket

--- a/ros2/Dockerfile
+++ b/ros2/Dockerfile
@@ -118,6 +118,8 @@ COPY src/mowgli_simulation/package.xml    src/mowgli_simulation/package.xml
 COPY src/mowgli_simulation/CMakeLists.txt src/mowgli_simulation/CMakeLists.txt
 COPY src/mowgli_bringup/package.xml       src/mowgli_bringup/package.xml
 COPY src/mowgli_bringup/CMakeLists.txt    src/mowgli_bringup/CMakeLists.txt
+COPY src/mowgli_mavros_bridge/package.xml      src/mowgli_mavros_bridge/package.xml
+COPY src/mowgli_mavros_bridge/CMakeLists.txt   src/mowgli_mavros_bridge/CMakeLists.txt
 
 # Resolve rosdep dependencies (cached until package.xml changes)
 RUN rosdep update --rosdistro jazzy \

--- a/ros2/src/mowgli_mavros_bridge/CMakeLists.txt
+++ b/ros2/src/mowgli_mavros_bridge/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.08)
+project(mowgli_mavros_bridge)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
+find_package(mowgli_interfaces REQUIRED)
+find_package(mavros_msgs REQUIRED)
+
+add_executable(mavros_hardware_bridge_node
+  src/mavros_hardware_bridge_node.cpp
+)
+
+target_include_directories(mavros_hardware_bridge_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+ament_target_dependencies(mavros_hardware_bridge_node
+  rclcpp
+  geometry_msgs
+  nav_msgs
+  sensor_msgs
+  std_msgs
+  std_srvs
+  mowgli_interfaces
+  mavros_msgs
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(
+  TARGETS mavros_hardware_bridge_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_package()

--- a/ros2/src/mowgli_mavros_bridge/include/mavros_hardware_bridge_node.hpp
+++ b/ros2/src/mowgli_mavros_bridge/include/mavros_hardware_bridge_node.hpp
@@ -13,7 +13,6 @@
 #include <mavros_msgs/msg/state.hpp>
 #include <mavros_msgs/srv/command_bool.hpp>
 #include <mavros_msgs/srv/set_mode.hpp>
-
 #include <mowgli_interfaces/msg/emergency.hpp>
 #include <mowgli_interfaces/msg/high_level_status.hpp>
 #include <mowgli_interfaces/msg/power.hpp>
@@ -27,8 +26,7 @@ namespace mowgli_mavros_bridge
 class MavrosHardwareBridgeNode : public rclcpp::Node
 {
 public:
-  explicit MavrosHardwareBridgeNode(
-    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+  explicit MavrosHardwareBridgeNode(const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
 
 private:
   void create_publishers();
@@ -46,19 +44,19 @@ private:
   void on_mavros_odom(const nav_msgs::msg::Odometry::SharedPtr msg);
 
   void on_mower_control(
-    const std::shared_ptr<mowgli_interfaces::srv::MowerControl::Request> request,
-    std::shared_ptr<mowgli_interfaces::srv::MowerControl::Response> response);
+      const std::shared_ptr<mowgli_interfaces::srv::MowerControl::Request> request,
+      std::shared_ptr<mowgli_interfaces::srv::MowerControl::Response> response);
 
   void on_emergency_stop(
-    const std::shared_ptr<mowgli_interfaces::srv::EmergencyStop::Request> request,
-    std::shared_ptr<mowgli_interfaces::srv::EmergencyStop::Response> response);
+      const std::shared_ptr<mowgli_interfaces::srv::EmergencyStop::Request> request,
+      std::shared_ptr<mowgli_interfaces::srv::EmergencyStop::Response> response);
 
   void publish_status();
   void publish_emergency();
   void publish_power();
 
   bool send_arm_command(bool arm);
-  bool send_mode_command(const std::string & mode);
+  bool send_mode_command(const std::string& mode);
 
 private:
   std::mutex mutex_;

--- a/ros2/src/mowgli_mavros_bridge/include/mavros_hardware_bridge_node.hpp
+++ b/ros2/src/mowgli_mavros_bridge/include/mavros_hardware_bridge_node.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <mutex>
+#include <string>
+
+#include <geometry_msgs/msg/twist.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/battery_state.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+
+#include <mavros_msgs/msg/manual_control.hpp>
+#include <mavros_msgs/msg/state.hpp>
+#include <mavros_msgs/srv/command_bool.hpp>
+#include <mavros_msgs/srv/set_mode.hpp>
+
+#include <mowgli_interfaces/msg/emergency.hpp>
+#include <mowgli_interfaces/msg/high_level_status.hpp>
+#include <mowgli_interfaces/msg/power.hpp>
+#include <mowgli_interfaces/msg/status.hpp>
+#include <mowgli_interfaces/srv/emergency_stop.hpp>
+#include <mowgli_interfaces/srv/mower_control.hpp>
+
+namespace mowgli_mavros_bridge
+{
+
+class MavrosHardwareBridgeNode : public rclcpp::Node
+{
+public:
+  explicit MavrosHardwareBridgeNode(
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+private:
+  void create_publishers();
+  void create_subscriptions();
+  void create_services();
+  void create_timers();
+  void create_clients();
+
+  void on_cmd_vel(const geometry_msgs::msg::Twist::SharedPtr msg);
+  void on_high_level_status(const mowgli_interfaces::msg::HighLevelStatus::SharedPtr msg);
+
+  void on_mavros_state(const mavros_msgs::msg::State::SharedPtr msg);
+  void on_mavros_imu(const sensor_msgs::msg::Imu::SharedPtr msg);
+  void on_mavros_battery(const sensor_msgs::msg::BatteryState::SharedPtr msg);
+  void on_mavros_odom(const nav_msgs::msg::Odometry::SharedPtr msg);
+
+  void on_mower_control(
+    const std::shared_ptr<mowgli_interfaces::srv::MowerControl::Request> request,
+    std::shared_ptr<mowgli_interfaces::srv::MowerControl::Response> response);
+
+  void on_emergency_stop(
+    const std::shared_ptr<mowgli_interfaces::srv::EmergencyStop::Request> request,
+    std::shared_ptr<mowgli_interfaces::srv::EmergencyStop::Response> response);
+
+  void publish_status();
+  void publish_emergency();
+  void publish_power();
+
+  bool send_arm_command(bool arm);
+  bool send_mode_command(const std::string & mode);
+
+private:
+  std::mutex mutex_;
+
+  double status_publish_rate_hz_{10.0};
+  bool rain_detected_{false};
+  bool esc_power_{true};
+  bool raspberry_pi_power_{true};
+  bool sound_module_available_{false};
+  bool sound_module_busy_{false};
+  bool ui_board_available_{false};
+
+  bool mow_enabled_{false};
+  uint8_t mow_direction_{0};
+
+  bool emergency_active_{false};
+  bool emergency_latched_{false};
+  std::string emergency_reason_{"NONE"};
+
+  bool is_charging_{false};
+  bool charger_enabled_{false};
+  std::string charger_status_{"unknown"};
+
+  double battery_voltage_{0.0};
+  double charge_voltage_{0.0};
+  double charge_current_{0.0};
+
+  uint8_t mower_esc_status_{0};
+  float mower_esc_temperature_{0.0F};
+  float mower_esc_current_{0.0F};
+  float mower_motor_temperature_{0.0F};
+  float mower_motor_rpm_{0.0F};
+
+  mavros_msgs::msg::State mavros_state_{};
+  sensor_msgs::msg::Imu last_imu_{};
+  nav_msgs::msg::Odometry last_odom_{};
+  sensor_msgs::msg::BatteryState last_battery_{};
+  mowgli_interfaces::msg::HighLevelStatus last_high_level_status_{};
+
+  rclcpp::Publisher<mowgli_interfaces::msg::Status>::SharedPtr pub_status_;
+  rclcpp::Publisher<mowgli_interfaces::msg::Emergency>::SharedPtr pub_emergency_;
+  rclcpp::Publisher<mowgli_interfaces::msg::Power>::SharedPtr pub_power_;
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub_imu_;
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_wheel_odom_;
+  rclcpp::Publisher<sensor_msgs::msg::BatteryState>::SharedPtr pub_battery_state_;
+  rclcpp::Publisher<mavros_msgs::msg::ManualControl>::SharedPtr pub_manual_control_;
+
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr sub_cmd_vel_;
+  rclcpp::Subscription<mowgli_interfaces::msg::HighLevelStatus>::SharedPtr sub_hl_status_;
+  rclcpp::Subscription<mavros_msgs::msg::State>::SharedPtr sub_mavros_state_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_mavros_imu_;
+  rclcpp::Subscription<sensor_msgs::msg::BatteryState>::SharedPtr sub_mavros_battery_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_mavros_odom_;
+
+  rclcpp::Service<mowgli_interfaces::srv::MowerControl>::SharedPtr srv_mower_control_;
+  rclcpp::Service<mowgli_interfaces::srv::EmergencyStop>::SharedPtr srv_emergency_stop_;
+
+  rclcpp::Client<mavros_msgs::srv::CommandBool>::SharedPtr cli_arm_;
+  rclcpp::Client<mavros_msgs::srv::SetMode>::SharedPtr cli_set_mode_;
+
+  rclcpp::TimerBase::SharedPtr timer_status_;
+};
+
+}  // namespace mowgli_mavros_bridge

--- a/ros2/src/mowgli_mavros_bridge/package.xml
+++ b/ros2/src/mowgli_mavros_bridge/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>mowgli_mavros_bridge</name>
+  <version>0.1.0</version>
+  <description>MAVROS/Pixhawk hardware bridge for Mowgli</description>
+
+  <maintainer email="pepeuch@gmail.com">You</maintainer>
+  <license>GPL-3.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>mowgli_interfaces</depend>
+  <depend>mavros_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros2/src/mowgli_mavros_bridge/src/mavros_hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_mavros_bridge/src/mavros_hardware_bridge_node.cpp
@@ -14,7 +14,7 @@ namespace mowgli_mavros_bridge
 using namespace std::chrono_literals;
 
 MavrosHardwareBridgeNode::MavrosHardwareBridgeNode(const rclcpp::NodeOptions& options)
-: rclcpp::Node("hardware_bridge", options)
+    : rclcpp::Node("hardware_bridge", options)
 {
   status_publish_rate_hz_ = declare_parameter<double>("status_publish_rate_hz", 10.0);
   rain_detected_ = declare_parameter<bool>("rain_detected_default", false);
@@ -40,7 +40,7 @@ void MavrosHardwareBridgeNode::create_publishers()
   pub_battery_state_ = create_publisher<sensor_msgs::msg::BatteryState>("/battery_state", 10);
 
   pub_manual_control_ =
-    create_publisher<mavros_msgs::msg::ManualControl>("/mavros/manual_control/send", 10);
+      create_publisher<mavros_msgs::msg::ManualControl>("/mavros/manual_control/send", 10);
 }
 
 void MavrosHardwareBridgeNode::create_subscriptions()
@@ -49,43 +49,51 @@ void MavrosHardwareBridgeNode::create_subscriptions()
   auto sensor_qos = rclcpp::SensorDataQoS();
 
   sub_cmd_vel_ = create_subscription<geometry_msgs::msg::Twist>(
-    "/cmd_vel", default_qos,
-    std::bind(&MavrosHardwareBridgeNode::on_cmd_vel, this, std::placeholders::_1));
+      "/cmd_vel",
+      default_qos,
+      std::bind(&MavrosHardwareBridgeNode::on_cmd_vel, this, std::placeholders::_1));
 
   sub_hl_status_ = create_subscription<mowgli_interfaces::msg::HighLevelStatus>(
-    "/high_level_status", default_qos,
-    std::bind(&MavrosHardwareBridgeNode::on_high_level_status, this, std::placeholders::_1));
+      "/high_level_status",
+      default_qos,
+      std::bind(&MavrosHardwareBridgeNode::on_high_level_status, this, std::placeholders::_1));
 
   sub_mavros_state_ = create_subscription<mavros_msgs::msg::State>(
-    "/mavros/state", default_qos,
-    std::bind(&MavrosHardwareBridgeNode::on_mavros_state, this, std::placeholders::_1));
+      "/mavros/state",
+      default_qos,
+      std::bind(&MavrosHardwareBridgeNode::on_mavros_state, this, std::placeholders::_1));
 
   sub_mavros_imu_ = create_subscription<sensor_msgs::msg::Imu>(
-    "/mavros/imu/data", sensor_qos,
-    std::bind(&MavrosHardwareBridgeNode::on_mavros_imu, this, std::placeholders::_1));
+      "/mavros/imu/data",
+      sensor_qos,
+      std::bind(&MavrosHardwareBridgeNode::on_mavros_imu, this, std::placeholders::_1));
 
   sub_mavros_battery_ = create_subscription<sensor_msgs::msg::BatteryState>(
-    "/mavros/battery", sensor_qos,
-    std::bind(&MavrosHardwareBridgeNode::on_mavros_battery, this, std::placeholders::_1));
+      "/mavros/battery",
+      sensor_qos,
+      std::bind(&MavrosHardwareBridgeNode::on_mavros_battery, this, std::placeholders::_1));
 
   sub_mavros_odom_ = create_subscription<nav_msgs::msg::Odometry>(
-    "/mavros/local_position/odom", sensor_qos,
-    std::bind(&MavrosHardwareBridgeNode::on_mavros_odom, this, std::placeholders::_1));
+      "/mavros/local_position/odom",
+      sensor_qos,
+      std::bind(&MavrosHardwareBridgeNode::on_mavros_odom, this, std::placeholders::_1));
 }
 
 void MavrosHardwareBridgeNode::create_services()
 {
   srv_mower_control_ = create_service<mowgli_interfaces::srv::MowerControl>(
-    "~/mower_control",
-    std::bind(
-      &MavrosHardwareBridgeNode::on_mower_control, this,
-      std::placeholders::_1, std::placeholders::_2));
+      "~/mower_control",
+      std::bind(&MavrosHardwareBridgeNode::on_mower_control,
+                this,
+                std::placeholders::_1,
+                std::placeholders::_2));
 
   srv_emergency_stop_ = create_service<mowgli_interfaces::srv::EmergencyStop>(
-    "~/emergency_stop",
-    std::bind(
-      &MavrosHardwareBridgeNode::on_emergency_stop, this,
-      std::placeholders::_1, std::placeholders::_2));
+      "~/emergency_stop",
+      std::bind(&MavrosHardwareBridgeNode::on_emergency_stop,
+                this,
+                std::placeholders::_1,
+                std::placeholders::_2));
 }
 
 void MavrosHardwareBridgeNode::create_clients()
@@ -98,19 +106,18 @@ void MavrosHardwareBridgeNode::create_timers()
 {
   const auto period = std::chrono::duration<double>(1.0 / std::max(1.0, status_publish_rate_hz_));
 
-  timer_status_ = create_wall_timer(
-    std::chrono::duration_cast<std::chrono::milliseconds>(period),
-    [this]()
-    {
-      publish_status();
-      publish_emergency();
-      publish_power();
+  timer_status_ = create_wall_timer(std::chrono::duration_cast<std::chrono::milliseconds>(period),
+                                    [this]()
+                                    {
+                                      publish_status();
+                                      publish_emergency();
+                                      publish_power();
 
-      std::lock_guard<std::mutex> lock(mutex_);
-      pub_imu_->publish(last_imu_);
-      pub_wheel_odom_->publish(last_odom_);
-      pub_battery_state_->publish(last_battery_);
-    });
+                                      std::lock_guard<std::mutex> lock(mutex_);
+                                      pub_imu_->publish(last_imu_);
+                                      pub_wheel_odom_->publish(last_odom_);
+                                      pub_battery_state_->publish(last_battery_);
+                                    });
 }
 
 void MavrosHardwareBridgeNode::on_cmd_vel(const geometry_msgs::msg::Twist::SharedPtr msg)
@@ -126,7 +133,7 @@ void MavrosHardwareBridgeNode::on_cmd_vel(const geometry_msgs::msg::Twist::Share
 }
 
 void MavrosHardwareBridgeNode::on_high_level_status(
-  const mowgli_interfaces::msg::HighLevelStatus::SharedPtr msg)
+    const mowgli_interfaces::msg::HighLevelStatus::SharedPtr msg)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   last_high_level_status_ = *msg;
@@ -145,7 +152,7 @@ void MavrosHardwareBridgeNode::on_mavros_imu(const sensor_msgs::msg::Imu::Shared
 }
 
 void MavrosHardwareBridgeNode::on_mavros_battery(
-  const sensor_msgs::msg::BatteryState::SharedPtr msg)
+    const sensor_msgs::msg::BatteryState::SharedPtr msg)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   last_battery_ = *msg;
@@ -159,8 +166,8 @@ void MavrosHardwareBridgeNode::on_mavros_odom(const nav_msgs::msg::Odometry::Sha
 }
 
 void MavrosHardwareBridgeNode::on_mower_control(
-  const std::shared_ptr<mowgli_interfaces::srv::MowerControl::Request> request,
-  std::shared_ptr<mowgli_interfaces::srv::MowerControl::Response> response)
+    const std::shared_ptr<mowgli_interfaces::srv::MowerControl::Request> request,
+    std::shared_ptr<mowgli_interfaces::srv::MowerControl::Response> response)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   mow_enabled_ = request->mow_enabled;
@@ -171,8 +178,8 @@ void MavrosHardwareBridgeNode::on_mower_control(
 }
 
 void MavrosHardwareBridgeNode::on_emergency_stop(
-  const std::shared_ptr<mowgli_interfaces::srv::EmergencyStop::Request> request,
-  std::shared_ptr<mowgli_interfaces::srv::EmergencyStop::Response> response)
+    const std::shared_ptr<mowgli_interfaces::srv::EmergencyStop::Request> request,
+    std::shared_ptr<mowgli_interfaces::srv::EmergencyStop::Response> response)
 {
   std::lock_guard<std::mutex> lock(mutex_);
 
@@ -270,7 +277,7 @@ bool MavrosHardwareBridgeNode::send_arm_command(bool arm)
   return result == rclcpp::FutureReturnCode::SUCCESS && future.get()->success;
 }
 
-bool MavrosHardwareBridgeNode::send_mode_command(const std::string & mode)
+bool MavrosHardwareBridgeNode::send_mode_command(const std::string& mode)
 {
   if (!cli_set_mode_->wait_for_service(1s))
   {
@@ -289,7 +296,7 @@ bool MavrosHardwareBridgeNode::send_mode_command(const std::string & mode)
 
 }  // namespace mowgli_mavros_bridge
 
-int main(int argc, char ** argv)
+int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
   rclcpp::spin(std::make_shared<mowgli_mavros_bridge::MavrosHardwareBridgeNode>());

--- a/ros2/src/mowgli_mavros_bridge/src/mavros_hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_mavros_bridge/src/mavros_hardware_bridge_node.cpp
@@ -1,0 +1,298 @@
+#include "mavros_hardware_bridge_node.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+
+namespace mowgli_mavros_bridge
+{
+
+using namespace std::chrono_literals;
+
+MavrosHardwareBridgeNode::MavrosHardwareBridgeNode(const rclcpp::NodeOptions& options)
+: rclcpp::Node("hardware_bridge", options)
+{
+  status_publish_rate_hz_ = declare_parameter<double>("status_publish_rate_hz", 10.0);
+  rain_detected_ = declare_parameter<bool>("rain_detected_default", false);
+  esc_power_ = declare_parameter<bool>("esc_power_default", true);
+  raspberry_pi_power_ = declare_parameter<bool>("raspberry_pi_power_default", true);
+
+  create_publishers();
+  create_subscriptions();
+  create_services();
+  create_clients();
+  create_timers();
+
+  RCLCPP_INFO(get_logger(), "MAVROS hardware bridge started.");
+}
+
+void MavrosHardwareBridgeNode::create_publishers()
+{
+  pub_status_ = create_publisher<mowgli_interfaces::msg::Status>("~/status", 10);
+  pub_emergency_ = create_publisher<mowgli_interfaces::msg::Emergency>("~/emergency", 10);
+  pub_power_ = create_publisher<mowgli_interfaces::msg::Power>("~/power", 10);
+  pub_imu_ = create_publisher<sensor_msgs::msg::Imu>("~/imu/data_raw", 10);
+  pub_wheel_odom_ = create_publisher<nav_msgs::msg::Odometry>("~/wheel_odom", 10);
+  pub_battery_state_ = create_publisher<sensor_msgs::msg::BatteryState>("/battery_state", 10);
+
+  pub_manual_control_ =
+    create_publisher<mavros_msgs::msg::ManualControl>("/mavros/manual_control/send", 10);
+}
+
+void MavrosHardwareBridgeNode::create_subscriptions()
+{
+  auto default_qos = rclcpp::QoS(rclcpp::KeepLast(10));
+  auto sensor_qos = rclcpp::SensorDataQoS();
+
+  sub_cmd_vel_ = create_subscription<geometry_msgs::msg::Twist>(
+    "/cmd_vel", default_qos,
+    std::bind(&MavrosHardwareBridgeNode::on_cmd_vel, this, std::placeholders::_1));
+
+  sub_hl_status_ = create_subscription<mowgli_interfaces::msg::HighLevelStatus>(
+    "/high_level_status", default_qos,
+    std::bind(&MavrosHardwareBridgeNode::on_high_level_status, this, std::placeholders::_1));
+
+  sub_mavros_state_ = create_subscription<mavros_msgs::msg::State>(
+    "/mavros/state", default_qos,
+    std::bind(&MavrosHardwareBridgeNode::on_mavros_state, this, std::placeholders::_1));
+
+  sub_mavros_imu_ = create_subscription<sensor_msgs::msg::Imu>(
+    "/mavros/imu/data", sensor_qos,
+    std::bind(&MavrosHardwareBridgeNode::on_mavros_imu, this, std::placeholders::_1));
+
+  sub_mavros_battery_ = create_subscription<sensor_msgs::msg::BatteryState>(
+    "/mavros/battery", sensor_qos,
+    std::bind(&MavrosHardwareBridgeNode::on_mavros_battery, this, std::placeholders::_1));
+
+  sub_mavros_odom_ = create_subscription<nav_msgs::msg::Odometry>(
+    "/mavros/local_position/odom", sensor_qos,
+    std::bind(&MavrosHardwareBridgeNode::on_mavros_odom, this, std::placeholders::_1));
+}
+
+void MavrosHardwareBridgeNode::create_services()
+{
+  srv_mower_control_ = create_service<mowgli_interfaces::srv::MowerControl>(
+    "~/mower_control",
+    std::bind(
+      &MavrosHardwareBridgeNode::on_mower_control, this,
+      std::placeholders::_1, std::placeholders::_2));
+
+  srv_emergency_stop_ = create_service<mowgli_interfaces::srv::EmergencyStop>(
+    "~/emergency_stop",
+    std::bind(
+      &MavrosHardwareBridgeNode::on_emergency_stop, this,
+      std::placeholders::_1, std::placeholders::_2));
+}
+
+void MavrosHardwareBridgeNode::create_clients()
+{
+  cli_arm_ = create_client<mavros_msgs::srv::CommandBool>("/mavros/cmd/arming");
+  cli_set_mode_ = create_client<mavros_msgs::srv::SetMode>("/mavros/set_mode");
+}
+
+void MavrosHardwareBridgeNode::create_timers()
+{
+  const auto period = std::chrono::duration<double>(1.0 / std::max(1.0, status_publish_rate_hz_));
+
+  timer_status_ = create_wall_timer(
+    std::chrono::duration_cast<std::chrono::milliseconds>(period),
+    [this]()
+    {
+      publish_status();
+      publish_emergency();
+      publish_power();
+
+      std::lock_guard<std::mutex> lock(mutex_);
+      pub_imu_->publish(last_imu_);
+      pub_wheel_odom_->publish(last_odom_);
+      pub_battery_state_->publish(last_battery_);
+    });
+}
+
+void MavrosHardwareBridgeNode::on_cmd_vel(const geometry_msgs::msg::Twist::SharedPtr msg)
+{
+  mavros_msgs::msg::ManualControl cmd{};
+  cmd.header.stamp = now();
+
+  // TODO: adapt scaling to ArduPilot expectations.
+  cmd.x = static_cast<int16_t>(msg->linear.x * 1000.0);
+  cmd.r = static_cast<int16_t>(msg->angular.z * 1000.0);
+
+  pub_manual_control_->publish(cmd);
+}
+
+void MavrosHardwareBridgeNode::on_high_level_status(
+  const mowgli_interfaces::msg::HighLevelStatus::SharedPtr msg)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  last_high_level_status_ = *msg;
+}
+
+void MavrosHardwareBridgeNode::on_mavros_state(const mavros_msgs::msg::State::SharedPtr msg)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  mavros_state_ = *msg;
+}
+
+void MavrosHardwareBridgeNode::on_mavros_imu(const sensor_msgs::msg::Imu::SharedPtr msg)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  last_imu_ = *msg;
+}
+
+void MavrosHardwareBridgeNode::on_mavros_battery(
+  const sensor_msgs::msg::BatteryState::SharedPtr msg)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  last_battery_ = *msg;
+  battery_voltage_ = msg->voltage;
+}
+
+void MavrosHardwareBridgeNode::on_mavros_odom(const nav_msgs::msg::Odometry::SharedPtr msg)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  last_odom_ = *msg;
+}
+
+void MavrosHardwareBridgeNode::on_mower_control(
+  const std::shared_ptr<mowgli_interfaces::srv::MowerControl::Request> request,
+  std::shared_ptr<mowgli_interfaces::srv::MowerControl::Response> response)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  mow_enabled_ = request->mow_enabled;
+  mow_direction_ = request->mow_direction;
+
+  // TODO: replace with actual Pixhawk output / MAVLink command for blade control.
+  response->success = true;
+}
+
+void MavrosHardwareBridgeNode::on_emergency_stop(
+  const std::shared_ptr<mowgli_interfaces::srv::EmergencyStop::Request> request,
+  std::shared_ptr<mowgli_interfaces::srv::EmergencyStop::Response> response)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (request->emergency != 0U)
+  {
+    emergency_active_ = true;
+    emergency_latched_ = true;
+    emergency_reason_ = "SERVICE_EMERGENCY_STOP";
+    mow_enabled_ = false;
+  }
+  else
+  {
+    emergency_active_ = false;
+    emergency_reason_ = "NONE";
+  }
+
+  response->success = true;
+}
+
+void MavrosHardwareBridgeNode::publish_status()
+{
+  mowgli_interfaces::msg::Status msg;
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    msg.stamp = now();
+    msg.raspberry_pi_power = raspberry_pi_power_;
+    msg.is_charging = is_charging_;
+    msg.esc_power = esc_power_;
+    msg.rain_detected = rain_detected_;
+    msg.sound_module_available = sound_module_available_;
+    msg.sound_module_busy = sound_module_busy_;
+    msg.ui_board_available = ui_board_available_;
+    msg.mow_enabled = mow_enabled_;
+
+    // TODO: define proper mower status enum mapping.
+    msg.mower_status = mavros_state_.armed ? 1U : 0U;
+
+    msg.mower_esc_status = mower_esc_status_;
+    msg.mower_esc_temperature = mower_esc_temperature_;
+    msg.mower_esc_current = mower_esc_current_;
+    msg.mower_motor_temperature = mower_motor_temperature_;
+    msg.mower_motor_rpm = mower_motor_rpm_;
+  }
+
+  pub_status_->publish(msg);
+}
+
+void MavrosHardwareBridgeNode::publish_emergency()
+{
+  mowgli_interfaces::msg::Emergency msg;
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    msg.stamp = now();
+    msg.active_emergency = emergency_active_;
+    msg.latched_emergency = emergency_latched_;
+    msg.reason = emergency_reason_;
+  }
+
+  pub_emergency_->publish(msg);
+}
+
+void MavrosHardwareBridgeNode::publish_power()
+{
+  mowgli_interfaces::msg::Power msg;
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    msg.stamp = now();
+    msg.v_charge = static_cast<float>(charge_voltage_);
+    msg.v_battery = static_cast<float>(battery_voltage_);
+    msg.charge_current = static_cast<float>(charge_current_);
+    msg.charger_enabled = charger_enabled_;
+    msg.charger_status = charger_status_;
+  }
+
+  pub_power_->publish(msg);
+}
+
+bool MavrosHardwareBridgeNode::send_arm_command(bool arm)
+{
+  if (!cli_arm_->wait_for_service(1s))
+  {
+    RCLCPP_WARN(get_logger(), "Arming service not available.");
+    return false;
+  }
+
+  auto req = std::make_shared<mavros_msgs::srv::CommandBool::Request>();
+  req->value = arm;
+
+  auto future = cli_arm_->async_send_request(req);
+  const auto result = rclcpp::spin_until_future_complete(get_node_base_interface(), future, 2s);
+
+  return result == rclcpp::FutureReturnCode::SUCCESS && future.get()->success;
+}
+
+bool MavrosHardwareBridgeNode::send_mode_command(const std::string & mode)
+{
+  if (!cli_set_mode_->wait_for_service(1s))
+  {
+    RCLCPP_WARN(get_logger(), "Set mode service not available.");
+    return false;
+  }
+
+  auto req = std::make_shared<mavros_msgs::srv::SetMode::Request>();
+  req->custom_mode = mode;
+
+  auto future = cli_set_mode_->async_send_request(req);
+  const auto result = rclcpp::spin_until_future_complete(get_node_base_interface(), future, 2s);
+
+  return result == rclcpp::FutureReturnCode::SUCCESS && future.get()->mode_sent;
+}
+
+}  // namespace mowgli_mavros_bridge
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<mowgli_mavros_bridge::MavrosHardwareBridgeNode>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
## Summary

Introduce a MAVROS-based hardware bridge to connect Mowgli ROS2 stack with Pixhawk flight controllers.

This enables using ArduPilot/PX4-compatible flight controllers as the main control unit for the mower.

## Changes

* Add new ROS2 package `mowgli_mavros_bridge`
* Implement hardware_bridge interface:

  * status
  * power
  * emergency
  * imu
  * odometry
* Integrate MAVROS topics:

  * `/mavros/state`
  * `/mavros/imu/data`
  * `/mavros/battery`
  * `/mavros/local_position/odom`
* Validate MAVLink communication with Pixhawk5X over USB
* Prepare architecture for future hardware integration (VESC, sensors, BMS)

## Component

* [x] ROS2 Stack (`ros2/`)
* [ ] GUI (`gui/`)
* [ ] Docker (`docker/`)
* [ ] Sensors (`sensors/`)
* [ ] Firmware (`firmware/`)
* [ ] Documentation (`docs/`)
* [ ] CI/CD (`.github/`)

## Testing

* [x] Built successfully
* [x] Tested on hardware (Pixhawk via USB)
* [ ] Tested in simulation
* [ ] Unit tests pass
* [x] Manual testing

## Checklist

* [x] Follows conventional commit format
* [ ] Documentation updated (if user-facing)
* [x] No hardcoded secrets or credentials
* [x] No unrelated changes

---

### Notes

This is a first functional version (MVP).
Some MAVROS topics may not provide meaningful data yet due to limited hardware setup (Pixhawk powered via USB only).

Future improvements will include:

* proper QoS handling
* full sensor integration
* actuator control validation
* power system integration

Project direction: reuse legacy drone hardware (Pixhawk + ArduPilot/PX4) for eco-friendly autonomous mowing.
