### PR TITLE
fix: publish absolute charging current for dock detection

### DIFF
--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -411,7 +411,10 @@ private:
       msg.header.stamp = stamp;
       msg.header.frame_id = "base_link";
       msg.voltage = pkt.v_system;
-      msg.current = pkt.charging_current;
+      // SimpleChargingDock::isDocked() checks current > charging_threshold.
+      // Firmware reports negative current when charging (into battery),
+      // so publish the absolute value for correct dock detection.
+      msg.current = std::abs(pkt.charging_current);
       msg.percentage = static_cast<float>(pkt.batt_percentage) / 100.0f;
       msg.power_supply_status =
           is_charging_ ? sensor_msgs::msg::BatteryState::POWER_SUPPLY_STATUS_CHARGING


### PR DESCRIPTION
## Summary
- Firmware reports negative charging current (convention: current flowing into battery)
- `SimpleChargingDock::isDocked()` checks `current > charging_threshold (0.1)`
- With current = -0.139, the check fails → docking server thinks robot is NOT docked → undock aborts immediately
- Fix: use `std::abs(pkt.charging_current)` so the value is always positive when charging

## Root cause
```
[docking_server]: Robot is not in the dock, no need to undock
[behavior_tree_node]: UndockRobot: undocking aborted
[behavior_tree_node]: ClearCommand: resetting current_command from 1 to 0
```
This repeated 3 times — robot never left IDLE state after pressing Start.

## Test plan
- [ ] Verify `/battery_state` current is positive when robot is on charger
- [ ] Verify pressing Start triggers successful undock sequence
- [ ] Verify robot transitions to AUTONOMOUS state and begins mowing