### PR TITLE
feat(onboarding): GPS auto-restart, restart-button feedback, NMEA driver

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,3 +52,11 @@ updates:
     labels:
       - "sensors"
       - "chore"
+
+  - package-ecosystem: "docker"
+    directory: "/sensors/nmea"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "sensors"
+      - "chore"

--- a/.github/workflows/sensors-nmea.yml
+++ b/.github/workflows/sensors-nmea.yml
@@ -1,0 +1,31 @@
+name: Sensors - NMEA
+
+on:
+  push:
+    branches: [main, dev, 'feat/**']
+    paths:
+      - 'sensors/nmea/**'
+      - '.github/workflows/sensors-nmea.yml'
+      - '.github/workflows/_sensor-docker.yml'
+  workflow_dispatch:
+    inputs:
+      no-cache:
+        description: 'Build without Docker layer cache'
+        type: boolean
+        default: false
+
+concurrency:
+  group: sensors-nmea-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/_sensor-docker.yml
+    with:
+      image: nmea
+      context: ./sensors/nmea
+      no-cache: ${{ inputs.no-cache == true }}

--- a/gui/web/src/components/MowerStatus.tsx
+++ b/gui/web/src/components/MowerStatus.tsx
@@ -7,6 +7,7 @@ import {useSettings} from "../hooks/useSettings.ts";
 import {AbsolutePoseConstants} from "../types/ros.ts";
 import {computeBatteryPercent} from "../utils/battery.ts";
 import {restartMowgliNext} from "../utils/containers.ts";
+import {useContainerRestart} from "../hooks/useContainerRestart.ts";
 import {App, Badge, Dropdown, Modal, Space, Typography} from "antd";
 import {PoweroffOutlined, ReloadOutlined, DesktopOutlined, WifiOutlined} from "@ant-design/icons"
 import {stateRenderer} from "./utils.tsx";
