### PR TITLE
fix: show joystick overlay during RECORDING state

### DIFF
--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -706,8 +706,8 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                     </Source>
                 </Map> : <Spinner/>}
                 <JoystickOverlay
-                    visible={highLevelStatus.highLevelStatus.state_name === "AREA_RECORDING" || highLevelStatus.highLevelStatus.state_name === "MANUAL_MOWING" || manualMode != null}
-                    isRecording={highLevelStatus.highLevelStatus.state_name === "AREA_RECORDING"}
+                    visible={highLevelStatus.highLevelStatus.state_name === "RECORDING" || highLevelStatus.highLevelStatus.state_name === "AREA_RECORDING" || highLevelStatus.highLevelStatus.state_name === "MANUAL_MOWING" || manualMode != null}
+                    isRecording={highLevelStatus.highLevelStatus.state_name === "RECORDING" || highLevelStatus.highLevelStatus.state_name === "AREA_RECORDING"}
                     onMove={handleJoyMove}
                     onStop={handleJoyStop}
                     onFinishRecording={mowerActions.onRecordFinish}


### PR DESCRIPTION
## Summary
BT publishes `state_name="RECORDING"` but MapPage.tsx only checked for `"AREA_RECORDING"`. The joystick overlay was invisible during area recording, making it impossible to drive the robot around the boundary.

Added `"RECORDING"` to the visibility and isRecording checks (useMapStreams already handled both states correctly).

## Test plan
- [ ] Enter area recording mode → joystick appears
- [ ] Joystick sends cmd_vel_teleop during recording
- [ ] Finish/Cancel recording buttons visible