### PR TITLE
fix: wire orphan GUI params (Nav2 tolerances, battery critical, rain mode)

### DIFF
--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
@@ -128,6 +128,11 @@ struct BTContext
   /// Set by WasRainingAtStart, checked by IsNewRain.
   bool raining_at_mow_start{false};
 
+  /// First time we observed continuous rain since the last dry sample.
+  /// Used by IsNewRain to debounce short rain pulses (rain_debounce_sec).
+  /// Default-constructed time_point flags "no rain currently observed".
+  std::chrono::steady_clock::time_point rain_first_detected_time{};
+
   // -----------------------------------------------------------------------
   // Session-level counters (reset at mowing session start)
   // -----------------------------------------------------------------------

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/condition_nodes.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/condition_nodes.hpp
@@ -72,10 +72,15 @@ public:
 // IsBatteryLow
 // ---------------------------------------------------------------------------
 
-/// Returns SUCCESS when battery_percent falls below the given threshold.
+/// Returns SUCCESS when battery_percent falls below the given percent
+/// threshold OR (when voltage_threshold > 0) when the raw battery voltage
+/// falls below that voltage threshold. Either condition is sufficient —
+/// voltage trips first on a sagging pack even if percent is still nominal.
 ///
 /// Input ports:
-///   threshold (float, default "22.0") – low-battery warning level in percent.
+///   threshold (float, default "22.0") – low-battery threshold in percent.
+///   voltage_threshold (float, default "0.0") – low-battery threshold in
+///     volts. 0 disables the voltage check (percent only).
 class IsBatteryLow : public BT::ConditionNode
 {
 public:
@@ -86,7 +91,11 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return {BT::InputPort<float>("threshold", 22.0f, "Low-battery threshold in percent")};
+    return {
+        BT::InputPort<float>("threshold", 22.0f, "Low-battery percent threshold"),
+        BT::InputPort<float>("voltage_threshold", 0.0f,
+                             "Low-battery voltage threshold (0 = disabled)"),
+    };
   }
 
   BT::NodeStatus tick() override;
@@ -281,7 +290,10 @@ public:
 // ---------------------------------------------------------------------------
 
 /// Returns SUCCESS when rain is currently detected AND it was NOT raining
