### PR TITLE
feat(sensors): add Unicore UM982 GNSS driver container

### DIFF
--- a/.github/workflows/sensors-unicore.yml
+++ b/.github/workflows/sensors-unicore.yml
@@ -1,0 +1,31 @@
+name: Sensors — Unicore UM982
+
+on:
+  push:
+    branches: [main, dev, 'feat/**']
+    paths:
+      - 'sensors/unicore/**'
+      - '.github/workflows/sensors-unicore.yml'
+      - '.github/workflows/_sensor-docker.yml'
+  workflow_dispatch:
+    inputs:
+      no-cache:
+        description: 'Build without Docker layer cache'
+        type: boolean
+        default: false
+
+concurrency:
+  group: sensors-unicore-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/_sensor-docker.yml
+    with:
+      image: unicore
+      context: ./sensors/unicore
+      no-cache: ${{ inputs.no-cache == true }}

--- a/sensors/unicore/Dockerfile
+++ b/sensors/unicore/Dockerfile
@@ -1,0 +1,84 @@
+# syntax=docker/dockerfile:1.7
+
+ARG UM982_REPO=https://github.com/mowglifrenchtouch/UM982Driver.git
+ARG UM982_REF=mowgli
+
+FROM ros:kilted-ros-base AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG UM982_REPO
+ARG UM982_REF
+
+ENV CCACHE_DIR=/root/.ccache
+ENV PATH="/usr/lib/ccache:${PATH}"
+
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+      git \
+      ccache \
+      build-essential \
+      cmake \
+      libcurl4-openssl-dev \
+      python3-colcon-common-extensions \
+      ros-kilted-rclcpp \
+      ros-kilted-rclcpp-components \
+      ros-kilted-diagnostic-msgs \
+      ros-kilted-rosidl-default-generators \
+      ros-kilted-rosidl-default-runtime \
+      ros-kilted-rtcm-msgs \
+      ros-kilted-sensor-msgs \
+      ros-kilted-std-msgs \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /ws/src
+
+RUN git clone --depth 1 --branch "${UM982_REF}" "${UM982_REPO}" um982_driver
+
+WORKDIR /ws
+
+RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
+    . /opt/ros/kilted/setup.sh \
+ && colcon build --merge-install \
+      --base-paths src/um982_driver/compass_msgs \
+                   src/um982_driver/ntrip_client_node \
+                   src/um982_driver \
+      --packages-up-to ntrip_client_node mowgli_unicore_gnss \
+      --cmake-args \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -Wno-dev \
+ && rm -rf /ws/build /ws/log /ws/src
+
+FROM ros:kilted-ros-base
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+      libcurl4 \
+      ros-kilted-diagnostic-msgs \
+      ros-kilted-rclcpp-components \
+      ros-kilted-rmw-cyclonedds-cpp \
+      ros-kilted-rosidl-default-runtime \
+      ros-kilted-rtcm-msgs \
+      ros-kilted-sensor-msgs \
+      ros-kilted-std-msgs \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /ws
+
+COPY --from=builder /ws/install /ws/install
+COPY ros2_entrypoint.sh /ros2_entrypoint.sh
+COPY start_gps.sh /start_gps.sh
+
+RUN chmod +x /ros2_entrypoint.sh /start_gps.sh
+
+ENTRYPOINT ["/ros2_entrypoint.sh"]
+CMD ["/start_gps.sh"]

--- a/sensors/unicore/package.xml
+++ b/sensors/unicore/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>mowgli_unicore_gnss</name>
+  <version>0.1.0</version>
+  <description>ROS 2 C++ driver for Unicore UM982 GNSS receivers using NMEA and Unicore extended output.</description>
+  <maintainer email="cedric@mowgli.dev">Cedric</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>compass_msgs</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>rtcm_msgs</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/sensors/unicore/ros2_entrypoint.sh
+++ b/sensors/unicore/ros2_entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Source ROS2 base environment
+set +u
+source /opt/ros/kilted/setup.bash
+# Autonomous Unicore workspace install tree
+if [ -f /ws/install/setup.bash ]; then
+  source /ws/install/setup.bash
+fi
+set -u
+
+exec "$@"

