### PR TITLE
fix: increase docking_threshold for SLAM relocalization drift

### DIFF
--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -382,7 +382,11 @@ docking_server:
     simple_charging_dock:
       plugin: "opennav_docking::SimpleChargingDock"
       charging_threshold: 0.1
-      docking_threshold: 0.05
+      # Geometric distance (m) from base_link to dock pose for isDocked().
+      # Must be large enough to accommodate SLAM relocalization drift on
+      # startup — lifelong SLAM can place the robot up to ~1m from the
+      # configured dock pose after loading a saved map.
+      docking_threshold: 1.0
       staging_x_offset: -1.0
       use_external_detection_pose: false
       use_battery_status: true


### PR DESCRIPTION
## Summary
- `SimpleChargingDock::isDocked()` checks distance from robot to dock pose: `d < docking_threshold`
- After lifelong SLAM loads a saved map, the robot's map-frame position can drift ~0.8m from the configured dock pose (0,0)
- With `docking_threshold: 0.05m`, this always fails → "Robot is not in the dock" → undock aborted → robot stuck in IDLE
- Fix: increase to 1.0m to accommodate SLAM relocalization error

## Test plan
- [ ] Start robot on dock, press Start → robot should undock successfully
- [ ] Verify robot transitions to AUTONOMOUS and begins mowing