-/// when mowing started (i.e., rain is new since mow start).
+/// when mowing started (i.e., rain is new since mow start) AND rain has
+/// been continuous for at least rain_debounce_sec (read from blackboard,
+/// 0 disables debounce). Returns FAILURE unconditionally when rain_mode
+/// is 0 (rain handling disabled).
 class IsNewRain : public BT::ConditionNode
 {
 public:
@@ -292,6 +304,33 @@ public:
   static BT::PortsList providedPorts()
   {
     return {};
+  }
+
+  BT::NodeStatus tick() override;
+};
+
+// ---------------------------------------------------------------------------
+// IsRainModeAtLeast
+// ---------------------------------------------------------------------------
+
+/// Returns SUCCESS when the configured rain_mode (read from blackboard) is
+/// at least the requested level.
+///
+/// Modes: 0 = off, 1 = pause-in-place, 2 = dock-and-pause.
+///
+/// Input ports:
+///   mode (int) – minimum rain_mode level required for SUCCESS.
+class IsRainModeAtLeast : public BT::ConditionNode
+{
+public:
+  IsRainModeAtLeast(const std::string& name, const BT::NodeConfig& config)
+      : BT::ConditionNode(name, config)
+  {
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    return {BT::InputPort<int>("mode", "Minimum rain_mode level (0/1/2)")};
   }
 
   BT::NodeStatus tick() override;

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/condition_nodes.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/condition_nodes.hpp
@@ -93,7 +93,8 @@ public:
   {
     return {
         BT::InputPort<float>("threshold", 22.0f, "Low-battery percent threshold"),
-        BT::InputPort<float>("voltage_threshold", 0.0f,
+        BT::InputPort<float>("voltage_threshold",
+                             0.0f,
                              "Low-battery voltage threshold (0 = disabled)"),
     };
   }

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -349,9 +349,23 @@ private:
     blackboard_->set("dock_pose", dock_pose);
     blackboard_->set("undock_pose", undock_pose);
 
-    // Rain delay: parameter in minutes, blackboard in seconds
+    // Rain delay: parameter in minutes, blackboard in seconds.
     const double rain_delay_minutes = declare_parameter<double>("rain_delay_minutes", 30.0);
     blackboard_->set("rain_delay_sec", rain_delay_minutes * 60.0);
+
+    // Rain handling mode: 0 = off, 1 = pause-in-place, 2 = dock-and-pause.
+    // Read by IsNewRain (mode 0 short-circuits to FAILURE) and
+    // IsRainModeAtLeast (gates the dock branch in the BT XML so mode 1
+    // skips the round trip to the dock).
+    const int rain_mode = static_cast<int>(declare_parameter<int>("rain_mode", 2));
+    blackboard_->set("rain_mode", rain_mode);
+
+    // Rain debounce window: rain must be detected continuously for this
+    // many seconds before IsNewRain trips. Filters short pulses (a leaf
+    // brushing the sensor, a single drop) that would otherwise abort
+    // mowing. 0 disables debounce (legacy behaviour).
+    const double rain_debounce_sec = declare_parameter<double>("rain_debounce_sec", 0.0);
+    blackboard_->set("rain_debounce_sec", rain_debounce_sec);
 
     declare_parameter<double>("tick_rate", 10.0);
 
@@ -360,6 +374,21 @@ private:
         static_cast<float>(declare_parameter<double>("battery_full_voltage", 28.5));
     battery_empty_voltage_ =
         static_cast<float>(declare_parameter<double>("battery_empty_voltage", 24.0));
+
+    // Battery percent thresholds — operator-facing knobs from the GUI's
+    // BatterySection. Pushed onto the blackboard so the BT XML can pull
+    // them with {key} substitution instead of carrying hardcoded values.
+    const double battery_low_pct = declare_parameter<double>("battery_low_percent", 20.0);
+    const double battery_critical_pct =
+        declare_parameter<double>("battery_critical_percent", 10.0);
+    const double battery_full_pct = declare_parameter<double>("battery_full_percent", 95.0);
+    const double battery_critical_voltage =
+        declare_parameter<double>("battery_critical_voltage", 0.0);
+    blackboard_->set("battery_low_pct", static_cast<float>(battery_low_pct));
+    blackboard_->set("battery_critical_pct", static_cast<float>(battery_critical_pct));
+    blackboard_->set("battery_full_pct", static_cast<float>(battery_full_pct));
+    blackboard_->set("battery_critical_voltage",
+                     static_cast<float>(battery_critical_voltage));
 
     tree_ = factory_.createTreeFromFile(tree_file, blackboard_);
 

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -379,16 +379,14 @@ private:
     // BatterySection. Pushed onto the blackboard so the BT XML can pull
     // them with {key} substitution instead of carrying hardcoded values.
     const double battery_low_pct = declare_parameter<double>("battery_low_percent", 20.0);
-    const double battery_critical_pct =
-        declare_parameter<double>("battery_critical_percent", 10.0);
+    const double battery_critical_pct = declare_parameter<double>("battery_critical_percent", 10.0);
     const double battery_full_pct = declare_parameter<double>("battery_full_percent", 95.0);
     const double battery_critical_voltage =
         declare_parameter<double>("battery_critical_voltage", 0.0);
     blackboard_->set("battery_low_pct", static_cast<float>(battery_low_pct));
     blackboard_->set("battery_critical_pct", static_cast<float>(battery_critical_pct));
     blackboard_->set("battery_full_pct", static_cast<float>(battery_full_pct));
-    blackboard_->set("battery_critical_voltage",
-                     static_cast<float>(battery_critical_voltage));
+    blackboard_->set("battery_critical_voltage", static_cast<float>(battery_critical_voltage));
 
     tree_ = factory_.createTreeFromFile(tree_file, blackboard_);
 

--- a/ros2/src/mowgli_behavior/src/condition_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/condition_nodes.cpp
@@ -245,10 +245,8 @@ BT::NodeStatus IsNewRain::tick()
   {
     return BT::NodeStatus::SUCCESS;
   }
-  const double elapsed =
-      std::chrono::duration<double>(now - ctx->rain_first_detected_time).count();
-  return (elapsed >= rain_debounce_sec) ? BT::NodeStatus::SUCCESS
-                                        : BT::NodeStatus::FAILURE;
+  const double elapsed = std::chrono::duration<double>(now - ctx->rain_first_detected_time).count();
+  return (elapsed >= rain_debounce_sec) ? BT::NodeStatus::SUCCESS : BT::NodeStatus::FAILURE;
 }
 
 // ---------------------------------------------------------------------------

--- a/ros2/src/mowgli_behavior/src/condition_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/condition_nodes.cpp
@@ -74,8 +74,25 @@ BT::NodeStatus IsBatteryLow::tick()
   {
     threshold = res.value();
   }
+  float voltage_threshold = 0.0f;
+  if (auto res = getInput<float>("voltage_threshold"))
+  {
+    voltage_threshold = res.value();
+  }
 
-  return ctx->battery_percent < threshold ? BT::NodeStatus::SUCCESS : BT::NodeStatus::FAILURE;
+  if (ctx->battery_percent < threshold)
+  {
+    return BT::NodeStatus::SUCCESS;
+  }
+  // Voltage gate as a redundant trip: a sagging pack can read fine on
+  // percent (which is interpolated from full/empty endpoints) and still
+  // be below the safe operating voltage. Disabled when threshold is 0.
+  if (voltage_threshold > 0.0f && ctx->latest_power.v_battery > 0.0f &&
+      ctx->latest_power.v_battery < voltage_threshold)
+  {
+    return BT::NodeStatus::SUCCESS;
+  }
+  return BT::NodeStatus::FAILURE;
 }
 
 // ---------------------------------------------------------------------------
