### PR TITLE
fix: translate ROS2 state values to firmware mode in hardware_bridge

### DIFF
--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -623,11 +623,24 @@ private:
                     sizeof(LlHeartbeat) - sizeof(uint16_t));  // CRC appended by encode_packet.
   }
 
+  // Translate ROS2 HighLevelStatus state values to firmware mode values.
+  // ROS2: 0=NULL, 1=IDLE, 2=AUTONOMOUS, 3=RECORDING
+  // FW:   0=IDLE, 1=AUTONOMOUS, 2=RECORDING
+  static uint8_t ros2_state_to_fw_mode(uint8_t ros2_state)
+  {
+    switch (ros2_state)
+    {
+      case 2: return 1;  // AUTONOMOUS
+      case 3: return 2;  // RECORDING
+      default: return 0; // NULL or IDLE → FW IDLE
+    }
+  }
+
   void send_high_level_state()
   {
     LlHighLevelState pkt{};
     pkt.type = PACKET_ID_LL_HIGH_LEVEL_STATE;
-    pkt.current_mode = current_mode_;
+    pkt.current_mode = ros2_state_to_fw_mode(current_mode_);
     pkt.gps_quality = gps_quality_;
 
     send_raw_packet(reinterpret_cast<const uint8_t*>(&pkt),
@@ -669,9 +682,10 @@ private:
   {
     // The firmware ignores cmd_vel when mode is IDLE.  When velocity commands
     // arrive (from Nav2 or teleop), ensure the firmware is in AUTONOMOUS mode.
-    if (current_mode_ == 0u && (msg->linear.x != 0.0 || msg->angular.z != 0.0))
+    // ROS2 states: 0=NULL, 1=IDLE, 2=AUTONOMOUS
+    if (current_mode_ <= 1u && (msg->linear.x != 0.0 || msg->angular.z != 0.0))
     {
-      current_mode_ = 1u;  // AUTONOMOUS
+      current_mode_ = 2u;  // ROS2 AUTONOMOUS (maps to FW mode 1)
       send_high_level_state();
     }
 


### PR DESCRIPTION
The ROS2 HighLevelStatus uses 0=NULL, 1=IDLE, 2=AUTONOMOUS, 3=RECORDING but the STM32 firmware expects 0=IDLE, 1=AUTONOMOUS, 2=RECORDING.

The hardware_bridge was forwarding ROS2 state values directly, so when the BT published state=2 (AUTONOMOUS), the firmware received mode=2 which it interpreted as RECORDING — motors stayed disabled during undock.

Also fixes the cmd_vel auto-promote which checked for NULL (0) instead of IDLE (1) and promoted to IDLE (1) instead of AUTONOMOUS (2).

## Summary

<!-- What does this PR do? Keep it brief. -->

## Changes

<!-- Bullet list of what changed and why -->

-

## Component

<!-- Check all that apply -->

- [ ] ROS2 Stack (`ros2/`)
- [ ] GUI (`gui/`)
- [ ] Docker (`docker/`)
- [ ] Sensors (`sensors/`)
- [ ] Firmware (`firmware/`)
- [ ] Documentation (`docs/`)
- [ ] CI/CD (`.github/`)

## Testing

<!-- How was this tested? -->

- [ ] Built successfully
- [ ] Tested on hardware
- [ ] Tested in simulation
- [ ] Unit tests pass
- [ ] Manual testing

## Checklist

- [ ] Follows conventional commit format
- [ ] Documentation updated (if user-facing)
- [ ] No hardcoded secrets or credentials
- [ ] No unrelated changes
