### PR TITLE
fix: remove snakeToPascalJSON transform — send raw rosbridge JSON to frontend

### DIFF
--- a/gui/pkg/providers/ros.go
+++ b/gui/pkg/providers/ros.go
@@ -180,7 +180,7 @@ func NewRosProvider(dbProvider types2.IDBProvider) types2.IRosProvider {
 // initRosbridgeSubscriptions sends subscribe ops to rosbridge for every
 // real (non-virtual) topic in topicMap. Shape-changing topics are passed
 // through dedicated adapter functions (defined in transform.go); all other
-// topics receive a generic snake_case → PascalCase key rename.
+// topics are forwarded as-is (rosbridge snake_case JSON).
 func (r *RosProvider) initRosbridgeSubscriptions() {
 	adapters := map[string]func([]byte) ([]byte, error){
 		"pose":  adaptPose,
@@ -202,15 +202,7 @@ func (r *RosProvider) initRosbridgeSubscriptions() {
 					logrus.Errorf("RosProvider: adapt %s: %v", key, err)
 					return
 				}
-				// Adapter output uses Go structs with json:"snake_case" tags;
-				// the frontend expects PascalCase keys, so convert.
-				converted, err := snakeToPascalJSON(adapted)
-				if err != nil {
-					logrus.Errorf("RosProvider: transform adapted %s: %v", key, err)
-					r.fanOut(key, adapted) // fallback
-					return
-				}
-				r.fanOut(key, converted)
+				r.fanOut(key, adapted)
 			}, throttle)
 			if err != nil {
 				logrus.Errorf("RosProvider: subscribe %s (%s): %v", def.ROS2Topic, key, err)
@@ -219,13 +211,7 @@ func (r *RosProvider) initRosbridgeSubscriptions() {
 			}
 		} else {
 			err := r.client.Subscribe(def.ROS2Topic, def.MsgType, "gui-"+key, func(msg json.RawMessage) {
-				converted, err := snakeToPascalJSON([]byte(msg))
-				if err != nil {
-					logrus.Errorf("RosProvider: transform %s: %v", key, err)
-					r.fanOut(key, []byte(msg)) // fallback
-					return
-				}
-				r.fanOut(key, converted)
+				r.fanOut(key, []byte(msg))
 			}, throttle)
 			if err != nil {
 				logrus.Errorf("RosProvider: subscribe %s (%s): %v", def.ROS2Topic, key, err)
@@ -367,13 +353,7 @@ func (r *RosProvider) pollMap() {
 		return
 	}
 
-	// Convert to PascalCase for frontend
-	converted, err := snakeToPascalJSON(data)
-	if err != nil {
-		r.fanOut("map", data)
-		return
-	}
-	r.fanOut("map", converted)
+	r.fanOut("map", data)
 }
 
 

--- a/gui/pkg/providers/scheduler.go
+++ b/gui/pkg/providers/scheduler.go
@@ -56,8 +56,7 @@ func (s *SchedulerProvider) subscribeToStatus() {
 	if err := s.rosProvider.Subscribe("highLevelStatus", "scheduler-hls", func(msg []byte) {
 		var hls mowgli.HighLevelStatus
 		if err := json.Unmarshal(msg, &hls); err != nil {
-			// Fan-out converts snake_case → PascalCase; try the PascalCase variant
-			// by trying to decode State from either representation.
+			// Fallback: try to find the state field by either name variant.
 			var raw map[string]json.RawMessage
 			if jsonErr := json.Unmarshal(msg, &raw); jsonErr != nil {
 				return

--- a/gui/pkg/providers/transform.go
+++ b/gui/pkg/providers/transform.go
@@ -3,69 +3,10 @@ package providers
 import (
 	"encoding/json"
 	"math"
-	"strings"
 
 	"github.com/cedbossneo/mowglinext/pkg/msgs/geometry"
 	"github.com/cedbossneo/mowglinext/pkg/msgs/mowgli"
 )
-
-// ---------------------------------------------------------------------------
-// Snake_case → PascalCase key conversion
-// ---------------------------------------------------------------------------
-
-// snakeToPascal converts a single snake_case identifier to PascalCase.
-// Each underscore-delimited segment has its first letter uppercased.
-// Examples:
-//
-//	"mower_status" → "MowerStatus"
-//	"frame_id"     → "FrameId"
-//	"x"            → "X"
-//	"v_charge"     → "VCharge"
-func snakeToPascal(s string) string {
-	parts := strings.Split(s, "_")
-	var b strings.Builder
-	for _, p := range parts {
-		if len(p) == 0 {
-			continue
-		}
-		b.WriteString(strings.ToUpper(p[:1]))
-		if len(p) > 1 {
-			b.WriteString(p[1:])
-		}
-	}
-	return b.String()
-}
-
-// convertKeys recursively walks a value produced by json.Unmarshal into an
-// interface{} and converts every map key from snake_case to PascalCase.
-// Non-map values are returned unchanged.
-func convertKeys(v interface{}) interface{} {
-	switch val := v.(type) {
-	case map[string]interface{}:
-		out := make(map[string]interface{}, len(val))
-		for k, child := range val {
-			out[snakeToPascal(k)] = convertKeys(child)
-		}
-		return out
-	case []interface{}:
-		for i, elem := range val {
-			val[i] = convertKeys(elem)
-		}
-		return val
-	default:
-		return v
-	}
-}
-
-// snakeToPascalJSON unmarshals data as generic JSON, converts all map keys
-// from snake_case to PascalCase, and re-marshals the result.
-func snakeToPascalJSON(data []byte) ([]byte, error) {
-	var v interface{}
-	if err := json.Unmarshal(data, &v); err != nil {
-		return nil, err
-	}
-	return json.Marshal(convertKeys(v))
-}
 
 // ---------------------------------------------------------------------------
 // Raw input structs – used only for unmarshalling rosbridge snake_case JSON.
@@ -170,7 +111,7 @@ func navSatStatusToFlags(status int8) uint16 {
 // ---------------------------------------------------------------------------
 
 // adaptGPS converts a sensor_msgs/NavSatFix payload (rosbridge snake_case
-// JSON) into an mowgli.AbsolutePose JSON payload (PascalCase, suitable for
+// JSON) into an mowgli.AbsolutePose JSON payload (snake_case, suitable for
 // the frontend).
 func adaptGPS(raw []byte) ([]byte, error) {
 	var fix rawNavSatFix
@@ -200,7 +141,7 @@ func adaptGPS(raw []byte) ([]byte, error) {
 }
 
 // adaptPose converts a nav_msgs/Odometry payload (rosbridge snake_case JSON)
-// into an mowgli.AbsolutePose JSON payload (PascalCase).
+// into an mowgli.AbsolutePose JSON payload (snake_case via json tags).
 // The heading (yaw) is derived from the orientation quaternion.
 func adaptPose(raw []byte) ([]byte, error) {
 	var odom rawOdometry
@@ -241,7 +182,7 @@ func adaptPose(raw []byte) ([]byte, error) {
 }
 
 // adaptTicks converts a nav_msgs/Odometry payload (rosbridge snake_case JSON)
-// into an mowgli.WheelTick JSON payload (PascalCase).
+// into an mowgli.WheelTick JSON payload (snake_case via json tags).
 // nav_msgs/Odometry does not carry raw tick data, so all tick fields are
 // zero. This is an acceptable transitional state while a dedicated
 // wheel-tick topic is wired up.


### PR DESCRIPTION
## Summary
- Remove `snakeToPascalJSON` / `snakeToPascal` / `convertKeys` from `providers/transform.go`
- Remove all calls to `snakeToPascalJSON` in `providers/ros.go` (subscription callbacks + `pollMap`)
- Frontend now receives native rosbridge snake_case JSON, matching the TypeScript types from #83

## Why
The Go backend had a `snakeToPascalJSON` transform that converted all rosbridge JSON keys from snake_case to PascalCase before sending to the frontend. This meant the frontend depended on a non-standard format that differed from both rosbridge and the `.msg` definitions. Removing it makes the data pipeline consistent end-to-end.

## Test plan
- [ ] Verify Go builds (`cd gui && go build ./...`)
- [ ] Verify all WebSocket subscriptions show data (status, GPS, emergency, power, IMU)
- [ ] Verify joystick teleop works
- [ ] Verify map loads correctly