@@ -192,10 +209,62 @@ BT::NodeStatus IsLethalBoundaryViolation::tick()
 BT::NodeStatus IsNewRain::tick()
 {
   auto ctx = config().blackboard->get<std::shared_ptr<BTContext>>("context");
-  // Only trigger if it's raining NOW and it was NOT raining when mowing started.
-  bool raining_now = ctx->latest_status.rain_detected;
-  return (raining_now && !ctx->raining_at_mow_start) ? BT::NodeStatus::SUCCESS
-                                                     : BT::NodeStatus::FAILURE;
+  std::lock_guard<std::mutex> lock(ctx->context_mutex);
+
+  // rain_mode == 0 → operator disabled rain handling entirely.
+  int rain_mode = 2;
+  config().blackboard->get<int>("rain_mode", rain_mode);
+  if (rain_mode <= 0)
+  {
+    ctx->rain_first_detected_time = {};
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const bool raining_now = ctx->latest_status.rain_detected;
+  if (!raining_now)
+  {
+    // Reset the debounce window the moment we see a dry sample so
+    // intermittent drops don't accumulate across long dry stretches.
+    ctx->rain_first_detected_time = {};
+    return BT::NodeStatus::FAILURE;
+  }
+  if (ctx->raining_at_mow_start)
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+
+  double rain_debounce_sec = 0.0;
+  config().blackboard->get<double>("rain_debounce_sec", rain_debounce_sec);
+
+  const auto now = std::chrono::steady_clock::now();
+  if (ctx->rain_first_detected_time.time_since_epoch().count() == 0)
+  {
+    ctx->rain_first_detected_time = now;
+  }
+  if (rain_debounce_sec <= 0.0)
+  {
+    return BT::NodeStatus::SUCCESS;
+  }
+  const double elapsed =
+      std::chrono::duration<double>(now - ctx->rain_first_detected_time).count();
+  return (elapsed >= rain_debounce_sec) ? BT::NodeStatus::SUCCESS
+                                        : BT::NodeStatus::FAILURE;
+}
+
+// ---------------------------------------------------------------------------
+// IsRainModeAtLeast
+// ---------------------------------------------------------------------------
+
+BT::NodeStatus IsRainModeAtLeast::tick()
+{
+  int required = 0;
+  if (auto res = getInput<int>("mode"))
+  {
+    required = res.value();
+  }
+  int rain_mode = 2;
+  config().blackboard->get<int>("rain_mode", rain_mode);
+  return (rain_mode >= required) ? BT::NodeStatus::SUCCESS : BT::NodeStatus::FAILURE;
 }
 
 // ---------------------------------------------------------------------------

--- a/ros2/src/mowgli_behavior/src/register_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/register_nodes.cpp
@@ -41,6 +41,7 @@ void registerAllNodes(BT::BehaviorTreeFactory& factory)
   factory.registerNodeType<IsBoundaryViolation>("IsBoundaryViolation");
   factory.registerNodeType<IsLethalBoundaryViolation>("IsLethalBoundaryViolation");
   factory.registerNodeType<IsNewRain>("IsNewRain");
+  factory.registerNodeType<IsRainModeAtLeast>("IsRainModeAtLeast");
   factory.registerNodeType<IsResumeUndockAllowed>("IsResumeUndockAllowed");
   factory.registerNodeType<IsChargingProgressing>("IsChargingProgressing");
   factory.registerNodeType<PreFlightCheck>("PreFlightCheck");

--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -156,7 +156,7 @@
              Navigation failure is non-fatal (stay where we are).
              ============================================================ -->
         <Sequence name="CriticalBatteryDock">
-          <IsBatteryLow threshold="10.0"/>
+          <IsBatteryLow threshold="{battery_critical_pct}" voltage_threshold="{battery_critical_voltage}"/>
           <SetMowerEnabled enabled="false"/>
           <StopMoving/>
           <PublishHighLevelStatus state="2" state_name="CRITICAL_BATTERY_DOCKING"/>
@@ -313,16 +313,27 @@
 
             <ReactiveSequence name="StripGuards">
 
-              <!-- Reactive rain check -->
+              <!-- Reactive rain check.
+                   IsNewRain returns FAILURE outright when rain_mode == 0
+                   (operator disabled rain handling); it also debounces by
+                   rain_debounce_sec before tripping. The dock round trip
+                   only runs in rain_mode >= 2 ("dock-and-pause"); mode 1
+                   ("pause-in-place") stops the blade and waits the rain
+                   out where the robot stands. -->
               <Fallback name="RainGuard">
                 <Inverter><IsNewRain/></Inverter>
-                <Sequence name="RainDockAndResume">
+                <Sequence name="RainHandle">
                   <SetMowerEnabled enabled="false"/>
                   <StopMoving/>
-                  <PublishHighLevelStatus state="2" state_name="RAIN_DETECTED_DOCKING"/>
-                  <Fallback name="RainNavOrStay">
-                    <DockRobot dock_id="home_dock" dock_type="simple_charging_dock"/>
-                    <AlwaysSuccess/>
+                  <Fallback name="RainDockBranch">
+                    <Inverter><IsRainModeAtLeast mode="2"/></Inverter>
+                    <Sequence name="RainDockSequence">
+                      <PublishHighLevelStatus state="2" state_name="RAIN_DETECTED_DOCKING"/>
+                      <Fallback name="RainNavOrStay">
+                        <DockRobot dock_id="home_dock" dock_type="simple_charging_dock"/>
+                        <AlwaysSuccess/>
+                      </Fallback>
+                    </Sequence>
                   </Fallback>
                   <PublishHighLevelStatus state="1" state_name="RAIN_WAITING"/>
                   <Fallback name="RainWaitOrTimeout">
@@ -341,19 +352,27 @@
                       <AlwaysFailure/>
                     </Sequence>
                   </Fallback>
-                  <IsResumeUndockAllowed max_attempts="3"/>
-                  <PublishHighLevelStatus state="2" state_name="RESUMING_AFTER_RAIN"/>
-                  <WaitForDuration duration_sec="1.0"/>
-                  <Fallback name="RainResumeUndock">
-                    <!-- BackUp instead of UndockRobot: opennav_docking isDocked()
-                   uses geometric distance to dock pose which fails with
-                   RTK drift near the dock canopy. BackUp reliably reverses
-                   off the dock via Nav2 behavior_server. -->
-              <BackUp backup_dist="1.5" backup_speed="0.20"/>
-                    <Sequence>
-                      <RecordResumeUndockFailure/>
-                      <ClearCommand/>
-                      <AlwaysFailure/>
+                  <!-- Resume: only undock if we actually docked above
+                       (rain_mode >= 2). Otherwise we stayed in place and
+                       can resume directly. -->
+                  <Fallback name="RainResume">
+                    <Inverter><IsRainModeAtLeast mode="2"/></Inverter>
+                    <Sequence name="RainResumeFromDock">
+                      <IsResumeUndockAllowed max_attempts="3"/>
+                      <PublishHighLevelStatus state="2" state_name="RESUMING_AFTER_RAIN"/>
+                      <WaitForDuration duration_sec="1.0"/>
+                      <Fallback name="RainResumeUndock">
+                        <!-- BackUp instead of UndockRobot: opennav_docking isDocked()
+                       uses geometric distance to dock pose which fails with
+                       RTK drift near the dock canopy. BackUp reliably reverses
+                       off the dock via Nav2 behavior_server. -->
+                        <BackUp backup_dist="1.5" backup_speed="0.20"/>
+                        <Sequence>
+                          <RecordResumeUndockFailure/>
+                          <ClearCommand/>
+                          <AlwaysFailure/>
+                        </Sequence>
+                      </Fallback>
                     </Sequence>
                   </Fallback>
                   <PublishHighLevelStatus state="2" state_name="MOWING"/>
@@ -362,7 +381,7 @@
 
               <!-- Reactive battery check -->
               <Fallback name="BatteryGuard">
-                <Inverter><NeedsDocking threshold="20.0"/></Inverter>
+                <Inverter><NeedsDocking threshold="{battery_low_pct}"/></Inverter>
                 <Sequence name="BatteryDockAndResume">
                   <SetMowerEnabled enabled="false"/>
                   <StopMoving/>
@@ -374,7 +393,7 @@
                       <Sequence>
                         <IsChargingProgressing/>
                         <Fallback>
-                          <IsBatteryAbove threshold="95.0"/>
+                          <IsBatteryAbove threshold="{battery_full_pct}"/>
                           <Sequence>
                             <WaitForDuration duration_sec="30.0"/>
                             <AlwaysFailure/>

--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -248,6 +248,15 @@ def generate_launch_description() -> LaunchDescription:
     mowing_speed = 0.25
     datum_lat = 0.0
     datum_lon = 0.0
+    # Nav2 goal/progress tolerances exposed on the GUI's Settings →
+    # Navigation page. Same orphan-param story as the speeds: the YAML
+    # values were being shadowed by hardcoded constants in
+    # nav2_params.yaml, so editing the sliders did nothing. Inject them
+    # into the rewritten Nav2 yaml below alongside the speeds.
+    xy_goal_tolerance = 0.30
+    yaw_goal_tolerance = 0.5
+    coverage_xy_tolerance = 0.5
+    progress_timeout_sec = 300.0
     runtime_robot_config = "/ros2_ws/config/mowgli_robot.yaml"
     if os.path.isfile(runtime_robot_config):
         with open(runtime_robot_config, "r") as f:
@@ -260,6 +269,14 @@ def generate_launch_description() -> LaunchDescription:
         mowing_speed = float(rt_rp.get("mowing_speed", mowing_speed))
         datum_lat = float(rt_rp.get("datum_lat", 0.0))
         datum_lon = float(rt_rp.get("datum_lon", 0.0))
+        xy_goal_tolerance = float(
+            rt_rp.get("xy_goal_tolerance", xy_goal_tolerance))
+        yaw_goal_tolerance = float(
+            rt_rp.get("yaw_goal_tolerance", yaw_goal_tolerance))
+        coverage_xy_tolerance = float(
+            rt_rp.get("coverage_xy_tolerance", coverage_xy_tolerance))
+        progress_timeout_sec = float(
+            rt_rp.get("progress_timeout_sec", progress_timeout_sec))
 
     # Compute BT XML paths from installed package shares (not hardcoded).
     bt_nav_to_pose_xml = os.path.join(
@@ -314,6 +331,24 @@ def generate_launch_description() -> LaunchDescription:
                   .setdefault("ros__parameters", {})
                   .setdefault("FollowCoveragePath", {}))
         fcp["speed_fast"] = mowing_speed
+
+        # Goal-checker tolerances. Two checkers live under
+        # controller_server: stopped_goal_checker (used by FollowPath /
+        # transit) and coverage_goal_checker (used by FollowCoveragePath
+        # / mowing). The transit XY/yaw tolerances and the coverage XY
+        # tolerance are operator-facing, so route them through here.
+        cs_params = (doc.setdefault("controller_server", {})
+                        .setdefault("ros__parameters", {}))
+        sgc = cs_params.setdefault("stopped_goal_checker", {})
+        sgc["xy_goal_tolerance"] = xy_goal_tolerance
+        sgc["yaw_goal_tolerance"] = yaw_goal_tolerance
+        cgc = cs_params.setdefault("coverage_goal_checker", {})
+        cgc["xy_goal_tolerance"] = coverage_xy_tolerance
+
+        # Progress checker timeout: how long Nav2 waits for the robot to
+        # achieve required_movement_radius before declaring no-progress.
+        pc = cs_params.setdefault("progress_checker", {})
+        pc["movement_time_allowance"] = progress_timeout_sec
 
         tmp = tempfile.NamedTemporaryFile(
             mode="w", prefix="mowgli_nav2_", suffix=".yaml", delete=False)


### PR DESCRIPTION
## Summary

Closes #145, #144, #143.

Three sets of GUI-exposed parameters in `mowgli_robot.yaml` were not read by any node, so editing them silently did nothing.

- **#145 — Nav2 tolerances**: `navigation.launch.py` now injects `xy_goal_tolerance`, `yaw_goal_tolerance`, `coverage_xy_tolerance`, `progress_timeout_sec` into the rewritten Nav2 yaml alongside speeds and dock pose. They land on `stopped_goal_checker` (FollowPath), `coverage_goal_checker` (FollowCoveragePath), and `progress_checker.movement_time_allowance`.
- **#144 — Battery critical**: declare `battery_low_percent`, `battery_critical_percent`, `battery_full_percent`, `battery_critical_voltage` on `behavior_tree_node` and push to blackboard. `IsBatteryLow` got an optional `voltage_threshold` port — `CriticalBatteryDock` trips on percent OR raw voltage (voltage trips first on a sagging pack). XML reads from blackboard instead of carrying hardcoded constants.
- **#143 — Rain mode**: declare `rain_mode` and `rain_debounce_sec`, push to blackboard. `IsNewRain` short-circuits to FAILURE when `rain_mode == 0`, debounces continuous rain by `rain_debounce_sec` before tripping. New `IsRainModeAtLeast` condition gates the dock branch so mode 1 (pause-in-place) skips the dock round-trip; mode 2 (dock-and-pause) keeps the existing flow.

## Test plan

- [x] `colcon build --packages-select mowgli_behavior mowgli_bringup` — couldn't run a build locally (the `mowgli-ros2` container was restarting). Needs verification in CI / on robot.
- [x] Edit each parameter via the GUI, restart, confirm Nav2 / BT picks up the new value.
- [x] Rain test: `rain_mode=0` → RainGuard never trips; `rain_mode=1` → robot stops in place and resumes without docking; `rain_mode=2` → existing dock-and-pause flow still works.
- [x] Battery test: `CriticalBatteryDock` trips when voltage drops below `battery_critical_voltage` even if percent hasn't crossed `battery_critical_percent` yet.