### PR TITLE
fix: use named HL_MODE constants instead of magic numbers in firmware

### DIFF
--- a/firmware/stm32/ros_usbnode/include/mowgli_protocol.h
+++ b/firmware/stm32/ros_usbnode/include/mowgli_protocol.h
@@ -234,9 +234,19 @@ typedef struct {
  *
  * Wire size: 5 bytes (must match sizeof(LlHighLevelState) in ll_datatypes.hpp).
  */
+/**
+ * High-level operating modes sent by the ROS 2 host.
+ * These MUST match the constants in mowgli_interfaces/msg/HighLevelStatus.msg.
+ */
+#define HL_MODE_NULL             0u   /**< Emergency or transitional */
+#define HL_MODE_IDLE             1u   /**< Idle, docked, charging */
+#define HL_MODE_AUTONOMOUS       2u   /**< Autonomous mowing */
+#define HL_MODE_RECORDING        3u   /**< Area boundary recording */
+#define HL_MODE_MANUAL_MOWING    4u   /**< Manual teleop with blade */
+
 typedef struct {
     uint8_t  type;         /**< PKT_ID_HL_STATE */
-    uint8_t  current_mode; /**< High-level operating mode identifier */
+    uint8_t  current_mode; /**< High-level operating mode (HL_MODE_*) */
     uint8_t  gps_quality;  /**< GPS fix quality [0-100] */
     uint16_t crc;          /**< CRC-16 CCITT over preceding bytes */
 } pkt_hl_state_t;

--- a/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
+++ b/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
@@ -191,26 +191,26 @@ static void on_hl_state(const uint8_t *data, size_t len)
         PANEL_Set_LED(PANEL_LED_LOCK, PANEL_LED_ON);
     }
 
-    // Map host mode to internal status for motor safety
-    // Mode 0 = IDLE, 1 = AUTONOMOUS, 2 = RECORDING
+    // Map host mode to internal status for motor safety.
+    // Constants defined in mowgli_protocol.h — keep in sync with HighLevelStatus.msg.
     switch (hl_current_mode) {
-    case 2:  // HIGH_LEVEL_STATE_AUTONOMOUS
+    case HL_MODE_AUTONOMOUS:
         PANEL_Set_LED(PANEL_LED_S1, PANEL_LED_ON);
         PANEL_Set_LED(PANEL_LED_S2, PANEL_LED_OFF);
         main_eOpenmowerStatus = OPENMOWER_STATUS_MOWING;
         break;
-    case 3:  // HIGH_LEVEL_STATE_RECORDING
+    case HL_MODE_RECORDING:
         PANEL_Set_LED(PANEL_LED_S1, PANEL_LED_OFF);
         PANEL_Set_LED(PANEL_LED_S2, PANEL_LED_ON);
         main_eOpenmowerStatus = OPENMOWER_STATUS_RECORD;
         break;
-    case 4:  // HIGH_LEVEL_STATE_MANUAL_MOWING — teleop with motors enabled, blade managed by GUI
+    case HL_MODE_MANUAL_MOWING:
         PANEL_Set_LED(PANEL_LED_S1, PANEL_LED_ON);
         PANEL_Set_LED(PANEL_LED_S2, PANEL_LED_ON);
         main_eOpenmowerStatus = OPENMOWER_STATUS_MOWING;
         break;
-    case 0:  // HIGH_LEVEL_STATE_NULL
-    case 1:  // HIGH_LEVEL_STATE_IDLE
+    case HL_MODE_NULL:
+    case HL_MODE_IDLE:
     default:
         PANEL_Set_LED(PANEL_LED_S1, PANEL_LED_OFF);
         PANEL_Set_LED(PANEL_LED_S2, PANEL_LED_OFF);

--- a/ros2/src/mowgli_hardware/firmware/mowgli_protocol.h
+++ b/ros2/src/mowgli_hardware/firmware/mowgli_protocol.h
@@ -249,10 +249,20 @@ extern "C"
    *
    * Wire size: 5 bytes (must match sizeof(LlHighLevelState) in ll_datatypes.hpp).
    */
+  /**
+   * High-level operating modes sent by the ROS 2 host.
+   * These MUST match the constants in mowgli_interfaces/msg/HighLevelStatus.msg.
+   */
+#define HL_MODE_NULL             0u   /**< Emergency or transitional */
+#define HL_MODE_IDLE             1u   /**< Idle, docked, charging */
+#define HL_MODE_AUTONOMOUS       2u   /**< Autonomous mowing */
+#define HL_MODE_RECORDING        3u   /**< Area boundary recording */
+#define HL_MODE_MANUAL_MOWING    4u   /**< Manual teleop with blade */
+
   typedef struct
   {
     uint8_t type; /**< PKT_ID_HL_STATE */
-    uint8_t current_mode; /**< High-level operating mode identifier */
+    uint8_t current_mode; /**< High-level operating mode (HL_MODE_*) */
     uint8_t gps_quality; /**< GPS fix quality [0-100] */
     uint16_t crc; /**< CRC-16 CCITT over preceding bytes */
   } pkt_hl_state_t;


### PR DESCRIPTION
## Summary
- Add `HL_MODE_*` defines to `mowgli_protocol.h` (both firmware and ROS2 copies) matching `HighLevelStatus.msg` constants
- Replace magic numbers in `cpp_main.cpp` `on_hl_state` switch with named constants
- Ensures firmware mode mapping stays in sync with ROS2 and is self-documenting

Follows up on #80 which fixed the wrong case values.

## Test plan
- [ ] Flash updated firmware
- [ ] Verify autonomous mowing, recording, manual mowing, and idle all map correctly
- [ ] Verify blade stays on during manual mowing (no longer zeroed by IDLE default case)