### PR TITLE
fix(set_pose): use TRANSIENT_LOCAL QoS for dock-yaw boot seed

### DIFF
--- a/ros2/src/fusion_graph/src/fusion_graph_node.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node.cpp
@@ -249,8 +249,21 @@ FusionGraphNode::FusionGraphNode(const rclcpp::NodeOptions& opts)
   // dual-publishes to /ekf_map_node/set_pose AND to this topic so
   // the dock-yaw seeding works regardless of which localizer is the
   // map-frame primary.
+  //
+  // QoS: TRANSIENT_LOCAL with depth-1, matching dock_yaw_to_set_pose's
+  // publisher. The boot seed is a one-shot rising-edge event; with
+  // VOLATILE either side, a subscriber that hasn't finished discovery
+  // when the message is published silently loses it and the graph
+  // never bootstraps (observed 2026-05-03 after a force-recreate). With
+  // TL on both sides, a late-joining subscriber gets the last seed
+  // pose latched on connect — node bootstraps without manual republish.
+  rclcpp::QoS set_pose_qos(rclcpp::KeepLast(1));
+  set_pose_qos.reliable();
+  set_pose_qos.transient_local();
   sub_set_pose_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
-      "~/set_pose", 1, std::bind(&FusionGraphNode::OnSetPose, this, std::placeholders::_1));
+      "~/set_pose",
+      set_pose_qos,
+      std::bind(&FusionGraphNode::OnSetPose, this, std::placeholders::_1));
 
   // ── Save-graph service ──────────────────────────────────────────
   // Trigger from the GUI / a BT node when transitioning out of

--- a/ros2/src/mowgli_localization/src/dock_yaw_to_set_pose_node.cpp
+++ b/ros2/src/mowgli_localization/src/dock_yaw_to_set_pose_node.cpp
@@ -42,6 +42,19 @@ public:
     qos_sensor.best_effort();
     qos_sensor.durability_volatile();
 
+    // The set_pose seed fires once (rising edge of is_charging) and the
+    // map-frame localizer has to receive it to bootstrap. With VOLATILE
+    // pub QoS, a subscriber that hasn't finished discovery loses the
+    // message — observed on 2026-05-03 after a force-recreate when
+    // fusion_graph_node started later than dock_yaw_to_set_pose. Use
+    // TRANSIENT_LOCAL with depth-1 so a late-joining subscriber that
+    // also opts in to TRANSIENT_LOCAL gets the last seed automatically.
+    // Subscribers with default VOLATILE QoS keep receiving real-time
+    // publishes as before (TL pub ↔ VOLATILE sub is compatible per DDS).
+    rclcpp::QoS qos_seed(rclcpp::KeepLast(1));
+    qos_seed.reliable();
+    qos_seed.transient_local();
+
     sub_status_ = create_subscription<mowgli_interfaces::msg::Status>(
         "/hardware_bridge/status",
         qos_reliable,
@@ -66,14 +79,14 @@ public:
 
     pub_map_ =
         create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("/ekf_map_node/set_pose",
-                                                                        qos_reliable);
+                                                                        qos_seed);
     pub_odom_ =
-        create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("/set_pose", qos_reliable);
+        create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("/set_pose", qos_seed);
     // Dual-publish to fusion_graph_node: works regardless of which
     // localizer is the active map-frame primary. The unused publisher
     // costs ~zero (no subscribers).
     pub_fg_ = create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
-        "/fusion_graph_node/set_pose", qos_reliable);
+        "/fusion_graph_node/set_pose", qos_seed);
 
     yaw_var_ = declare_parameter<double>("seed_yaw_variance", 0.1);
 


### PR DESCRIPTION
## Summary
After PR #156 deployed, a `docker compose up --force-recreate mowgli-ros2` exposed a second bootstrap bug: `dock_yaw_to_set_pose` publishes the seed pose **once** on the rising edge of `is_charging`, with VOLATILE QoS. If `fusion_graph_node` hasn't finished DDS discovery when that single message goes out, it's silently lost and the graph never initializes — no `map → odom` TF, no `/odometry/filtered_map`, BT cannot navigate.

Repro confirmed today: after force-recreate, fusion_graph_node started ~0.1 s after dock_yaw_to_set_pose published `(-0.150, 0.174, -2.508 rad)`. The seed never reached `OnSetPose`. Manual `ros2 topic pub --once /fusion_graph_node/set_pose ...` immediately bootstrapped the graph and TF came up.

## Fix
- `dock_yaw_to_set_pose_node`: switch all three set_pose publishers (`/ekf_map_node/set_pose`, `/set_pose`, `/fusion_graph_node/set_pose`) from RELIABLE/VOLATILE to RELIABLE/TRANSIENT_LOCAL, depth 1.
- `fusion_graph_node`: matching TRANSIENT_LOCAL/depth-1 subscription on `~/set_pose`. Late-joining subscriber gets the last seed latched on connect.
- `ekf_map_node` (robot_localization built-in) keeps its default VOLATILE subscription. Per DDS rules, TL publisher ↔ VOLATILE subscriber is compatible — the VOLATILE side just doesn't get the latched message, only real-time publishes. That matches its current behavior; no regression.

## Test plan
- [ ] `colcon test --packages-select mowgli_localization fusion_graph` passes
- [ ] `docker compose up --force-recreate mowgli-ros2` (no manual reseed) → `fusion_graph_node` log shows `bootstrap init from /set_pose at (...)` automatically
- [ ] `ros2 run tf2_ros tf2_echo map odom` succeeds within ~5 s of container start
- [ ] No regression on `/ekf_map_node/set_pose` flow (existing default-config installs unaffected)

## Related
Follows up on #156. Together they close the `fusion_graph_node` bootstrap gap end-to-end: #156 stops empty persisted state from poisoning the graph; this PR stops the boot seed from being silently lost.