### PR TITLE
fix: undock via BackUp, progress timeout 30s, source_timeout 5s

### DIFF
--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -159,7 +159,11 @@
               <SaveSlamMap map_path="/ros2_ws/maps/garden_map"/>
               <PublishHighLevelStatus state="2" state_name="UNDOCKING"/>
               <RecordUndockStart/>
-              <UndockRobot dock_type="simple_charging_dock"/>
+              <!-- BackUp instead of UndockRobot: opennav_docking isDocked()
+                   uses geometric distance to dock pose which fails with
+                   SLAM relocalization drift. BackUp reliably reverses
+                   off the dock via Nav2 behavior_server. -->
+              <BackUp backup_dist="1.5" backup_speed="0.15"/>
               <!-- Compute heading from GPS displacement during undock -->
               <CalibrateHeadingFromUndock/>
             </Sequence>
@@ -226,7 +230,11 @@
                   <PublishHighLevelStatus state="2" state_name="RESUMING_AFTER_RAIN"/>
                   <WaitForDuration duration_sec="1.0"/>
                   <Fallback name="RainResumeUndock">
-                    <UndockRobot dock_type="simple_charging_dock"/>
+                    <!-- BackUp instead of UndockRobot: opennav_docking isDocked()
+                   uses geometric distance to dock pose which fails with
+                   SLAM relocalization drift. BackUp reliably reverses
+                   off the dock via Nav2 behavior_server. -->
+              <BackUp backup_dist="1.5" backup_speed="0.15"/>
                     <Sequence>
                       <RecordResumeUndockFailure/>
                       <ClearCommand/>
@@ -270,7 +278,11 @@
                   <PublishHighLevelStatus state="2" state_name="RESUMING_UNDOCKING"/>
                   <WaitForDuration duration_sec="1.0"/>
                   <Fallback name="ResumeUndockOrAbort">
-                    <UndockRobot dock_type="simple_charging_dock"/>
+                    <!-- BackUp instead of UndockRobot: opennav_docking isDocked()
+                   uses geometric distance to dock pose which fails with
+                   SLAM relocalization drift. BackUp reliably reverses
+                   off the dock via Nav2 behavior_server. -->
+              <BackUp backup_dist="1.5" backup_speed="0.15"/>
                     <Sequence>
                       <RecordResumeUndockFailure/>
                       <ClearCommand/>

--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -44,7 +44,7 @@ controller_server:
     progress_checker:
       plugin: "nav2_controller::SimpleProgressChecker"
       required_movement_radius: 0.02  # tight — even small movements count
-      movement_time_allowance: 3600.0 # 1 hour — effectively disabled for long coverage runs
+      movement_time_allowance: 30.0  # seconds without progress before controller fails
 
     stopped_goal_checker:
       plugin: "nav2_controller::StoppedGoalChecker"
@@ -383,10 +383,10 @@ docking_server:
       plugin: "opennav_docking::SimpleChargingDock"
       charging_threshold: 0.1
       # Geometric distance (m) from base_link to dock pose for isDocked().
-      # Must be large enough to accommodate SLAM relocalization drift on
-      # startup — lifelong SLAM can place the robot up to ~1m from the
-      # configured dock pose after loading a saved map.
-      docking_threshold: 1.0
+      # Must accommodate SLAM relocalization drift — lifelong SLAM can
+      # place the robot several metres from the configured dock pose
+      # after loading a saved map with heading mismatch.
+      docking_threshold: 5.0
       staging_x_offset: -1.0
       use_external_detection_pose: false
       use_battery_status: true
@@ -406,7 +406,10 @@ collision_monitor:
     cmd_vel_out_topic: cmd_vel_monitored
     state_topic: collision_monitor_state
     transform_tolerance: 0.2
-    source_timeout: 1.0
+    # Source timeout: how long before stale sensor data triggers a stop.
+    # ARM boards can have TF/scan timing jitter — 5s avoids false stops
+    # while still catching genuinely dead sensors.
+    source_timeout: 5.0
     base_shift_correction: true
     stop_pub_timeout: 2.0
     polygons: ["PolygonStop", "PolygonSlow", "FootprintApproach"]


### PR DESCRIPTION
## Summary
Validated on real hardware during live mowing session:

- **BackUp replaces UndockRobot** in all 3 BT locations: `opennav_docking::isDocked()` uses geometric distance which fails with SLAM relocalization drift. BackUp via `nav2_behaviors` reliably reverses 1.5m off the dock.
- **movement_time_allowance: 3600s → 30s**: Progress checker was effectively disabled. Robot sat stuck at obstacles forever. Now detects no-progress in 30s, BT StripRecovery kicks in (backup → clear → next strip).
- **source_timeout: 1s → 5s**: ARM TF/scan timing jitter caused "invalid source" collision_monitor stops during every navigation goal. 5s accommodates the jitter.
- **docking_threshold: 1m → 5m**: SLAM heading drift on startup places robot far from configured dock pose in odom frame.

## Test plan
- [x] Undock succeeds (BackUp 1.5m, wheels spin, heading calibrated)
- [x] Transit to strip works (robot navigates to strip start)
- [x] Stuck recovery works (30s timeout → replan around obstacle)
- [x] No false collision_monitor stops during navigation
- [x] FTCController receives strip poses and starts mowing