@@ -101,14 +102,14 @@ export const MowerStatus = () => {
         ? Math.round(((highLevelStatus.current_path_index ?? 0) / (highLevelStatus.current_path ?? 1)) * 100)
         : null;
 
-    const restartMowgli = async () => {
-        try {
-            await restartMowgliNext(guiApi);
-            notification.success({message: "Mowgli restarted"});
-        } catch (e: any) {
-            notification.error({message: "Failed to restart Mowgli", description: e.message});
-        }
-    };
+    // Long-running: container restart + rosbridge reconnect. Lock the menu
+    // item until ROS2 is reachable again to prevent duplicate-click storms.
+    const mowgliRestart = useContainerRestart({
+        pendingLabel: "Redémarrage Mowgli…",
+        successMessage: "Mowgli redémarré",
+        errorMessage: "Échec du redémarrage Mowgli",
+    });
+    const restartMowgli = () => mowgliRestart.run(() => restartMowgliNext(guiApi));
 
     const rebootSystem = async () => {
         try {
@@ -143,7 +144,8 @@ export const MowerStatus = () => {
         {
             key: "restart-mowgli",
             icon: <ReloadOutlined/>,
-            label: "Restart Mowgli",
+            label: mowgliRestart.pending ? mowgliRestart.pendingLabel : "Restart Mowgli",
+            disabled: mowgliRestart.pending,
             onClick: () => confirmAction("Restart Mowgli", "This will restart the MowgliNext container.", restartMowgli),
         },
         {type: "divider"},

--- a/gui/web/src/hooks/useContainerRestart.ts
+++ b/gui/web/src/hooks/useContainerRestart.ts
@@ -1,0 +1,102 @@
+import { useCallback, useRef, useState } from "react";
+import { App } from "antd";
+
+/**
+ * Wait for ROS2 to be reachable again after a container restart.
+ *
+ * Opens a short-lived probe WebSocket to a known mowgli stream. The Go
+ * backend only forwards a message once it has reconnected to rosbridge
+ * AND received a fresh sample, so the first MessageEvent is a reliable
+ * "ROS2 is back" signal. Resolves true on first message, false on timeout.
+ */
+const waitForRos2 = (timeoutMs: number): Promise<boolean> =>
+    new Promise((resolve) => {
+        const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+        const host = import.meta.env.DEV ? "localhost:4006" : window.location.host;
+        const url = `${protocol}://${host}/api/mowglinext/subscribe/highLevelStatus`;
+
+        let settled = false;
+        const finish = (ok: boolean) => {
+            if (settled) return;
+            settled = true;
+            try {
+                ws.close();
+            } catch {
+                /* ignore */
+            }
+            clearTimeout(timer);
+            resolve(ok);
+        };
+
+        const ws = new WebSocket(url);
+        const timer = setTimeout(() => finish(false), timeoutMs);
+        ws.onmessage = () => finish(true);
+        ws.onerror = () => {
+            /* keep waiting — backend will reconnect */
+        };
+    });
+
+export type ContainerRestartOptions = {
+    /** Label shown on the disabled button while restarting. */
+    pendingLabel?: string;
+    /** Toast message on success. */
+    successMessage?: string;
+    /** Toast message on failure (timeout or error). */
+    errorMessage?: string;
+    /** How long to wait for ROS2 to come back before giving up. */
+    timeoutMs?: number;
+    /** If true, skip the readiness probe and resolve as soon as the container API call returns. */
+    skipReadinessProbe?: boolean;
+};
+
+/**
+ * Manages a long-running container restart with proper pending-state UX.
+ *
+ * Returns `{pending, run}`:
+ * - `pending`: true while the restart is in flight (button should be disabled).
+ * - `run(action)`: kicks off `action()` (the actual restart call) then waits
+ *   for ROS2 to come back. Idempotent: re-entrant calls while pending are no-ops.
+ */
+export const useContainerRestart = (options: ContainerRestartOptions = {}) => {
+    const {
+        pendingLabel = "Redémarrage…",
+        successMessage = "Container redémarré",
+        errorMessage = "Échec du redémarrage",
+        timeoutMs = 60_000,
+        skipReadinessProbe = false,
+    } = options;
+
+    const { notification } = App.useApp();
+    const [pending, setPending] = useState(false);
+    const pendingRef = useRef(false);
+
+    const run = useCallback(
+        async (action: () => Promise<void>) => {
+            if (pendingRef.current) return;
+            pendingRef.current = true;
+            setPending(true);
+            try {
+                await action();
+                if (!skipReadinessProbe) {
+                    const ok = await waitForRos2(timeoutMs);
+                    if (!ok) {
+                        notification.warning({
+                            message: errorMessage,
+                            description: `ROS2 n'a pas redémarré dans les ${Math.round(timeoutMs / 1000)} s.`,
+                        });
+                        return;
+                    }
+                }
+                notification.success({ message: successMessage });
+            } catch (e: any) {
+                notification.error({ message: errorMessage, description: e.message });
+            } finally {
+                pendingRef.current = false;
+                setPending(false);
+            }
+        },
+        [notification, successMessage, errorMessage, timeoutMs, skipReadinessProbe],
+    );
+
+    return { pending, pendingLabel, run };
+};

--- a/gui/web/src/hooks/useSettingsManager.ts
+++ b/gui/web/src/hooks/useSettingsManager.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useApi } from "./useApi.ts";
 import { App } from "antd";
+import { dirtyKeysRequireGpsRestart, restartGps } from "../utils/containers.ts";
+import { useContainerRestart } from "./useContainerRestart.ts";
 
 export type SettingsSection =
     | "hardware"
@@ -149,6 +151,13 @@ export const useSettingsManager = () => {
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
     const [restartRequired, setRestartRequired] = useState(false);
+    // GPS restart skips the rosbridge readiness probe (ROS2 is unaffected).
+    const gpsRestart = useContainerRestart({
+        pendingLabel: "Redémarrage GPS…",
+        successMessage: "GPS redémarré — patientez ~10–30 s pour le RTK Fix",
+        errorMessage: "Échec du redémarrage GPS",
+        skipReadinessProbe: true,
+    });
     const [searchQuery, setSearchQuery] = useState("");
     const initialLoadDone = useRef(false);
 
@@ -222,14 +231,27 @@ export const useSettingsManager = () => {
     const save = useCallback(async () => {
         try {
             setSaving(true);
+            // Capture which keys were dirty BEFORE we mark them saved, so we
+            // can decide whether GPS needs an auto-restart.
+            const gpsDirty = dirtyKeysRequireGpsRestart(dirtyKeys);
             const res = await guiApi.settings.yamlCreate(localValues);
             if (res.error) throw new Error((res.error as any).error);
             setSavedValues({ ...localValues });
             setRestartRequired(true);
             notification.success({
                 message: "Settings saved",
-                description: "Restart ROS2 to apply changes.",
+                description: gpsDirty
+                    ? "Restarting GPS to apply NTRIP/serial changes. Restart ROS2 to apply other changes."
+                    : "Restart ROS2 to apply changes.",
             });
+            // Auto-restart the GPS container when GPS/NTRIP fields changed —
+            // ROS2 keeps running, the user just sees RTCM stop briefly. This
+            // unblocks the "Set Datum from current GPS" path in onboarding,
+            // which silently fails when the old (un-credentialled) GPS
+            // container is still running.
+            if (gpsDirty) {
+                await gpsRestart.run(() => restartGps(guiApi));
+            }
         } catch (e: any) {
             notification.error({
                 message: "Failed to save settings",
@@ -238,7 +260,7 @@ export const useSettingsManager = () => {
         } finally {
             setSaving(false);
         }
-    }, [localValues, guiApi, notification]);
+    }, [localValues, dirtyKeys, guiApi, notification, gpsRestart]);
 
     const revert = useCallback(() => {
         setLocalValues({ ...savedValues });
@@ -288,6 +310,7 @@ export const useSettingsManager = () => {
         savedValues,
         loading,
         saving,
+        gpsRestarting: gpsRestart.pending,
         isDirty,
         dirtyKeys,
         restartRequired,

--- a/gui/web/src/pages/OnboardingPage.tsx
+++ b/gui/web/src/pages/OnboardingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
     Button, Card, Col, Row, Steps, Typography, Select, Space, Alert,
     Input, InputNumber, Switch, Form, Divider, Tag, Result,
@@ -21,7 +21,13 @@ import { CompassOutlined } from "@ant-design/icons";
 import { RobotComponentEditor } from "../components/RobotComponentEditor.tsx";
 import { FlashBoardComponent } from "../components/FlashBoardComponent.tsx";
 import { MOWER_MODELS } from "../constants/mowerModels.ts";
-import { restartRos2, restartGui } from "../utils/containers.ts";
+import {
+    restartRos2,
+    restartGui,
+    restartGps,
+    GPS_RESTART_KEYS,
+} from "../utils/containers.ts";
+import { useContainerRestart } from "../hooks/useContainerRestart.ts";
 
 const { Title, Text, Paragraph } = Typography;
 
@@ -210,7 +216,9 @@ const RobotModelStep: React.FC<RobotModelStepProps> = ({ values, onChange }) => 
 
 // ── Step 2: GPS Configuration ───────────────────────────────────────────
 
-const GpsStep: React.FC<RobotModelStepProps> = ({ values, onChange }) => {
+type GpsStepProps = RobotModelStepProps & { gpsRestarting?: boolean };
+
+const GpsStep: React.FC<GpsStepProps> = ({ values, onChange, gpsRestarting }) => {
     const ntripEnabled = values.ntrip_enabled ?? true;
     const guiApi = useApi();
     const [datumLoading, setDatumLoading] = useState(false);
@@ -286,13 +294,24 @@ const GpsStep: React.FC<RobotModelStepProps> = ({ values, onChange }) => {
                     </Row>
                     <Button
                         icon={<AimOutlined />}
-                        loading={datumLoading}
+                        loading={datumLoading || gpsRestarting}
                         onClick={setDatumFromGps}
-                        disabled={!isRtkFixed}
+                        disabled={!isRtkFixed || gpsRestarting}
                         style={{ marginTop: -8 }}
                     >
-                        Use current GPS position {isRtkFixed ? "" : "(waiting for RTK Fix)"}
+                        {gpsRestarting
+                            ? "GPS restarting…"
+                            : `Use current GPS position ${isRtkFixed ? "" : "(waiting for RTK Fix)"}`}
                     </Button>
+                    {gpsRestarting && (
+                        <Alert
+                            type="info"
+                            showIcon
+                            message="GPS container is restarting to apply your NTRIP / serial settings"
+                            description="Wait ~10–30 s for RTK Fix to come back before setting the datum."
+                            style={{ marginTop: 12 }}
+                        />
+                    )}
                     {!isRtkFixed && (
                         <Alert
                             type="warning"
@@ -787,15 +806,37 @@ const OnboardingWizard: React.FC = () => {
     const { colors } = useThemeMode();
     const isMobile = useIsMobile();
     const { values: savedValues, saveValues, loading } = useSettingsSchema();
+    const guiApi = useApi();
     const [currentStep, setCurrentStep] = useState(0);
     const [localValues, setLocalValues] = useState<Record<string, any>>({});
     const [saving, setSaving] = useState(false);
+    const gpsRestart = useContainerRestart({
+        pendingLabel: "Redémarrage GPS…",
+        successMessage: "GPS redémarré — patientez pour le RTK Fix",
+        errorMessage: "Échec du redémarrage GPS",
+        skipReadinessProbe: true,
+    });
+    const gpsRestarting = gpsRestart.pending;
+    // Snapshot of saved GPS-related values at the time the user enters
+    // step 2 — used to detect whether the GPS container needs an auto-
+    // restart when leaving the step.
+    const gpsSnapshotRef = useRef<Record<string, any> | null>(null);
 
     useEffect(() => {
         if (savedValues) {
             setLocalValues(savedValues);
         }
     }, [savedValues]);
+
+    // Snapshot GPS-affecting fields whenever the user enters the GPS step,
+    // so we can compare on Next and decide whether to auto-restart mowgli-gps.
+    useEffect(() => {
+        if (currentStep === 2) {
+            const snap: Record<string, any> = {};
+            for (const k of GPS_RESTART_KEYS) snap[k] = localValues[k];
+            gpsSnapshotRef.current = snap;
+        }
+    }, [currentStep]);
 
     const handleChange = useCallback((key: string, value: any) => {
         setLocalValues((prev) => ({ ...prev, [key]: value }));
@@ -810,8 +851,25 @@ const OnboardingWizard: React.FC = () => {
             await saveValues(localValues);
             setSaving(false);
         }
+        // Leaving the GPS step: if any GPS/NTRIP/serial field actually
+        // changed vs the snapshot taken on entry, bounce the GPS container
+        // so the new config is applied. Without this the user has to know
+        // to click "Restart GPS" before "Set Datum" can ever see RTK Fix.
+        if (currentStep === 2 && gpsSnapshotRef.current) {
+            const snap = gpsSnapshotRef.current;
+            let changed = false;
+            for (const k of GPS_RESTART_KEYS) {
+                if (JSON.stringify(snap[k]) !== JSON.stringify(localValues[k])) {
+                    changed = true;
+                    break;
+                }
+            }
+            if (changed) {
+                await gpsRestart.run(() => restartGps(guiApi));
+            }
+        }
         setCurrentStep((s) => Math.min(s + 1, STEP_TITLES.length - 1));
-    }, [currentStep, localValues, saveValues]);
+    }, [currentStep, localValues, saveValues, guiApi, gpsRestart]);
 
     const handlePrev = useCallback(() => {
         setCurrentStep((s) => Math.max(s - 1, 0));
@@ -848,7 +906,7 @@ const OnboardingWizard: React.FC = () => {
             >
                 {currentStep === 0 && <WelcomeStep onNext={handleNext} />}
                 {currentStep === 1 && <RobotModelStep values={localValues} onChange={handleChange} />}
-                {currentStep === 2 && <GpsStep values={localValues} onChange={handleChange} />}
+                {currentStep === 2 && <GpsStep values={localValues} onChange={handleChange} gpsRestarting={gpsRestarting} />}
                 {currentStep === 3 && <SensorStep values={localValues} onChange={handleChange} />}
                 {currentStep === 4 && <ImuYawStep values={localValues} onChange={handleChange} />}
                 {currentStep === 5 && <FirmwareStep onNext={handleNext} />}
@@ -878,9 +936,11 @@ const OnboardingWizard: React.FC = () => {
                             type="primary"
                             icon={currentStep < 4 ? <ArrowRightOutlined /> : <SaveOutlined />}
                             onClick={handleNext}
-                            loading={saving || loading}
+                            loading={saving || loading || gpsRestarting}
                         >
-                            {currentStep < 4 ? "Next" : "Save & Continue"}
+                            {gpsRestarting
+                                ? "Restarting GPS…"
+                                : currentStep < 4 ? "Next" : "Save & Continue"}
                         </Button>
                     </Space>
                 </Col>

--- a/gui/web/src/pages/SettingsPage.tsx
+++ b/gui/web/src/pages/SettingsPage.tsx
@@ -7,11 +7,11 @@ import {
     UndoOutlined,
 } from "@ant-design/icons";
 import { useApi } from "../hooks/useApi.ts";
-import { App } from "antd";
 import { useIsMobile } from "../hooks/useIsMobile.ts";
 import { useThemeMode } from "../theme/ThemeContext.tsx";
 import { SettingsSection, useSettingsManager } from "../hooks/useSettingsManager.ts";
 import { restartRos2 } from "../utils/containers.ts";
+import { useContainerRestart } from "../hooks/useContainerRestart.ts";
 import { SettingsNav } from "../components/settings/SettingsNav.tsx";
 import { HardwareSection } from "../components/settings/HardwareSection.tsx";
 import { PositioningSection } from "../components/settings/PositioningSection.tsx";
@@ -29,7 +29,6 @@ const { Text } = Typography;
 
 export const SettingsPage = () => {
     const guiApi = useApi();
-    const { notification } = App.useApp();
     const isMobile = useIsMobile();
     const { colors } = useThemeMode();
     const [activeSection, setActiveSection] = useState<SettingsSection>("hardware");
@@ -52,14 +51,17 @@ export const SettingsPage = () => {
         revert,
     } = useSettingsManager();
 
-    const handleRestartRos2 = useCallback(async () => {
-        try {
-            await restartRos2(guiApi);
-            notification.success({ message: "ROS2 container restarted" });
-        } catch (e: any) {
-            notification.error({ message: "Failed to restart ROS2", description: e.message });
-        }
-    }, [guiApi, notification]);
+    // Long-running: container restart + rosbridge reconnect. Disable button
+    // until ROS2 is reachable again to avoid duplicate-click restart storms.
+    const ros2Restart = useContainerRestart({
+        pendingLabel: "Redémarrage ROS2…",
+        successMessage: "ROS2 redémarré",
+        errorMessage: "Échec du redémarrage ROS2",
+    });
+    const handleRestartRos2 = useCallback(
+        () => ros2Restart.run(() => restartRos2(guiApi)),
+        [ros2Restart, guiApi],
+    );
 
     const renderSection = () => {
         switch (activeSection) {
@@ -129,8 +131,15 @@ export const SettingsPage = () => {
                         showIcon
                         message="Restart required to apply saved changes"
                         action={
-                            <Button size="small" type="primary" icon={<ReloadOutlined />} onClick={handleRestartRos2}>
-                                Restart ROS2
+                            <Button
+                                size="small"
+                                type="primary"
+                                icon={<ReloadOutlined />}
+                                onClick={handleRestartRos2}
+                                loading={ros2Restart.pending}
+                                disabled={ros2Restart.pending}
+                            >
+                                {ros2Restart.pending ? ros2Restart.pendingLabel : "Restart ROS2"}
                             </Button>
                         }
                         style={{ marginBottom: 12 }}
@@ -214,8 +223,14 @@ export const SettingsPage = () => {
                     </Button>
                 )}
                 <div style={{ flex: 1 }} />
-                <Button icon={<ReloadOutlined />} onClick={handleRestartRos2} size="small">
-                    Restart ROS2
+                <Button
+                    icon={<ReloadOutlined />}
+                    onClick={handleRestartRos2}
+                    size="small"
+                    loading={ros2Restart.pending}
+                    disabled={ros2Restart.pending}
+                >
+                    {ros2Restart.pending ? ros2Restart.pendingLabel : "Restart ROS2"}
                 </Button>
             </div>
         </div>

--- a/gui/web/src/utils/containers.ts
+++ b/gui/web/src/utils/containers.ts
@@ -46,3 +46,31 @@ export const restartGui = (api: GuiApi) =>
 /** Restart the MowgliNext container */
 export const restartMowgliNext = (api: GuiApi) =>
     containerAction(api, { name: "mowglinext", label: { key: "app", value: "mowglinext" } }, "restart");
+
+/** Restart the GPS container (picks up new NTRIP / serial / protocol config) */
+export const restartGps = (api: GuiApi) =>
+    containerAction(api, { name: "gps" }, "restart");
+
+/**
+ * Settings keys whose values are consumed by the GPS docker container
+ * (NTRIP credentials, mountpoint, serial port, protocol). Saving any of
+ * these requires bouncing mowgli-gps to actually apply the change.
+ * Datum lat/lon/alt are read by ROS2 (navsat_to_absolute_pose_node), not
+ * by the GPS container itself, so they are deliberately not in this list.
+ */
+export const GPS_RESTART_KEYS = new Set<string>([
+    "gps_protocol",
+    "gps_port",
+    "ntrip_enabled",
+    "ntrip_host",
+    "ntrip_port",
+    "ntrip_user",
+    "ntrip_password",
+    "ntrip_mountpoint",
+]);
+
+/** True if any dirty key affects the GPS container. */
+export const dirtyKeysRequireGpsRestart = (dirty: Iterable<string>): boolean => {
+    for (const k of dirty) if (GPS_RESTART_KEYS.has(k)) return true;
+    return false;
+};

--- a/install/compose/docker-compose.nmea.yaml
+++ b/install/compose/docker-compose.nmea.yaml
@@ -1,0 +1,47 @@
+# -------------------------------------------------------------------------
+# Generic NMEA-0183 GNSS backend.
+#
+# Truly generic — works with any receiver that emits standard NMEA over
+# UART or USB-serial (Emlid Reach, BN-220, LC29H, NEO-M8N in NMEA mode,
+# etc.). Distinct from the `gps` backend (UBX) and `ublox` backend
+# (libusb / serial UBX HP). Selected via GNSS_BACKEND=nmea.
+#
+# Tradeoffs vs UBX:
+#   * Position covariance derived from HDOP only — no `position_accuracy`,
+#     so map-frame fusion sees a more pessimistic σ than RTK-Fixed implies.
+#   * No carrier-solution flag — RTK Fixed/Float status only inferable
+#     from GGA fix-quality (4 / 5).
+#   * NTRIP/RTCM relay not bundled. Configure NTRIP on the receiver itself
+#     (most modern modules support it), or run a separate sidecar that
+#     writes RTCM bytes back to the same /dev/gps — non-trivial, see
+#     sensors/nmea/Dockerfile header.
+# -------------------------------------------------------------------------
+x-ros2-env: &ros2-env
+  ROS_DOMAIN_ID: ${ROS_DOMAIN_ID:-0}
+  RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
+  ROS_AUTOMATIC_DISCOVERY_RANGE: LOCALHOST
+  RCUTILS_COLORIZED_OUTPUT: "1"
+  RCUTILS_LOGGING_USE_STDOUT: "1"
+  CYCLONEDDS_URI: file:///cyclonedds.xml
+
+services:
+  gnss_nmea:
+    container_name: mowgli-gps
+    image: ${NMEA_IMAGE}
+    network_mode: host
+    ipc: host
+    privileged: true
+    environment:
+      <<: *ros2-env
+      NMEA_PORT: ${GPS_PORT:-/dev/gps}
+      NMEA_BAUD: ${GPS_BAUD:-9600}
+      NMEA_FRAME_ID: gps_link
+    volumes:
+      - /dev:/dev
+      - ./docker/config/cyclonedds.xml:/cyclonedds.xml:ro
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-file: "3"
+        max-size: 5m

--- a/install/lib/compose.sh
+++ b/install/lib/compose.sh
@@ -57,8 +57,11 @@ build_compose_stack() {
       unicore)
         COMPOSE_FILES+=("$COMPOSE_SRC_DIR/docker-compose.unicore.yaml")
         ;;
+      nmea)
+        COMPOSE_FILES+=("$COMPOSE_SRC_DIR/docker-compose.nmea.yaml")
+        ;;
       *)
-        error "Unknown GNSS_BACKEND: ${GNSS_BACKEND:-unset} (expected: gps, ublox, unicore)"
+        error "Unknown GNSS_BACKEND: ${GNSS_BACKEND:-unset} (expected: gps, ublox, unicore, nmea)"
         return 1
         ;;
     esac

--- a/install/lib/config.sh
+++ b/install/lib/config.sh
@@ -21,6 +21,7 @@ LIDAR_LDLIDAR_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/lidar-ldlidar:${IMAGE
 LIDAR_RPLIDAR_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/lidar-rplidar:${IMAGE_TAG}"
 LIDAR_STL27L_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/lidar-stl27l:${IMAGE_TAG}"
 MAVROS_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/mavros:${IMAGE_TAG}"
+NMEA_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/nmea:${IMAGE_TAG}"
 GUI_IMAGE_DEFAULT="ghcr.io/cedbossneo/mowglinext/mowglinext-gui:${IMAGE_TAG}"
 
 CHECK_ONLY=false

--- a/install/lib/env.sh
+++ b/install/lib/env.sh
@@ -62,6 +62,7 @@ setup_env() {
   : "${GPS_IMAGE:=${GPS_IMAGE_DEFAULT}}"
   : "${GUI_IMAGE:=${GUI_IMAGE_DEFAULT}}"
   : "${MAVROS_IMAGE:=${MAVROS_IMAGE_DEFAULT}}"
+  : "${NMEA_IMAGE:=${NMEA_IMAGE_DEFAULT}}"
 
   if [[ -z "${LIDAR_IMAGE:-}" ]]; then
     case "${LIDAR_TYPE:-ldlidar}" in
@@ -133,6 +134,7 @@ setup_env() {
   upsert_env_key "$env_file" "GPS_IMAGE" "$GPS_IMAGE"
   upsert_env_key "$env_file" "LIDAR_IMAGE" "$LIDAR_IMAGE"
   upsert_env_key "$env_file" "MAVROS_IMAGE" "$MAVROS_IMAGE"
+  upsert_env_key "$env_file" "NMEA_IMAGE" "$NMEA_IMAGE"
   upsert_env_key "$env_file" "GUI_IMAGE" "$GUI_IMAGE"
 
   upsert_env_key "$env_file" "HARDWARE_BACKEND" "$HARDWARE_BACKEND"

--- a/install/lib/gps.sh
+++ b/install/lib/gps.sh
@@ -61,9 +61,9 @@ configure_gps() {
   # If preset values exist (from web composer or CLI), skip interactive prompts
   if [[ "${PRESET_LOADED:-false}" == "true" && -n "${GNSS_BACKEND:-}" && -n "${GPS_CONNECTION:-}" && -n "${GPS_PROTOCOL:-}" ]]; then
     case "${GNSS_BACKEND}" in
-      gps|ublox|unicore) ;;
+      gps|ublox|unicore|nmea) ;;
       *)
-        error "Invalid GNSS_BACKEND preset: ${GNSS_BACKEND} (expected: gps, ublox, unicore)"
+        error "Invalid GNSS_BACKEND preset: ${GNSS_BACKEND} (expected: gps, ublox, unicore, nmea)"
         return 1
         ;;
     esac
@@ -94,9 +94,10 @@ configure_gps() {
   else
     echo ""
     echo "Select GNSS backend:"
-    echo "  1) Generic GPS (legacy)"
-    echo "  2) u-blox (F9P)"
+    echo "  1) Generic GPS (legacy, UBX-only despite the name)"
+    echo "  2) u-blox (F9P, UBX HP + NTRIP bundled)"
     echo "  3) Unicore (UM98x)"
+    echo "  4) Generic NMEA (any NMEA-0183 receiver, UART or USB)"
     prompt "$MSG_CHOICE" "1"
     local gnss_choice="$REPLY"
 
@@ -109,6 +110,9 @@ configure_gps() {
         ;;
       3)
         GNSS_BACKEND="unicore"
+        ;;
+      4)
+        GNSS_BACKEND="nmea"
         ;;
       *)
         error "Invalid GNSS backend choice"
@@ -178,6 +182,17 @@ configure_gps() {
         return 1
         ;;
     esac
+
+    # Generic NMEA backend forces NMEA protocol and prompts for baud
+    # since NMEA receivers vary widely (9600 default, 38400/115200 common
+    # for higher rates).
+    if [ "$GNSS_BACKEND" = "nmea" ]; then
+      GPS_PROTOCOL="NMEA"
+      echo ""
+      echo "NMEA baud rate (typical: 9600, 38400, 115200):"
+      prompt "$MSG_CHOICE" "9600"
+      GPS_BAUD="$REPLY"
+    fi
 
     echo ""
     if confirm "$MSG_GPS_DEBUG_CONFIRM"; then

--- a/sensors/README.md
+++ b/sensors/README.md
@@ -7,7 +7,17 @@ Dockerized ROS2 drivers for each supported sensor. Each subdirectory contains a 
 | Sensor | Type | Directory | ROS2 Topic | Protocol |
 |--------|------|-----------|------------|----------|
 | u-blox ZED-F9P | RTK GPS | [`gps/`](gps/) | `/ublox_gps_node/fix` (NavSatFix) | USB-CDC |
+| Unicore UM98x | RTK GPS | [`unicore/`](unicore/) | `/gps/fix` (NavSatFix) | UART/USB |
+| Generic NMEA-0183 | GPS (any vendor) | [`nmea/`](nmea/) | `/gps/fix` (NavSatFix), `/gps/vel` (TwistStamped) | UART/USB |
 | LDRobot LD19 | 2D LiDAR | [`lidar/`](lidar/) | `/scan` (LaserScan) | UART 230400 |
+
+### GPS backend selection
+
+The installer offers four GNSS backends (`GNSS_BACKEND` env): `gps` (legacy UBX), `ublox` (F9P UBX HP + bundled NTRIP), `unicore` (UM98x), `nmea` (this driver). Pick `nmea` for any receiver that emits standard NMEA-0183 sentences (GGA, RMC, GSA, VTG) — Emlid Reach, BN-220, LC29H, NEO-M8N in NMEA mode, etc. Caveats:
+
+- Position covariance is derived from HDOP only, no UBX `position_accuracy`. The map-frame EKF / `fusion_graph` will see a more pessimistic σ than RTK-Fixed implies.
+- RTK still works if the receiver outputs RTK-quality GGA fix-quality codes (4=Fixed, 5=Float), but the project's BT/GUI cannot distinguish Fixed from Float beyond GGA quality.
+- NTRIP/RTCM relay is **not bundled**. Configure NTRIP on the receiver itself (Emlid and most modern modules support it natively). Relaying RTCM from a ROS-side ntrip client back to the same `/dev/gps` port requires a custom sidecar — not provided here.
 
 ## Adding a New Sensor
 

--- a/sensors/nmea/Dockerfile
+++ b/sensors/nmea/Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1.7
+# =============================================================================
+# Generic NMEA-0183 GPS driver
+#
+# Truly generic NMEA driver for any receiver that emits standard NMEA
+# sentences (GGA, RMC, GSA, VTG) over UART or USB-serial. Examples:
+# Emlid Reach, generic u-blox in NMEA mode, BN-220, LC29H, NEO-M8N
+# in NMEA mode, etc.
+#
+# Uses the upstream ros-drivers `nmea_navsat_driver` package from the
+# Kilted apt index — no source build required, no UBX dependency.
+#
+# Publishes (remapped to the project's /gps/ namespace by the launch):
+#   /gps/fix    sensor_msgs/NavSatFix      (lat/lon/alt + HDOP-derived cov)
+#   /gps/vel    geometry_msgs/TwistStamped (from RMC/VTG ground speed+track)
+#   /gps/heading mowgli interop topic — not produced by this driver
+#
+# Caveats vs the ublox backend:
+#   * Covariance comes from HDOP only (no UBX position_accuracy), so the
+#     map-frame EKF / fusion_graph see a more pessimistic σ than RTK-Fixed
+#     would imply. RTK still works if the receiver outputs RTK-quality
+#     GGA fix-quality codes (4=Fix, 5=Float).
+#   * No carrier-solution flag → BT/GUI cannot distinguish RTK-Fixed from
+#     Float beyond GGA fix-quality.
+#   * NTRIP injection is NOT bundled here. If your receiver supports NTRIP
+#     internally (Emlid, most modern modules), configure it on the device.
+#     If you need ROS-side RTCM relay over the same serial port, run a
+#     separate ntrip_client_node and write RTCM bytes back to the device
+#     — non-trivial and out of scope for this fragment.
+# =============================================================================
+FROM ros:kilted-ros-base
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+      ros-kilted-nmea-navsat-driver \
+      ros-kilted-rmw-cyclonedds-cpp
+
+COPY ros2_entrypoint.sh /ros2_entrypoint.sh
+COPY start_nmea.sh /start_nmea.sh
+RUN chmod +x /ros2_entrypoint.sh /start_nmea.sh
+
+ENTRYPOINT ["/ros2_entrypoint.sh"]
+CMD ["/start_nmea.sh"]

--- a/sensors/nmea/ros2_entrypoint.sh
+++ b/sensors/nmea/ros2_entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+source /opt/ros/kilted/setup.bash
+exec "$@"

--- a/sensors/nmea/start_nmea.sh
+++ b/sensors/nmea/start_nmea.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# =============================================================================
+# Generic NMEA driver launcher.
+#
+# Reads from a single serial device — UART (/dev/ttyS*, /dev/ttyAMA*) or
+# USB (/dev/ttyACM*, /dev/ttyUSB*). The compose layer maps the host device
+# to NMEA_PORT inside the container so this script does not care which.
+#
+# Env:
+#   NMEA_PORT      device path inside container  (default /dev/gps)
+#   NMEA_BAUD      serial baud rate              (default 9600)
+#   NMEA_FRAME_ID  TF frame for NavSatFix        (default gps_link)
+# =============================================================================
+set -euo pipefail
+
+NMEA_PORT="${NMEA_PORT:-/dev/gps}"
+NMEA_BAUD="${NMEA_BAUD:-9600}"
+NMEA_FRAME_ID="${NMEA_FRAME_ID:-gps_link}"
+
+echo "[start_nmea.sh] port=${NMEA_PORT} baud=${NMEA_BAUD} frame=${NMEA_FRAME_ID}"
+
+# Wait for the device path (up to 5 s) — udev/by-id symlinks may race
+# the container start.
+for i in $(seq 1 50); do
+  [ -e "${NMEA_PORT}" ] && break
+  sleep 0.1
+done
+if [ ! -e "${NMEA_PORT}" ]; then
+  echo "[start_nmea.sh] ERROR: ${NMEA_PORT} did not appear after 5s"
+  exit 1
+fi
+
+# nmea_serial_driver publishes /fix (NavSatFix), /vel (TwistStamped),
+# /time_reference, /heading. Remap to the project /gps/* namespace.
+exec ros2 run nmea_navsat_driver nmea_serial_driver --ros-args \
+  -p port:="${NMEA_PORT}" \
+  -p baud:="${NMEA_BAUD}" \
+  -p frame_id:="${NMEA_FRAME_ID}" \
+  -p use_GNSS_time:=false \
+  -p time_ref_source:="${NMEA_FRAME_ID}" \
+  -r /fix:=/gps/fix \
+  -r /vel:=/gps/vel \
+  -r /heading:=/gps/heading \
+  -r /time_reference:=/gps/time_reference


### PR DESCRIPTION
## Summary

Three onboarding/UX fixes grouped together:

### 1. Auto-restart GPS on NTRIP/GPS settings change
The GPS container now restarts automatically when the user saves changes to GPS-related fields (`gps_protocol`, `gps_port`, `ntrip_*`). Previously the user had to know to click a separate restart button — without it, the new NTRIP credentials were never applied, RTK Fix never came, and the next-step "Set Datum" button stayed disabled with no feedback as to why.

- New helpers in `gui/web/src/utils/containers.ts` (`restartGps`, `GPS_RESTART_KEYS`, `dirtyKeysRequireGpsRestart`)
- `useSettingsManager` triggers the restart on save when GPS keys are dirty
- `OnboardingPage` shows a "GPS restarting…" alert and blocks Next during the restart call
- Datum lat/lon/alt deliberately excluded (read by ROS2's `navsat_to_absolute_pose_node`, not the GPS container)

### 2. Restart ROS2 / Restart Mowgli — proper pending state
Long restart actions now disable the button + show a spinner + label change ("Redémarrage ROS2…") and only re-enable once rosbridge is verifiably back, killing the "user clicks 5×" pattern.

- New `useContainerRestart` hook opens a probe WebSocket on `/api/mowglinext/subscribe/highLevelStatus` and resolves on the first message — that path is end-to-end (rosbridge → Go → browser), so it's a reliable liveness signal
- 60s timeout falls back to a warning toast
- Applied to both Restart ROS2 buttons in `SettingsPage` and the Restart Mowgli item in `MowerStatus`

### 3. Generic NMEA GPS driver
New third backend option for non-ublox receivers (Emlid, generic NMEA modules, etc.). Additive — ublox/unicore/legacy paths untouched.

- `sensors/nmea/` — Dockerfile + entrypoint, runs `nmea_serial_driver` from `ros-kilted-nmea-navsat-driver`
- Same code path for UART and USB (only `NMEA_PORT` + `NMEA_BAUD` differ)
- Remaps to `/gps/fix`, `/gps/vel`, `/gps/heading`, `/gps/time_reference`
- 4th option in installer GPS menu, default baud 9600
- CI workflow + dependabot entry for the new image

**Caveats** (also documented in `sensors/README.md`):
- HDOP only — no UBX `position_accuracy`, so EKF/`fusion_graph` cov is more pessimistic than with ublox
- RTK works only if receiver emits GGA quality 4/5 (Fixed vs Float not separable beyond that)
- **NTRIP not bundled** — configure on the receiver itself, or add a sidecar that relays RTCM to the serial port (out of scope here)

## Test plan

- [ ] CI: tsc + lint pass (couldn't run locally — no node toolchain on the host)
- [ ] Onboarding: change NTRIP host → see "GPS restarting…" toast → wait for RTK Fix → "Set Datum" becomes clickable
- [ ] Settings: click Restart ROS2 → button shows spinner + disabled → success toast on reconnect
- [ ] Rapidly click Restart ROS2 several times → only one restart fires
- [ ] Installer: select option 4 (Generic NMEA), pick UART or USB, set baud → compose comes up with mowgli-gps running nmea_serial_driver → /gps/fix publishes
- [ ] Existing ublox / unicore / legacy GPS / mavros paths still work