### PR TITLE
fix: align firmware mode switch with ROS2 HighLevelStatus constants

### DIFF
--- a/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
+++ b/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
@@ -194,17 +194,23 @@ static void on_hl_state(const uint8_t *data, size_t len)
     // Map host mode to internal status for motor safety
     // Mode 0 = IDLE, 1 = AUTONOMOUS, 2 = RECORDING
     switch (hl_current_mode) {
-    case 1:  // AUTONOMOUS
+    case 2:  // HIGH_LEVEL_STATE_AUTONOMOUS
         PANEL_Set_LED(PANEL_LED_S1, PANEL_LED_ON);
         PANEL_Set_LED(PANEL_LED_S2, PANEL_LED_OFF);
         main_eOpenmowerStatus = OPENMOWER_STATUS_MOWING;
         break;
-    case 2:  // RECORDING
+    case 3:  // HIGH_LEVEL_STATE_RECORDING
         PANEL_Set_LED(PANEL_LED_S1, PANEL_LED_OFF);
         PANEL_Set_LED(PANEL_LED_S2, PANEL_LED_ON);
         main_eOpenmowerStatus = OPENMOWER_STATUS_RECORD;
         break;
-    case 0:  // IDLE
+    case 4:  // HIGH_LEVEL_STATE_MANUAL_MOWING — teleop with motors enabled, blade managed by GUI
+        PANEL_Set_LED(PANEL_LED_S1, PANEL_LED_ON);
+        PANEL_Set_LED(PANEL_LED_S2, PANEL_LED_ON);
+        main_eOpenmowerStatus = OPENMOWER_STATUS_MOWING;
+        break;
+    case 0:  // HIGH_LEVEL_STATE_NULL
+    case 1:  // HIGH_LEVEL_STATE_IDLE
     default:
         PANEL_Set_LED(PANEL_LED_S1, PANEL_LED_OFF);
         PANEL_Set_LED(PANEL_LED_S2, PANEL_LED_OFF);


### PR DESCRIPTION
## Summary
- Firmware `on_hl_state` switch cases were off-by-one vs ROS2 `HighLevelStatus.msg` constants (AUTONOMOUS=2, RECORDING=3, not 1 and 2)
- All modes (teleop, autonomous, recording) fell into `default` → IDLE, causing firmware to silently discard every `cmd_vel`
- Added missing `case 4` for MANUAL_MOWING so teleop works

## Test plan
- [ ] Flash updated firmware (`cd firmware/stm32/ros_usbnode && pio run`)
- [ ] Verify teleop via Foxglove (`/cmd_vel_teleop`) moves the robot
- [ ] Verify autonomous mowing (`COMMAND_START`) drives the robot
- [ ] Verify area recording (`COMMAND_RECORD_AREA`) allows driving during boundary recording
- [ ] Verify IDLE mode still zeroes motors and rejects cmd_vel