### PR TITLE
fix: coverage cells orientation — use manual row-flip like other grids

### DIFF
--- a/ros2/src/mowgli_map/src/map_server_node.cpp
+++ b/ros2/src/mowgli_map/src/map_server_node.cpp
@@ -1004,70 +1004,75 @@ nav_msgs::msg::OccupancyGrid MapServerNode::mow_progress_to_occupancy_grid() con
 
 nav_msgs::msg::OccupancyGrid MapServerNode::coverage_cells_to_occupancy_grid() const
 {
-  // Strategy: write coverage values into a temporary grid_map layer,
-  // then use grid_map_ros converter for pixel-perfect coordinate mapping.
-  // This avoids manual index computation which causes offset bugs.
+  // Use the same manual row-flip as mow_progress and keepout_mask.
+  // GridMapRosConverter::toOccupancyGrid() uses a different orientation
+  // convention, causing the coverage grid to appear rotated relative
+  // to the other grids and the mowing area polygon.
 
-  const std::string tmp_layer = "_coverage_tmp";
-  auto& mutable_map = const_cast<grid_map::GridMap&>(map_);
-
-  // Add temp layer (or reuse if exists)
-  if (!mutable_map.exists(tmp_layer))
-    mutable_map.add(tmp_layer, NAN);
-  else
-    mutable_map[tmp_layer].setConstant(NAN);
-
-  auto& cov = mutable_map[tmp_layer];
   const auto& prog = map_[std::string(layers::MOW_PROGRESS)];
   const auto& cls = map_[std::string(layers::CLASSIFICATION)];
+  const int rows = map_.getSize()(0);
+  const int cols = map_.getSize()(1);
 
-  for (grid_map::GridMapIterator it(map_); !it.isPastEnd(); ++it)
+  nav_msgs::msg::OccupancyGrid og;
+  og.header.stamp = now();
+  og.header.frame_id = map_frame_;
+  og.info.resolution = static_cast<float>(resolution_);
+  og.info.width = static_cast<uint32_t>(cols);
+  og.info.height = static_cast<uint32_t>(rows);
+  og.info.origin.position.x = map_.getPosition().x() - map_.getLength().x() * 0.5;
+  og.info.origin.position.y = map_.getPosition().y() - map_.getLength().y() * 0.5;
+  og.info.origin.position.z = 0.0;
+  og.info.origin.orientation.w = 1.0;
+  og.data.resize(static_cast<std::size_t>(rows * cols), -1);  // default: unknown
+
+  for (int r = 0; r < rows; ++r)
   {
-    const auto idx = *it;
-
-    // Check if inside any mowing area
-    grid_map::Position pos;
-    map_.getPosition(idx, pos);
-    bool in_area = false;
-    for (const auto& area : areas_)
+    for (int c = 0; c < cols; ++c)
     {
-      if (area.is_navigation_area)
+      const grid_map::Index idx(r, c);
+      grid_map::Position pos;
+      if (!map_.getPosition(idx, pos))
         continue;
+
+      const int og_row = rows - 1 - r;
+      const auto flat_idx = static_cast<std::size_t>(og_row * cols + c);
+
+      // Check if inside any mowing area
+      bool in_area = false;
       geometry_msgs::msg::Point32 pt;
       pt.x = static_cast<float>(pos.x());
       pt.y = static_cast<float>(pos.y());
-      if (point_in_polygon(pt, area.polygon))
+      for (const auto& area : areas_)
       {
-        in_area = true;
-        break;
+        if (area.is_navigation_area)
+          continue;
+        if (point_in_polygon(pt, area.polygon))
+        {
+          in_area = true;
+          break;
+        }
+      }
+
+      if (!in_area)
+        continue;  // stays -1 (unknown)
+
+      auto cell_type = static_cast<CellType>(static_cast<int>(cls(r, c)));
+      if (cell_type == CellType::OBSTACLE_PERMANENT || cell_type == CellType::OBSTACLE_TEMPORARY ||
+          cell_type == CellType::NO_GO_ZONE)
+      {
+        og.data[flat_idx] = 100;  // Obstacle/no-go
+      }
+      else if (prog(r, c) >= 0.3f)
+      {
+        og.data[flat_idx] = 0;  // Mowed
+      }
+      else
+      {
+        og.data[flat_idx] = 60;  // To mow
       }
     }
-
-    if (!in_area)
-    {
-      cov(idx(0), idx(1)) = NAN;  // Outside → unknown in OG
-      continue;
-    }
-
-    auto cell_type = static_cast<CellType>(static_cast<int>(cls(idx(0), idx(1))));
-    if (cell_type == CellType::OBSTACLE_PERMANENT || cell_type == CellType::OBSTACLE_TEMPORARY ||
-        cell_type == CellType::NO_GO_ZONE)
-    {
-      cov(idx(0), idx(1)) = 1.0f;  // Obstacle/no-go → maps to 100
-    }
-    else if (prog(idx(0), idx(1)) >= 0.3f)
-    {
-      cov(idx(0), idx(1)) = 0.0f;  // Mowed → maps to 0 (transparent)
-    }
-    else
-    {
-      cov(idx(0), idx(1)) = 0.6f;  // To mow → maps to 60
-    }
   }
-
-  // Use grid_map_ros converter — handles all coordinate mapping correctly
-  nav_msgs::msg::OccupancyGrid og;
-  grid_map::GridMapRosConverter::toOccupancyGrid(mutable_map, tmp_layer, 0.0f, 1.0f, og);
 
   return og;
 }


### PR DESCRIPTION
## Summary
`coverage_cells_to_occupancy_grid()` used `GridMapRosConverter::toOccupancyGrid()` which uses a different orientation convention than the manual row-flip (`og_row = rows - 1 - r`) used by `mow_progress_to_occupancy_grid()` and `publish_keepout_mask()`.

This caused the coverage cells to appear rotated/flipped relative to the mowing area polygon when viewed in Foxglove/GUI.

Fix: replace the converter with the same manual row-flip and origin computation used by the other two grids.

## Test plan
- [ ] Coverage cells align with the mowing area polygon in Foxglove
- [ ] Mowed cells (green) appear where the robot actually drove
- [ ] Strips are generated inside the coverage cells area