--- a/sensors/unicore/start_gps.sh
+++ b/sensors/unicore/start_gps.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# =============================================================================
+# UM982 GNSS driver startup + NTRIP client
+#
+# Launches:
+#   1. um982_node         — UM982 GNSS driver and RTCM injector on /dev/gps
+#   2. ntrip_client_node  — NTRIP caster client publishing /ntrip_client/rtcm
+# Config read from /ws/install/share/mowgli_unicore_gnss/config/um982.yaml
+# Serial device default: /dev/gps (configurable via params)
+# =============================================================================
+set -euo pipefail
+
+CONFIG="/config/mowgli_robot.yaml"
+GPS_PID=""
+NTRIP_PID=""
+
+if [ ! -f "$CONFIG" ]; then
+  echo "[start_gps.sh] ERROR: $CONFIG not found. Bind-mount config/mowgli/ to /config."
+  exit 1
+fi
+
+parse_yaml() {
+  awk -F: -v key="$1" '
+    $1 ~ "^[[:space:]]*" key "[[:space:]]*$" {
+      value = substr($0, index($0, ":") + 1)
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      gsub(/^["'"'"']|["'"'"']$/, "", value)
+      print value
+      exit
+    }
+  ' "$CONFIG"
+}
+
+is_truthy() {
+  case "${1,,}" in
+    true|1|yes|y|on)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+cleanup() {
+  [ -n "$NTRIP_PID" ] && kill "$NTRIP_PID" 2>/dev/null || true
+  [ -n "$GPS_PID" ] && kill "$GPS_PID" 2>/dev/null || true
+}
+
+trap cleanup EXIT INT TERM
+
+NTRIP_ENABLED=$(parse_yaml ntrip_enabled)
+NTRIP_HOST=$(parse_yaml ntrip_host)
+NTRIP_PORT=$(parse_yaml ntrip_port)
+NTRIP_USER=$(parse_yaml ntrip_user)
+NTRIP_PASSWORD=$(parse_yaml ntrip_password)
+NTRIP_MOUNTPOINT=$(parse_yaml ntrip_mountpoint)
+NTRIP_ENABLED="${NTRIP_ENABLED:-false}"
+
+echo "[start_gps.sh] Launching Unicore UM982 GNSS driver..."
+ros2 launch mowgli_unicore_gnss um982_launch.py &
+GPS_PID=$!
+
+if is_truthy "$NTRIP_ENABLED"; then
+  echo "[start_gps.sh] NTRIP enabled: ${NTRIP_HOST}:${NTRIP_PORT}/${NTRIP_MOUNTPOINT}"
+  sleep 3
+  ros2 run ntrip_client_node ntrip_client_node --ros-args \
+    -p "host:=${NTRIP_HOST}" \
+    -p "port:=${NTRIP_PORT}" \
+    -p "mountpoint:=${NTRIP_MOUNTPOINT}" \
+    -p "username:=${NTRIP_USER}" \
+    -p "password:=${NTRIP_PASSWORD}" &
+  NTRIP_PID=$!
+fi
+
+wait -n || true
+wait


### PR DESCRIPTION
## Summary

- New `sensors/unicore/` Docker image for Unicore UM982 dual-antenna GNSS receivers
- Builds UM982Driver from `mowglifrenchtouch/UM982Driver` (mowgli branch) with NTRIP support
- Publishes `/gps/fix`, `/gps/azimuth`, `/gps/diagnostics` — compatible with existing GPS contract
- CI workflow for automated Docker image builds (`sensors-unicore.yml`)
- Compose fragment already available via #121

Based on @Pepeuch's PR #120 — kept only the `sensors/unicore/` files (the Makefile/CI formatting changes targeted C++ files that only exist inside the Docker build, not locally).

Closes #120

Co-authored-by: Pepeuch <44699883+Pepeuch@users.noreply.github.com>