### PR TITLE
fix(behavior_tree): preserve yaw_seeded_this_session across mid-session errors

### DIFF
--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/status_nodes.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/status_nodes.hpp
@@ -82,11 +82,39 @@ public:
 // ---------------------------------------------------------------------------
 
 /// Resets the current_command in BTContext to 0 (no command), preventing the
-/// BT from re-entering a completed sequence.
+/// BT from re-entering a completed sequence. Safe to call from mid-session
+/// error handlers — does NOT touch session-scoped state.
 class ClearCommand : public BT::SyncActionNode
 {
 public:
   ClearCommand(const std::string& name, const BT::NodeConfig& config)
+      : BT::SyncActionNode(name, config)
+  {
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    return {};
+  }
+
+  BT::NodeStatus tick() override;
+};
+
+// ---------------------------------------------------------------------------
+// EndSession
+// ---------------------------------------------------------------------------
+
+/// Resets per-session BTContext flags so the next session starts with a clean
+/// slate — yaw-seed flag, undock bookkeeping, skipped-swath counter. Call only
+/// at confirmed session boundaries (IDLE_DOCKED after MOWING_COMPLETE,
+/// RECORDING_COMPLETE, etc.). Mid-session error handlers must NOT call this:
+/// resetting yaw_seeded_this_session there causes SeedYawFromMotion to re-fire
+/// the 1 m forward drive on the next ReactiveSequence re-tick of UndockOrSkip,
+/// even though the dock_yaw seed is already healthy.
+class EndSession : public BT::SyncActionNode
+{
+public:
+  EndSession(const std::string& name, const BT::NodeConfig& config)
       : BT::SyncActionNode(name, config)
   {
   }

--- a/ros2/src/mowgli_behavior/src/register_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/register_nodes.cpp
@@ -58,6 +58,7 @@ void registerAllNodes(BT::BehaviorTreeFactory& factory)
   factory.registerNodeType<NavigateInsideBoundary>("NavigateInsideBoundary");
   factory.registerNodeType<BackUp>("BackUp");
   factory.registerNodeType<ClearCommand>("ClearCommand");
+  factory.registerNodeType<EndSession>("EndSession");
   factory.registerNodeType<IncrementSkippedSwaths>("IncrementSkippedSwaths");
   factory.registerNodeType<SaveObstacles>("SaveObstacles");
   factory.registerNodeType<SetNavMode>("SetNavMode");

--- a/ros2/src/mowgli_behavior/src/status_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/status_nodes.cpp
@@ -103,9 +103,32 @@ BT::NodeStatus ClearCommand::tick()
               "ClearCommand: resetting current_command from %u to 0",
               ctx->current_command);
   ctx->current_command = 0;
