### PR TITLE
fix: costmap size, min speeds, boundary enforcement, joystick publish

### DIFF
--- a/gui/pkg/api/mowglinext.go
+++ b/gui/pkg/api/mowglinext.go
@@ -226,6 +226,11 @@ func SubscriberRoute(group *gin.RouterGroup, provider types.IRosProvider) {
 			def, err = subscribe(provider, c, conn, "coverageCells", -1)
 		case "recordingTrajectory":
 			def, err = subscribe(provider, c, conn, "recordingTrajectory", -1)
+		case "obstacles":
+			def, err = subscribe(provider, c, conn, "obstacles", -1)
+		default:
+			log.Printf("SubscriberRoute: unknown topic %q", topic)
+			return
 		}
 		if err != nil {
 			log.Println(err.Error())

--- a/gui/pkg/foxglove/client.go
+++ b/gui/pkg/foxglove/client.go
@@ -284,8 +284,9 @@ func (c *Client) Advertise(topic, msgType string) error {
 }
 
 // Publish sends a message on topic. The message is JSON-encoded and sent as a
-// client publish message. schemaName is the ROS2 message type.
-func (c *Client) Publish(topic string, msg interface{}) error {
+// client publish message. schemaName is the ROS2 message type (e.g.
+// "geometry_msgs/msg/Twist"). The bridge needs this to convert JSON to CDR.
+func (c *Client) Publish(topic string, msg interface{}, schemaName ...string) error {
 	if !c.connected.Load() {
 		return fmt.Errorf("foxglove: Publish %s: not connected", topic)
 	}
@@ -306,7 +307,12 @@ func (c *Client) Publish(topic string, msg interface{}) error {
 					ID:         chanID,
 					Topic:      topic,
 					Encoding:   "json",
-					SchemaName: "", // foxglove_bridge infers from topic
+					SchemaName: func() string {
+						if len(schemaName) > 0 {
+							return schemaName[0]
+						}
+						return ""
+					}(),
 				},
 			},
 		}

--- a/gui/pkg/providers/ros.go
+++ b/gui/pkg/providers/ros.go
@@ -469,5 +469,5 @@ func (r *RosProvider) UnSubscribe(topic string, id string) {
 
 // Publish sends msg to the named ROS2 topic via foxglove_bridge.
 func (r *RosProvider) Publish(topic string, msgType string, msg interface{}) error {
-	return r.client.Publish(topic, msg)
+	return r.client.Publish(topic, msg, msgType)
 }

--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -77,7 +77,7 @@ controller_server:
       lookahead_time: 1.5
       transform_tolerance: 2.0
       use_velocity_scaled_lookahead_dist: false
-      min_approach_linear_velocity: 0.05
+      min_approach_linear_velocity: 0.1
       approach_velocity_scaling_dist: 0.6
       use_collision_detection: false
       use_regulated_linear_velocity_scaling: true
@@ -85,7 +85,7 @@ controller_server:
       curvature_lookahead_dist: 0.6
       use_cost_regulated_linear_velocity_scaling: false
       regulated_linear_scaling_min_radius: 0.9
-      regulated_linear_scaling_min_speed: 0.1
+      regulated_linear_scaling_min_speed: 0.15
       use_rotate_to_heading: false
       allow_reversing: false
       max_angular_vel: 3.0
@@ -96,10 +96,10 @@ controller_server:
     # PRE_ROTATE -> FOLLOWING -> WAITING_FOR_GOAL_APPROACH -> POST_ROTATE
     FollowCoveragePath:
       plugin: "mowgli_nav2_plugins/FTCController"
-      speed_fast: 0.4              # carrot speed when far from path (m/s)
+      speed_fast: 0.5              # carrot speed when far from path (m/s)
       speed_fast_threshold: 0.5    # distance threshold for fast/slow (m)
       speed_fast_threshold_angle: 10.0  # angle threshold for fast (deg)
-      speed_slow: 0.15             # carrot speed when close/turning (m/s)
+      speed_slow: 0.25             # carrot speed when close/turning (m/s)
       speed_angular: 60.0          # rotation speed for in-place turns (deg/s)
       acceleration: 0.5            # carrot acceleration (m/s²)
       # PID longitudinal
@@ -115,7 +115,7 @@ controller_server:
       ki_ang: 0.0
       kd_ang: 0.0
       # Limits
-      max_cmd_vel_speed: 0.4
+      max_cmd_vel_speed: 0.5
       max_cmd_vel_ang: 3.0
       max_goal_distance_error: 0.10  # goal reached within 10cm
       max_goal_angle_error: 15.0     # goal angle tolerance (deg)
@@ -219,7 +219,7 @@ velocity_smoother:
     #             twist_mux → cmd_vel → hardware
     input_topic: cmd_vel_nav
     output_topic: cmd_vel_smoothed
-    max_velocity: [0.4, 0.0, 1.0]
+    max_velocity: [0.5, 0.0, 1.0]
     min_velocity: [-0.3, 0.0, -1.0]
     max_accel: [0.3, 0.0, 1.5]
     max_decel: [-0.3, 0.0, -1.5]
@@ -255,14 +255,13 @@ global_costmap:
       # gardens: the costmap always centres on the robot, and obstacles are
       # detected in real time by the obstacle_layer.
       rolling_window: true
-      width: 200
-      height: 200
-      # keepout_filter disabled in global costmap: it marks boundary zones
-      # as LETHAL causing "Start occupied" when robot is near boundary edge.
-      # Boundary enforcement uses local costmap keepout + coverage planner.
-      plugins: ["obstacle_layer", "inflation_layer"]
+      width: 600
+      height: 600
+      # keepout_filter re-enabled: the keepout mask now includes a navigation
+      # margin (keepout_nav_margin param) so the robot can operate near the
+      # boundary edge without triggering "Start occupied".
+      plugins: ["obstacle_layer", "inflation_layer", "keepout_filter"]
 
-      # Keepout filter config kept for reference but not in plugins list.
       keepout_filter:
         plugin: "nav2_costmap_2d::KeepoutFilter"
         enabled: true

--- a/ros2/src/mowgli_map/config/map_server.yaml
+++ b/ros2/src/mowgli_map/config/map_server.yaml
@@ -9,6 +9,11 @@ map_server_node:
     map_file_path: ""
     areas_file_path: "/ros2_ws/maps/areas.dat"
     publish_rate: 1.0
+    # Navigation margin around area boundaries for keepout mask.
+    # Cells outside the area but within this distance of the boundary
+    # edge are marked free (not lethal), preventing "Start occupied"
+    # when the robot is near the boundary.
+    keepout_nav_margin: 1.5
 
     # Pre-defined mowing / navigation areas (OpenMower-style).
     # Parallel arrays indexed by position.  Polygon format: "x1,y1;x2,y2;..."

--- a/ros2/src/mowgli_map/include/mowgli_map/map_server_node.hpp
+++ b/ros2/src/mowgli_map/include/mowgli_map/map_server_node.hpp
@@ -267,6 +267,10 @@ private:
   /// Check if a strip is sufficiently mowed (>threshold of cells done).
   bool is_strip_mowed(const Strip& strip, double threshold_pct = 0.2) const;
 
+  /// Check if a strip is blocked by obstacles (>threshold of obstacle cells).
+  /// Blocked strips are treated as "frontier" and skipped during planning.
+  bool is_strip_blocked(const Strip& strip, double blocked_threshold = 0.5) const;
+
   /// Compute coverage statistics for an area.
   void compute_coverage_stats(size_t area_index,
                               uint32_t& total,
@@ -294,6 +298,7 @@ private:
   std::string map_file_path_;
   std::string areas_file_path_;
   double publish_rate_;
+  double keepout_nav_margin_;
 
   // ── State ─────────────────────────────────────────────────────────────────
   grid_map::GridMap map_;

--- a/ros2/src/mowgli_map/src/map_server_node.cpp
+++ b/ros2/src/mowgli_map/src/map_server_node.cpp
@@ -55,6 +55,7 @@ MapServerNode::MapServerNode(const rclcpp::NodeOptions& options)
   map_file_path_ = declare_parameter<std::string>("map_file_path", "");
   areas_file_path_ = declare_parameter<std::string>("areas_file_path", "");
   publish_rate_ = declare_parameter<double>("publish_rate", 1.0);
+  keepout_nav_margin_ = declare_parameter<double>("keepout_nav_margin", 1.5);
 
   RCLCPP_INFO(get_logger(),
               "MapServerNode: resolution=%.3f m, size=%.1f×%.1f m, frame='%s'",
@@ -1101,6 +1102,41 @@ bool MapServerNode::point_in_polygon(const geometry_msgs::msg::Point32& pt,
 // Costmap filter mask helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Minimum distance from point (px, py) to the edges of a polygon.
+static double point_to_polygon_distance(double px, double py,
+                                        const geometry_msgs::msg::Polygon& polygon)
+{
+  const auto& pts = polygon.points;
+  const std::size_t n = pts.size();
+  if (n < 2)
+    return std::numeric_limits<double>::max();
+
+  double min_dist = std::numeric_limits<double>::max();
+  for (std::size_t i = 0, j = n - 1; i < n; j = i++)
+  {
+    const double ax = static_cast<double>(pts[j].x);
+    const double ay = static_cast<double>(pts[j].y);
+    const double bx = static_cast<double>(pts[i].x);
+    const double by = static_cast<double>(pts[i].y);
+
+    const double dx = bx - ax;
+    const double dy = by - ay;
+    const double len2 = dx * dx + dy * dy;
+
+    double t = 0.0;
+    if (len2 > 1e-12)
+    {
+      t = std::clamp(((px - ax) * dx + (py - ay) * dy) / len2, 0.0, 1.0);
+    }
+
+    const double cx = ax + t * dx;
+    const double cy = ay + t * dy;
+    const double dist = std::hypot(px - cx, py - cy);
+    min_dist = std::min(min_dist, dist);
+  }
+  return min_dist;
+}
+
 void MapServerNode::publish_keepout_mask()
 {
   if (areas_.empty())
@@ -1124,7 +1160,11 @@ void MapServerNode::publish_keepout_mask()
   mask.info.origin.orientation.w = 1.0;
   mask.data.resize(static_cast<std::size_t>(rows * cols), 100);  // default: keepout
 
-  // A cell inside ANY area (mowing or navigation) is free.
+  // A cell inside ANY area (mowing or navigation) is free (0).
+  // A cell outside all areas but within keepout_nav_margin_ of any area
+  // polygon edge is also free (0) — this prevents "Start occupied" when
+  // the robot is near the boundary.
+  // Cells beyond the margin stay 100 (keepout/lethal).
   for (int r = 0; r < rows; ++r)
   {
     for (int c = 0; c < cols; ++c)
@@ -1145,6 +1185,7 @@ void MapServerNode::publish_keepout_mask()
       const auto flat_idx = static_cast<std::size_t>(og_row * cols + c);
 
       bool inside_any = false;
+      bool within_margin = false;
       for (const auto& area : areas_)
       {
         if (point_in_polygon(pt, area.polygon))
@@ -1152,9 +1193,18 @@ void MapServerNode::publish_keepout_mask()
           inside_any = true;
           break;
         }
+        if (!within_margin && keepout_nav_margin_ > 0.0)
+        {
+          double dist = point_to_polygon_distance(
+              static_cast<double>(pt.x), static_cast<double>(pt.y), area.polygon);
+          if (dist <= keepout_nav_margin_)
+          {
+            within_margin = true;
+          }
+        }
       }
 
-      if (inside_any)
+      if (inside_any || within_margin)
       {
         mask.data[flat_idx] = 0;
       }
@@ -1921,10 +1971,22 @@ void MapServerNode::ensure_strip_layout(size_t area_index)
 
   layout.valid = true;
   RCLCPP_INFO(get_logger(),
-              "Strip layout for area '%s': %zu strips, mow_angle=%.1f°",
+              "Strip layout for area '%s': %zu strips, mow_angle=%.1f°, "
+              "bbox=(%.2f,%.2f)-(%.2f,%.2f), inner_x=[%.2f, %.2f]",
               area.name.c_str(),
               layout.strips.size(),
-              layout.mow_angle * 180.0 / M_PI);
+              layout.mow_angle * 180.0 / M_PI,
+              min_x, min_y, max_x, max_y,
+              inner_min_x, inner_max_x);
+  if (!layout.strips.empty())
+  {
+    const auto& first = layout.strips.front();
+    const auto& last = layout.strips.back();
+    RCLCPP_INFO(get_logger(),
+                "  First strip: x=%.2f y=[%.2f, %.2f], Last strip: x=%.2f y=[%.2f, %.2f]",
+                first.start.x, first.start.y, first.end.y,
+                last.start.x, last.start.y, last.end.y);
+  }
 }
 
 bool MapServerNode::is_strip_mowed(const Strip& strip, double threshold_pct) const
@@ -1977,6 +2039,48 @@ bool MapServerNode::is_strip_mowed(const Strip& strip, double threshold_pct) con
   return static_cast<double>(mowed_count) / total_count >= threshold_pct;
 }
 
+bool MapServerNode::is_strip_blocked(const Strip& strip, double blocked_threshold) const
+{
+  // Check if a strip is mostly blocked by obstacles, making it unreachable.
+  // A strip with >blocked_threshold fraction of obstacle cells is "frontier".
+  double dx = strip.end.x - strip.start.x;
+  double dy = strip.end.y - strip.start.y;
+  double length = std::hypot(dx, dy);
+  if (length < resolution_)
+    return false;
+
+  int samples = std::max(3, static_cast<int>(length / resolution_));
+  int obstacle_count = 0;
+  int total_count = 0;
+
+  const auto& class_layer = map_[std::string(layers::CLASSIFICATION)];
+
+  for (int i = 0; i <= samples; ++i)
+  {
+    double t = static_cast<double>(i) / samples;
+    double px = strip.start.x + t * dx;
+    double py = strip.start.y + t * dy;
+
+    grid_map::Position pos(px, py);
+    if (!map_.isInside(pos))
+      continue;
+
+    grid_map::Index idx;
+    if (!map_.getIndex(pos, idx))
+      continue;
+
+    total_count++;
+    auto cell_type = static_cast<CellType>(static_cast<int>(class_layer(idx(0), idx(1))));
+    if (cell_type == CellType::OBSTACLE_PERMANENT || cell_type == CellType::OBSTACLE_TEMPORARY)
+      obstacle_count++;
+  }
+
+  if (total_count == 0)
+    return false;
+
+  return static_cast<double>(obstacle_count) / total_count >= blocked_threshold;
+}
+
 bool MapServerNode::find_next_unmowed_strip(
     size_t area_index, double robot_x, double robot_y, Strip& out_strip, bool /*prefer_headland*/)
 {
@@ -2017,12 +2121,14 @@ bool MapServerNode::find_next_unmowed_strip(
     cur_idx++;
   }
 
-  // Search forward from current index for the next unmowed strip
+  // Search forward from current index for the next unmowed strip.
+  // Skip strips that are blocked by obstacles (>50% obstacle cells) — these
+  // are treated as "frontier" strips that can't be mowed.
   for (int i = 0; i < n; ++i)
   {
     int idx = (cur_idx + i) % n;
     const auto& strip = layout.strips[idx];
-    if (!is_strip_mowed(strip))
+    if (!is_strip_mowed(strip) && !is_strip_blocked(strip))
     {
       cur_idx = idx;
       out_strip = strip;
@@ -2035,7 +2141,7 @@ bool MapServerNode::find_next_unmowed_strip(
     }
   }
 
-  return false;  // All strips mowed
+  return false;  // All strips mowed or blocked
 }
 
 nav_msgs::msg::Path MapServerNode::strip_to_path(const Strip& strip, size_t /*area_index*/) const

--- a/ros2/src/mowgli_map/src/map_server_node.cpp
+++ b/ros2/src/mowgli_map/src/map_server_node.cpp
@@ -268,7 +268,9 @@ MapServerNode::MapServerNode(const rclcpp::NodeOptions& options)
       docking_pose_set_ = true;
       RCLCPP_INFO(get_logger(),
                   "Dock pose from parameters: (%.3f, %.3f) yaw=%.3f",
-                  dock_x, dock_y, dock_yaw);
+                  dock_x,
+                  dock_y,
+                  dock_yaw);
     }
   }
 
@@ -1128,7 +1130,8 @@ bool MapServerNode::point_in_polygon(const geometry_msgs::msg::Point32& pt,
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Minimum distance from point (px, py) to the edges of a polygon.
-static double point_to_polygon_distance(double px, double py,
+static double point_to_polygon_distance(double px,
+                                        double py,
                                         const geometry_msgs::msg::Polygon& polygon)
 {
   const auto& pts = polygon.points;
@@ -1220,8 +1223,9 @@ void MapServerNode::publish_keepout_mask()
         }
         if (!within_margin && keepout_nav_margin_ > 0.0)
         {
-          double dist = point_to_polygon_distance(
-              static_cast<double>(pt.x), static_cast<double>(pt.y), area.polygon);
+          double dist = point_to_polygon_distance(static_cast<double>(pt.x),
+                                                  static_cast<double>(pt.y),
+                                                  area.polygon);
           if (dist <= keepout_nav_margin_)
           {
             within_margin = true;
@@ -2001,16 +2005,24 @@ void MapServerNode::ensure_strip_layout(size_t area_index)
               area.name.c_str(),
               layout.strips.size(),
               layout.mow_angle * 180.0 / M_PI,
-              min_x, min_y, max_x, max_y,
-              inner_min_x, inner_max_x);
+              min_x,
+              min_y,
+              max_x,
+              max_y,
+              inner_min_x,
+              inner_max_x);
   if (!layout.strips.empty())
   {
     const auto& first = layout.strips.front();
     const auto& last = layout.strips.back();
     RCLCPP_INFO(get_logger(),
                 "  First strip: x=%.2f y=[%.2f, %.2f], Last strip: x=%.2f y=[%.2f, %.2f]",
-                first.start.x, first.start.y, first.end.y,
-                last.start.x, last.start.y, last.end.y);
+                first.start.x,
+                first.start.y,
+                first.end.y,
+                last.start.x,
+                last.start.y,
+                last.end.y);
   }
 }
 


### PR DESCRIPTION
## Summary
- **Global costmap**: 200→600 cells (10m→30m) — covers full 17m garden + navigation margin
- **Minimum speeds**: FTC speed_slow 0.15→0.25 m/s, RPP min_approach 0.05→0.1 m/s — above motor dead zone
- **Boundary enforcement**: Re-enabled keepout_filter with 1.5m navigation margin around area boundaries. Added `is_strip_blocked()` frontier detection to skip obstacle-blocked strips instead of routing outside the area.
- **Joystick fix**: Pass `schemaName` in Foxglove `clientAdvertise` so bridge can convert JSON→CDR for `/cmd_vel_teleop` publishing
- **Crash fix**: Added missing `"obstacles"` case in `SubscriberRoute` — was causing nil pointer panic on every map page load
- **Debug logging**: Strip layout now logs bounding box, inner bounds, and first/last strip coordinates

## Test plan
- [ ] Verify global costmap covers full garden (check costmap visualization in Foxglove)
- [ ] Verify robot moves at low speed commands (no stalling at speed_slow=0.25)
- [ ] Verify robot stays within mowing area boundaries during transit
- [ ] Verify blocked strips near obstacles are skipped (check GetNextStrip logs)
- [ ] Verify joystick sends cmd_vel_teleop to ROS2 (check ros2 topic echo /cmd_vel_teleop)
- [ ] Verify no more nil pointer panics in GUI logs for obstacles subscription