### PR TITLE
fix(fusion_graph): refuse empty-graph save/load, add Tick guard

### DIFF
--- a/ros2/src/fusion_graph/CMakeLists.txt
+++ b/ros2/src/fusion_graph/CMakeLists.txt
@@ -136,6 +136,11 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_factors fusion_graph_core)
 
+  ament_add_gtest(test_persistence
+    test/test_persistence.cpp
+  )
+  target_link_libraries(test_persistence fusion_graph_core)
+
   # Performance benchmarks. Long-running (~30 s on ARM); only meaningful
   # in Release builds. Output is grep-friendly for tracking regressions.
   ament_add_gtest(test_perf

--- a/ros2/src/fusion_graph/src/fusion_graph_node.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node.cpp
@@ -681,7 +681,8 @@ void FusionGraphNode::OnHighLevelStatus(mowgli_interfaces::msg::HighLevelStatus:
   {
     constexpr uint8_t kRecording =
         mowgli_interfaces::msg::HighLevelStatus::HIGH_LEVEL_STATE_RECORDING;
-    if (last_hl_state_ == kRecording && msg->state != kRecording)
+    if (last_hl_state_ == kRecording && msg->state != kRecording &&
+        graph_->IsInitialized())
     {
       const bool ok = graph_->Save(graph_save_prefix_);
       RCLCPP_INFO(get_logger(),
@@ -738,7 +739,8 @@ void FusionGraphNode::OnSetPose(geometry_msgs::msg::PoseWithCovarianceStamped::C
 void FusionGraphNode::OnHardwareStatus(mowgli_interfaces::msg::Status::ConstSharedPtr msg)
 {
   // Rising edge of is_charging = robot just docked.
-  if (last_is_charging_valid_ && !last_is_charging_ && msg->is_charging)
+  if (last_is_charging_valid_ && !last_is_charging_ && msg->is_charging &&
+      graph_->IsInitialized())
   {
     const bool ok = graph_->Save(graph_save_prefix_);
     RCLCPP_INFO(get_logger(), "fusion_graph: auto-save on dock arrival → %s", ok ? "ok" : "failed");

--- a/ros2/src/fusion_graph/src/graph_manager.cpp
+++ b/ros2/src/fusion_graph/src/graph_manager.cpp
@@ -217,6 +217,18 @@ std::optional<TickOutput> GraphManager::Tick(double now_s)
 
 TickOutput GraphManager::CreateNodeLocked(double now_s)
 {
+  // Guard against next_index_ == 0: would underflow PoseKey(next_index_ - 1)
+  // and crash GTSAM with "Symbol index is too large" when j wraps to 2^64-1.
+  // Reachable historically when Load() restored an empty persisted graph
+  // (next_index=0) and marked the manager initialized; both Save() and Load()
+  // now refuse the empty case, but keep this defensive — the cost of the
+  // check is one compare and the upside is no abort if a future code path
+  // reintroduces the same hole.
+  if (next_index_ == 0)
+  {
+    return latest_.value_or(TickOutput{});
+  }
+
   // 1. Build the wheel between-factor: relative pose from X_{k-1} to X_k.
   //    Pose2(dx, dy, dtheta_gyro) — gyro for yaw, wheel for translation.
   //    If gyro accumulator is zero (no IMU received) fall back to wheel.
@@ -690,6 +702,13 @@ void GraphManager::Reset()
 bool GraphManager::Save(const std::string& prefix) const
 {
   std::lock_guard<std::mutex> lock(mu_);
+  // Refuse to persist an empty graph. An auto-save fired right after a
+  // Reset() would otherwise overwrite the on-disk files with
+  // next_index=0 / count=0; on next launch Load() restored that state,
+  // marked initialized_, and the first Tick crashed with a Symbol-index
+  // underflow. Keep whatever good state was on disk before the reset.
+  if (!initialized_ || next_index_ == 0)
+    return false;
   // Manual / on-checkpoint path. Always refreshes from iSAM2 — the
   // serialized state must reflect all factor updates since the last
   // RefreshEstimateLocked() call.
@@ -787,6 +806,15 @@ bool GraphManager::Load(const std::string& prefix)
   {
     return false;
   }
+
+  // Refuse to restore a degenerate persisted state. With next_idx == 0
+  // (or no values at all) marking initialized_ would let CreateNodeLocked
+  // form PoseKey(next_idx - 1) and underflow into a 2^64-1 Symbol index
+  // — GTSAM throws std::invalid_argument and the process aborts. Treat
+  // this as "no graph on disk" so the node bootstraps from the next GPS
+  // / set_pose seed.
+  if (next_idx == 0 || loaded_values.empty())
+    return false;
 
   // Re-seed iSAM2 with each loaded pose pinned by a tight prior; the
   // priors keep optimization stable as new wheel/GPS factors arrive.

--- a/ros2/src/fusion_graph/test/test_persistence.cpp
+++ b/ros2/src/fusion_graph/test/test_persistence.cpp
@@ -1,0 +1,124 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Regression tests for GraphManager::Save / Load. The motivating
+// failure: a Reset() (Clear-graph service) followed by an auto-save
+// (RECORDING-exit or dock-arrival) wrote an empty graph to disk
+// (next_index=0, count=0). On next launch, Load() restored that state
+// and marked the manager initialized. The first Tick then formed
+// PoseKey(next_index_ - 1) → underflow to 2^64-1 → GTSAM
+// std::invalid_argument → process abort.
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+
+#include "fusion_graph/graph_manager.hpp"
+#include <gtest/gtest.h>
+
+namespace fg = fusion_graph;
+namespace fs = std::filesystem;
+
+namespace
+{
+std::string TempPrefix(const char* tag)
+{
+  auto base = fs::temp_directory_path() / (std::string("fg_test_") + tag + "_" +
+                                           std::to_string(::getpid()));
+  return base.string();
+}
+
+void CleanupPrefix(const std::string& prefix)
+{
+  std::error_code ec;
+  fs::remove(prefix + ".graph", ec);
+  fs::remove(prefix + ".scans", ec);
+  fs::remove(prefix + ".meta", ec);
+}
+}  // namespace
+
+// Reset() leaves the manager uninitialized with next_index_ == 0. Any
+// auto-save fired in that window must NOT touch on-disk files; otherwise
+// the next launch resurrects the poisoned state.
+TEST(Persistence, SaveAfterResetIsRefused)
+{
+  const auto prefix = TempPrefix("save_after_reset");
+  CleanupPrefix(prefix);
+
+  fg::GraphManager gm(fg::GraphParams{});
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 0.0);
+  ASSERT_TRUE(gm.Save(prefix));  // baseline: a real graph saves
+  gm.Reset();
+
+  EXPECT_FALSE(gm.Save(prefix));  // empty graph must be refused
+  CleanupPrefix(prefix);
+}
+
+// Symmetric on the read side: even if a stale empty file pair survives
+// (e.g. written by a pre-fix binary), Load() must refuse to mark the
+// manager initialized — otherwise CreateNodeLocked's PoseKey(j-1) with
+// j=0 underflows the GTSAM Symbol index check.
+TEST(Persistence, LoadOfEmptyMetaIsRefused)
+{
+  const auto prefix = TempPrefix("load_empty");
+  CleanupPrefix(prefix);
+
+  // Hand-craft the empty file triple a pre-fix binary would produce.
+  {
+    std::ofstream g(prefix + ".graph");
+    g << "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\" ?>\n"
+         "<!DOCTYPE boost_serialization>\n"
+         "<boost_serialization signature=\"serialization::archive\" version=\"19\">\n"
+         "<data class_id=\"0\" tracking_level=\"0\" version=\"0\">\n"
+         "  <values_ class_id=\"1\" tracking_level=\"0\" version=\"0\">\n"
+         "    <count>0</count>\n"
+         "    <item_version>0</item_version>\n"
+         "  </values_>\n"
+         "</data>\n"
+         "</boost_serialization>\n";
+  }
+  {
+    std::ofstream s(prefix + ".scans", std::ios::binary);
+    const uint64_t zero = 0;
+    s.write(reinterpret_cast<const char*>(&zero), sizeof(zero));
+  }
+  {
+    std::ofstream m(prefix + ".meta");
+    m << "next_index=0\nlast_node_time_s=0.000000\n";
+  }
+
+  fg::GraphManager gm(fg::GraphParams{});
+  EXPECT_FALSE(gm.Load(prefix));
+  EXPECT_FALSE(gm.IsInitialized());
+
+  // The bug repro: with the previous code, IsInitialized() was true
+  // here and the next Tick aborted. Confirm Tick is a no-op now.
+  EXPECT_FALSE(gm.Tick(1.0).has_value());
+
+  CleanupPrefix(prefix);
+}
+
+// Healthy round-trip is unchanged.
+TEST(Persistence, NonEmptyRoundTrip)
+{
+  const auto prefix = TempPrefix("roundtrip");
+  CleanupPrefix(prefix);
+
+  {
+    fg::GraphManager gm(fg::GraphParams{});
+    gm.Initialize(gtsam::Pose2(1.0, 2.0, 0.5), 0.0);
+    gm.AddWheelTwist(0.1, 0.0, 0.0, 0.1);
+    auto out = gm.Tick(0.2);
+    ASSERT_TRUE(out.has_value());
+    EXPECT_TRUE(gm.Save(prefix));
+  }
+  {
+    fg::GraphManager gm(fg::GraphParams{});
+    EXPECT_TRUE(gm.Load(prefix));
+    EXPECT_TRUE(gm.IsInitialized());
+  }
+
+  CleanupPrefix(prefix);
+}


### PR DESCRIPTION
## Summary
- `fusion_graph_node` was aborting with `Symbol index is too large, j=18446744073709551615` — `uint64_t` underflow at `PoseKey(next_index_ - 1)` when `next_index_ == 0`.
- Repro chain: `Reset()` (Clear-graph service) → auto-save fired on RECORDING-exit / dock-arrival → wrote `next_index=0, count=0` to disk → next launch's `Load()` restored that state and set `initialized_ = true` → first `Tick()` underflowed → SIGABRT, no relaunch.
- Downstream symptom on the live robot today: with `fusion_graph_node` dead, no `map → odom` TF was published. FTCController rejected every FollowPath (`Invalid frame ID 'map'`), so the BT cycled `MOWING → TRANSIT → SKIP_SEGMENT` every ~3 s while `mow_enabled = true` (RPM ~1061). Robot stationary with blade running.

## Fix
- `GraphManager::Save` refuses to write when uninitialized or `next_index_ == 0` (so a poisoned state can't overwrite a healthy on-disk file).
- `GraphManager::Load` refuses to set `initialized_` when the loaded graph has no values or `next_idx == 0` — caller bootstraps from the next GPS / set_pose seed instead.
- `GraphManager::CreateNodeLocked` defensive guard for the same condition.
- `FusionGraphNode` RECORDING-exit and dock-arrival auto-saves now check `IsInitialized()` (matching the existing periodic-timer guard).
- New `test_persistence.cpp`: `Save-after-Reset` refusal, `Load-of-empty-meta` refusal, plus a non-empty round-trip.

## Field evidence
```
/ros2_ws/maps/fusion_graph.meta  → next_index=0
/ros2_ws/maps/fusion_graph.graph → <count>0</count>
[fusion_graph_node-6] terminate called after throwing 'std::invalid_argument'
[fusion_graph_node-6]   what(): Symbol index is too large, j=18446744073709551615
[ERROR] process has died [pid 30, exit code -6]
```

## Test plan
- [ ] CI builds `fusion_graph` on arm64 + amd64
- [ ] `colcon test --packages-select fusion_graph` passes
- [ ] Watchtower pulls `:dev`, robot restarts cleanly, `fusion_graph_node` stays up
- [ ] `ros2 run tf2_ros tf2_echo map odom` succeeds
- [ ] BT mows real strips instead of cycling SKIP_SEGMENT