-  // Per-session flags reset here so the next session's seeding nodes
-  // actually run instead of short-circuiting on stale state.
+  // Note: session-scoped flags (yaw_seeded_this_session, skipped_swaths) are
+  // intentionally NOT touched here. ClearCommand is invoked from mid-session
+  // error handlers (UndockFailed, RainTimeout, ChargerFailed,
+  // ResumeUndockOrAbort), and resetting yaw_seeded_this_session there caused
+  // SeedYawFromMotion to re-drive 1 m forward on the next ReactiveSequence
+  // re-tick of UndockOrSkip — even when the dock_yaw seed was already healthy.
+  // Use EndSession at the real session boundaries instead.
+  return BT::NodeStatus::SUCCESS;
+}
+
+// ---------------------------------------------------------------------------
+// EndSession
+// ---------------------------------------------------------------------------
+
+BT::NodeStatus EndSession::tick()
+{
+  auto ctx = config().blackboard->get<std::shared_ptr<BTContext>>("context");
+  RCLCPP_INFO(ctx->node->get_logger(),
+              "EndSession: clearing per-session flags "
+              "(yaw_seeded=%s, skipped_swaths=%d, undock_recorded=%s)",
+              ctx->yaw_seeded_this_session ? "true" : "false",
+              ctx->skipped_swaths,
+              ctx->undock_start_recorded ? "true" : "false");
   ctx->yaw_seeded_this_session = false;
+  ctx->skipped_swaths = 0;
+  ctx->undock_start_recorded = false;
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -170,6 +170,7 @@
             </Sequence>
           </Fallback>
           <PublishHighLevelStatus state="1" state_name="IDLE_DOCKED"/>
+          <EndSession/>
           <ClearCommand/>
         </Sequence>
 
@@ -502,6 +503,7 @@
                 </Sequence>
               </Fallback>
               <PublishHighLevelStatus state="1" state_name="IDLE_DOCKED"/>
+              <EndSession/>
               <ClearCommand/>
             </Sequence>
           </Fallback>
@@ -513,6 +515,7 @@
           <SaveObstacles/>
           <DockRobot dock_id="home_dock" dock_type="simple_charging_dock"/>
           <PublishHighLevelStatus state="1" state_name="IDLE_DOCKED"/>
+          <EndSession/>
           <ClearCommand/>
         </Sequence>
 
@@ -555,6 +558,7 @@
               </Sequence>
             </ReactiveFallback>
             <PublishHighLevelStatus state="1" state_name="IDLE_DOCKED"/>
+            <EndSession/>
             <ClearCommand/>
           </Sequence>
         </ReactiveSequence>
@@ -604,6 +608,7 @@
             record_rate_hz="2.0"
             is_exclusion_zone="false"/>
           <PublishHighLevelStatus state="1" state_name="RECORDING_COMPLETE"/>
+          <EndSession/>
           <ClearCommand/>
         </ReactiveSequence>
 


### PR DESCRIPTION
## Summary
The robot was occasionally driving 1 m forward post-undock even when the dock_yaw seed was already healthy. Field repro: after `BackUp 1 m` partial-completed (wheel slip on dock ramp → ~0.4 m GPS displacement), `CalibrateHeadingFromUndock` returned FAILURE on the still-charging-but-stuck path, `UndockSequence` failed, the Fallback fell through to `UndockFailed` which called `<ClearCommand/>`, and `ClearCommand` silently reset `yaw_seeded_this_session=false`. On the next ReactiveSequence re-tick of `UndockOrSkip` the charging contact had dropped, `NotDockedBranch` fired, `SeedYawFromMotion` saw `flag=false`, and the robot drove 1 m forward unnecessarily.

## Fix
Decouple session-flag resets from `current_command` resets:
- `ClearCommand` no longer touches `yaw_seeded_this_session`.
- New `EndSession` BT node resets the per-session flags
  (`yaw_seeded_this_session`, `skipped_swaths`, `undock_start_recorded`).
- `main_tree.xml` inserts `<EndSession/>` before `<ClearCommand/>` at the five real session boundaries (post-emergency `IDLE_DOCKED`, `FailedCoverageDock`, `MOWING_COMPLETE`, NavToDock end, `RECORDING_COMPLETE`). The five mid-session error handlers (`UndockFailed`, `RainTimeout`, `ChargerFailed`, `RainResumeFromDock` BackUp failure, `ResumeUndockOrAbort` failure) keep `<ClearCommand/>` only.

## Follow-up suggestion (not in this PR)
`CalibrateHeadingFromUndock`'s `min_displacement_m=0.5` is tighter than the node's internal default (0.20). With wheel slip on the dock ramp, partial undocks of 0.3–0.5 m are routine and currently fail the gate while charging is still asserted. Consider lowering to 0.30 or relaxing the FAILURE branch to also accept partial undocks where charging dropped within the BackUp window. Tracked separately.

## Test plan
- [ ] `colcon test --packages-select mowgli_behavior` passes
- [ ] BT smoke test: undock → mow → low battery → re-dock → re-undock — `SeedYawFromMotion` does NOT fire on the resume undock (flag stays true)
- [ ] BT smoke test: undock → BackUp partial → `UndockFailed` → retry from clean state — `SeedYawFromMotion` does fire ONCE then guard works as expected on subsequent re-ticks
- [ ] Visually confirm `<EndSession/>` is at session-boundary sites only (5 places) and no mid-session site has it