### PR TITLE
fix: remap docking_server cmd_vel through twist_mux

### DIFF
--- a/ros2/src/mowgli_bringup/config/twist_mux.yaml
+++ b/ros2/src/mowgli_bringup/config/twist_mux.yaml
@@ -11,6 +11,11 @@ twist_mux:
         timeout: 0.5      # seconds – source considered stale if no message arrives
         priority: 10      # lowest priority – autonomous navigation (post collision_monitor)
 
+      docking:
+        topic: /cmd_vel_docking
+        timeout: 0.5
+        priority: 15      # between navigation and teleop — docking/undocking manoeuvres
+
       teleop:
         topic: /cmd_vel_teleop
         timeout: 0.5

--- a/ros2/src/mowgli_bringup/launch/nav2_navigation_launch.py
+++ b/ros2/src/mowgli_bringup/launch/nav2_navigation_launch.py
@@ -222,7 +222,9 @@ def generate_launch_description():
                 respawn_delay=2.0,
                 parameters=[configured_params],
                 arguments=['--ros-args', '--log-level', log_level],
-                remappings=remappings,
+                # Remap docking_server's cmd_vel to go through twist_mux
+                # instead of competing directly on /cmd_vel with twist_mux output.
+                remappings=remappings + [('cmd_vel', 'cmd_vel_docking')],
             ),
             Node(
                 package='nav2_lifecycle_manager',
@@ -304,7 +306,8 @@ def generate_launch_description():
                         plugin='opennav_docking::DockingServer',
                         name='docking_server',
                         parameters=[configured_params],
-                        remappings=remappings,
+                        remappings=remappings
+                        + [('cmd_vel', 'cmd_vel_docking')],
                     ),
                     ComposableNode(
                         package='nav2_lifecycle_manager',


### PR DESCRIPTION
## Summary
The docking_server was publishing velocity commands directly to `/cmd_vel`, but twist_mux also publishes to `/cmd_vel`. The twist_mux zero-velocity output was overwriting the docking server's undock commands, so the robot never moved during undock (30s timeout → abort).

- Remap docking_server `cmd_vel` → `/cmd_vel_docking`
- Add `/cmd_vel_docking` as twist_mux input at priority 15 (between navigation=10 and teleop=20)
- Both Node and ComposableNode variants updated

## Test plan
- [ ] Undock drives the robot backwards off the dock
- [ ] Docking drives the robot forward onto the dock
- [ ] twist_mux correctly prioritizes docking over navigation