### PR TITLE
feat(behavior_tree): back off when collision_monitor wedges robot on obstacle

### DIFF
--- a/ros2/src/mowgli_behavior/CMakeLists.txt
+++ b/ros2/src/mowgli_behavior/CMakeLists.txt
@@ -126,6 +126,34 @@ if(BUILD_TESTING)
     tf2
     tf2_ros
   )
+
+  # ---- test_obstacle_recovery ----
+  # Exercises IsObstacleStuck by ticking it through a minimal BT, with
+  # the BTContext (and its collision_monitor fields) mutated directly to
+  # simulate the subscriber callback in behavior_tree_node.cpp.
+  ament_add_gtest(test_obstacle_recovery
+    test/test_obstacle_recovery.cpp
+    src/condition_nodes.cpp
+  )
+
+  target_include_directories(test_obstacle_recovery PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+
+  ament_target_dependencies(test_obstacle_recovery
+    rclcpp
+    behaviortree_cpp
+    mowgli_interfaces
+    nav2_msgs
+    nav_msgs
+    geometry_msgs
+    std_msgs
+    std_srvs
+    tf2
+    tf2_ros
+    tf2_geometry_msgs
+  )
 endif()
 
 ament_package()

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
@@ -149,6 +149,29 @@ struct BTContext
   bool undock_start_recorded{false};
 
   // -----------------------------------------------------------------------
+  // Obstacle-stuck recovery (collision_monitor wedging)
+  // -----------------------------------------------------------------------
+
+  /// Latest action_type from /collision_monitor_state
+  /// (nav2_msgs/CollisionMonitorState). 0 = DO_NOTHING, 1 = STOP,
+  /// 2 = SLOWDOWN, 3 = APPROACH, 4 = LIMIT.
+  uint8_t collision_action_type{0};
+
+  /// Time at which collision_monitor first transitioned into STOP and
+  /// has remained in STOP continuously since. Default-constructed value
+  /// flags "not currently in STOP".
+  std::chrono::steady_clock::time_point collision_stop_since{};
+
+  /// Number of obstacle-backoff recoveries already attempted in the
+  /// current session. Reset by EndSession.
+  int obstacle_backoff_count{0};
+
+  /// Time of the most recent obstacle-backoff success-tick. Used to
+  /// enforce a cooldown so we don't re-fire on the same wedge while
+  /// the BackUp + costmap clear is still settling.
+  std::chrono::steady_clock::time_point last_obstacle_backoff_time{};
+
+  // -----------------------------------------------------------------------
   // Per-session flags reset by ClearCommand at session end
   // -----------------------------------------------------------------------
 

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/condition_nodes.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/condition_nodes.hpp
@@ -487,4 +487,62 @@ private:
   rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr client_;
 };
 
+// ---------------------------------------------------------------------------
+// IsObstacleStuck
+// ---------------------------------------------------------------------------
+
+/// Returns SUCCESS when collision_monitor's PolygonStop has been
+/// continuously active for at least min_duration_sec AND we are still
+/// under max_count obstacle-backoffs for this session AND the cooldown
+/// since the previous backoff has elapsed. On success, increments
+/// ctx->obstacle_backoff_count and stamps ctx->last_obstacle_backoff_time
+/// — that is the side effect the StuckBackoff sequence relies on for its
+/// per-session cap and cooldown.
+///
+/// Field problem this solves: collision_monitor's front-stop polygon can
+/// wedge the robot motionless for minutes when LiDAR sees an obstacle.
+/// /cmd_vel_nav stays nonzero (Nav2 wants to move) but /cmd_vel reaches
+/// the motors as zero, so progress_checker eventually escalates to
+/// MarkBlockedAndSkip — which then re-plants the robot on the same
+/// obstacle. This node lets the BT trigger a 0.40 m reverse + costmap
+/// clear when collision_monitor has stopped us for ≥5 s, capped at
+/// max_count attempts/session with a cooldown between firings.
+///
+/// "Stuck" detection is sourced from /collision_monitor_state
+/// (nav2_msgs/CollisionMonitorState). The behavior_tree_node subscribes
+/// and updates ctx->collision_action_type + ctx->collision_stop_since;
+/// this node only consumes those fields. Note that we deliberately do
+/// NOT read /cmd_vel{,_nav} as a fallback heuristic — collision_monitor
+/// publishes its state directly, so the heuristic would just be a noisier
+/// proxy for the same signal.
+///
+/// Input ports:
+///   min_duration_sec (double, default 5.0) — STOP must be active this
+///                                            long before we trip.
+///   max_count        (int,    default 3)   — per-session backoff cap.
+///   cooldown_sec     (double, default 8.0) — min gap between firings.
+class IsObstacleStuck : public BT::ConditionNode
+{
+public:
+  IsObstacleStuck(const std::string& name, const BT::NodeConfig& config)
+      : BT::ConditionNode(name, config)
+  {
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    return {
+        BT::InputPort<double>("min_duration_sec",
+                              5.0,
+                              "Seconds collision_monitor must be in STOP before tripping"),
+        BT::InputPort<int>("max_count", 3, "Per-session cap on obstacle-backoff firings"),
+        BT::InputPort<double>("cooldown_sec",
+                              8.0,
+                              "Minimum gap between obstacle-backoff firings"),
+    };
+  }
+
+  BT::NodeStatus tick() override;
+};
+
 }  // namespace mowgli_behavior

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/status_nodes.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/status_nodes.hpp
@@ -82,11 +82,39 @@ public:
 // ---------------------------------------------------------------------------
 
 /// Resets the current_command in BTContext to 0 (no command), preventing the
-/// BT from re-entering a completed sequence.
+/// BT from re-entering a completed sequence. Safe to call from mid-session
+/// error handlers — does NOT touch session-scoped state.
 class ClearCommand : public BT::SyncActionNode
 {
 public:
   ClearCommand(const std::string& name, const BT::NodeConfig& config)
+      : BT::SyncActionNode(name, config)
+  {
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    return {};
+  }
+
+  BT::NodeStatus tick() override;
+};
+
+// ---------------------------------------------------------------------------
+// EndSession
+// ---------------------------------------------------------------------------
+
+/// Resets per-session BTContext flags so the next session starts with a clean
+/// slate — yaw-seed flag, undock bookkeeping, skipped-swath counter. Call only
+/// at confirmed session boundaries (IDLE_DOCKED after MOWING_COMPLETE,
+/// RECORDING_COMPLETE, etc.). Mid-session error handlers must NOT call this:
+/// resetting yaw_seeded_this_session there causes SeedYawFromMotion to re-fire
+/// the 1 m forward drive on the next ReactiveSequence re-tick of UndockOrSkip,
+/// even though the dock_yaw seed is already healthy.
+class EndSession : public BT::SyncActionNode
+{
+public:
+  EndSession(const std::string& name, const BT::NodeConfig& config)
       : BT::SyncActionNode(name, config)
   {
   }

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -35,6 +35,7 @@
 #include "mowgli_interfaces/srv/start_in_area.hpp"
 #include "nav2_msgs/action/navigate_to_pose.hpp"
 #include "nav2_msgs/action/undock_robot.hpp"
+#include "nav2_msgs/msg/collision_monitor_state.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "std_msgs/msg/bool.hpp"
@@ -206,6 +207,33 @@ private:
           // RTK fixed (fix_type >= 4) with reasonable accuracy → GPS is fixed.
           context_->gps_is_fixed = (context_->gps_fix_type >= 4) && (msg->position_accuracy < 0.1f);
           context_->gps_quality = std::clamp(1.0f - msg->position_accuracy, 0.0f, 1.0f);
+        });
+
+    // collision_monitor state — used by IsObstacleStuck to detect when
+    // the robot is wedged on an obstacle (PolygonStop active for ≥5 s).
+    // Latched into BTContext so the condition tick is a pure read.
+    collision_monitor_sub_ = create_subscription<nav2_msgs::msg::CollisionMonitorState>(
+        "/collision_monitor_state",
+        10,
+        [this](nav2_msgs::msg::CollisionMonitorState::ConstSharedPtr msg)
+        {
+          std::lock_guard<std::mutex> lock(context_->context_mutex);
+          const uint8_t prev = context_->collision_action_type;
+          context_->collision_action_type = msg->action_type;
+
+          // Stamp the entry-into-STOP transition so IsObstacleStuck can
+          // measure duration. Clear on exit.
+          if (msg->action_type == nav2_msgs::msg::CollisionMonitorState::STOP)
+          {
+            if (prev != nav2_msgs::msg::CollisionMonitorState::STOP)
+            {
+              context_->collision_stop_since = std::chrono::steady_clock::now();
+            }
+          }
+          else
+          {
+            context_->collision_stop_since = std::chrono::steady_clock::time_point{};
+          }
         });
 
     RCLCPP_DEBUG(get_logger(), "Topic subscribers created");
@@ -450,6 +478,7 @@ private:
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr boundary_violation_sub_;
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr lethal_boundary_violation_sub_;
   rclcpp::Subscription<mowgli_interfaces::msg::AbsolutePose>::SharedPtr gps_sub_;
+  rclcpp::Subscription<nav2_msgs::msg::CollisionMonitorState>::SharedPtr collision_monitor_sub_;
 
   // Service server
   rclcpp::Service<mowgli_interfaces::srv::HighLevelControl>::SharedPtr high_level_control_srv_;

--- a/ros2/src/mowgli_behavior/src/condition_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/condition_nodes.cpp
@@ -544,4 +544,95 @@ BT::NodeStatus Nav2Active::tick()
   return BT::NodeStatus::FAILURE;
 }
 
+// ---------------------------------------------------------------------------
+// IsObstacleStuck
+// ---------------------------------------------------------------------------
+
+BT::NodeStatus IsObstacleStuck::tick()
+{
+  auto ctx = config().blackboard->get<std::shared_ptr<BTContext>>("context");
+
+  double min_duration_sec = 5.0;
+  if (auto res = getInput<double>("min_duration_sec"))
+  {
+    min_duration_sec = res.value();
+  }
+  int max_count = 3;
+  if (auto res = getInput<int>("max_count"))
+  {
+    max_count = res.value();
+  }
+  double cooldown_sec = 8.0;
+  if (auto res = getInput<double>("cooldown_sec"))
+  {
+    cooldown_sec = res.value();
+  }
+
+  std::lock_guard<std::mutex> lock(ctx->context_mutex);
+
+  // collision_monitor not in STOP → not stuck.
+  // CollisionMonitorState::STOP == 1.
+  if (ctx->collision_action_type != 1)
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const auto now = std::chrono::steady_clock::now();
+
+  // STOP active but we have no start timestamp yet (subscriber should
+  // always set this when transitioning to STOP — guard anyway).
+  if (ctx->collision_stop_since.time_since_epoch().count() == 0)
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const double stop_age_sec =
+      std::chrono::duration<double>(now - ctx->collision_stop_since).count();
+  if (stop_age_sec < min_duration_sec)
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Per-session attempt cap — let MarkBlockedAndSkip handle persistent
+  // wedges past this point.
+  if (ctx->obstacle_backoff_count >= max_count)
+  {
+    RCLCPP_WARN_THROTTLE(ctx->node->get_logger(),
+                         *ctx->node->get_clock(),
+                         5000,
+                         "IsObstacleStuck: backoff cap reached (%d/%d), "
+                         "deferring to MarkBlockedAndSkip",
+                         ctx->obstacle_backoff_count,
+                         max_count);
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Cooldown — once we successfully fire, wait this long before allowing
+  // another fire so the BackUp + costmap-clear sequence has time to
+  // settle and we don't double-count one wedge.
+  if (ctx->last_obstacle_backoff_time.time_since_epoch().count() != 0)
+  {
+    const double since_last_sec =
+        std::chrono::duration<double>(now - ctx->last_obstacle_backoff_time).count();
+    if (since_last_sec < cooldown_sec)
+    {
+      return BT::NodeStatus::FAILURE;
+    }
+  }
+
+  // Fire: increment count + stamp time so the cooldown engages even if
+  // the StuckBackoff sequence's BackUp itself fails partway through.
+  ctx->obstacle_backoff_count++;
+  ctx->last_obstacle_backoff_time = now;
+
+  RCLCPP_WARN(ctx->node->get_logger(),
+              "IsObstacleStuck: collision_monitor STOP active for %.1fs — "
+              "triggering obstacle-backoff (%d/%d)",
+              stop_age_sec,
+              ctx->obstacle_backoff_count,
+              max_count);
+
+  return BT::NodeStatus::SUCCESS;
+}
+
 }  // namespace mowgli_behavior

--- a/ros2/src/mowgli_behavior/src/register_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/register_nodes.cpp
@@ -46,6 +46,7 @@ void registerAllNodes(BT::BehaviorTreeFactory& factory)
   factory.registerNodeType<IsChargingProgressing>("IsChargingProgressing");
   factory.registerNodeType<PreFlightCheck>("PreFlightCheck");
   factory.registerNodeType<Nav2Active>("Nav2Active");
+  factory.registerNodeType<IsObstacleStuck>("IsObstacleStuck");
 
   // Action nodes
   factory.registerNodeType<SetMowerEnabled>("SetMowerEnabled");

--- a/ros2/src/mowgli_behavior/src/register_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/register_nodes.cpp
@@ -58,6 +58,7 @@ void registerAllNodes(BT::BehaviorTreeFactory& factory)
   factory.registerNodeType<NavigateInsideBoundary>("NavigateInsideBoundary");
   factory.registerNodeType<BackUp>("BackUp");
   factory.registerNodeType<ClearCommand>("ClearCommand");
+  factory.registerNodeType<EndSession>("EndSession");
   factory.registerNodeType<IncrementSkippedSwaths>("IncrementSkippedSwaths");
   factory.registerNodeType<SaveObstacles>("SaveObstacles");
   factory.registerNodeType<SetNavMode>("SetNavMode");

--- a/ros2/src/mowgli_behavior/src/status_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/status_nodes.cpp
@@ -122,13 +122,17 @@ BT::NodeStatus EndSession::tick()
   auto ctx = config().blackboard->get<std::shared_ptr<BTContext>>("context");
   RCLCPP_INFO(ctx->node->get_logger(),
               "EndSession: clearing per-session flags "
-              "(yaw_seeded=%s, skipped_swaths=%d, undock_recorded=%s)",
+              "(yaw_seeded=%s, skipped_swaths=%d, undock_recorded=%s, "
+              "obstacle_backoffs=%d)",
               ctx->yaw_seeded_this_session ? "true" : "false",
               ctx->skipped_swaths,
-              ctx->undock_start_recorded ? "true" : "false");
+              ctx->undock_start_recorded ? "true" : "false",
+              ctx->obstacle_backoff_count);
   ctx->yaw_seeded_this_session = false;
   ctx->skipped_swaths = 0;
   ctx->undock_start_recorded = false;
+  ctx->obstacle_backoff_count = 0;
+  ctx->last_obstacle_backoff_time = std::chrono::steady_clock::time_point{};
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/ros2/src/mowgli_behavior/src/status_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/status_nodes.cpp
@@ -103,9 +103,32 @@ BT::NodeStatus ClearCommand::tick()
               "ClearCommand: resetting current_command from %u to 0",
               ctx->current_command);
   ctx->current_command = 0;
-  // Per-session flags reset here so the next session's seeding nodes
-  // actually run instead of short-circuiting on stale state.
+  // Note: session-scoped flags (yaw_seeded_this_session, skipped_swaths) are
+  // intentionally NOT touched here. ClearCommand is invoked from mid-session
+  // error handlers (UndockFailed, RainTimeout, ChargerFailed,
+  // ResumeUndockOrAbort), and resetting yaw_seeded_this_session there caused
+  // SeedYawFromMotion to re-drive 1 m forward on the next ReactiveSequence
+  // re-tick of UndockOrSkip — even when the dock_yaw seed was already healthy.
+  // Use EndSession at the real session boundaries instead.
+  return BT::NodeStatus::SUCCESS;
+}
+
+// ---------------------------------------------------------------------------
+// EndSession
+// ---------------------------------------------------------------------------
+
+BT::NodeStatus EndSession::tick()
+{
+  auto ctx = config().blackboard->get<std::shared_ptr<BTContext>>("context");
+  RCLCPP_INFO(ctx->node->get_logger(),
+              "EndSession: clearing per-session flags "
+              "(yaw_seeded=%s, skipped_swaths=%d, undock_recorded=%s)",
+              ctx->yaw_seeded_this_session ? "true" : "false",
+              ctx->skipped_swaths,
+              ctx->undock_start_recorded ? "true" : "false");
   ctx->yaw_seeded_this_session = false;
+  ctx->skipped_swaths = 0;
+  ctx->undock_start_recorded = false;
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/ros2/src/mowgli_behavior/test/test_obstacle_recovery.cpp
+++ b/ros2/src/mowgli_behavior/test/test_obstacle_recovery.cpp
@@ -1,0 +1,216 @@
+// Copyright 2026 Mowgli Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * @file test_obstacle_recovery.cpp
+ * @brief Unit tests for IsObstacleStuck condition node.
+ *
+ * Drives the condition node tick() across the time window, the per-session
+ * cap, and the cooldown. BTContext is built directly in-process and the
+ * collision_monitor fields are set as a callback would set them.
+ */
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "behaviortree_cpp/bt_factory.h"
+#include "mowgli_behavior/bt_context.hpp"
+#include "mowgli_behavior/condition_nodes.hpp"
+#include "nav2_msgs/msg/collision_monitor_state.hpp"
+#include <gtest/gtest.h>
+
+using mowgli_behavior::BTContext;
+using mowgli_behavior::IsObstacleStuck;
+using CollisionMonitorState = nav2_msgs::msg::CollisionMonitorState;
+
+// ---------------------------------------------------------------------------
+// Global ROS2 init/shutdown
+// ---------------------------------------------------------------------------
+
+class RclcppEnvironment : public ::testing::Environment
+{
+public:
+  void SetUp() override
+  {
+    if (!rclcpp::ok())
+    {
+      rclcpp::init(0, nullptr);
+    }
+  }
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+  }
+};
+
+::testing::Environment* const rclcpp_env =
+    ::testing::AddGlobalTestEnvironment(new RclcppEnvironment());
+
+// ---------------------------------------------------------------------------
+// Fixture — builds a BTContext + blackboard + IsObstacleStuck instance
+// ---------------------------------------------------------------------------
+
+class IsObstacleStuckTest : public ::testing::Test
+{
+protected:
+  std::shared_ptr<BTContext> ctx;
+  BT::Blackboard::Ptr blackboard;
+  BT::BehaviorTreeFactory factory;
+  BT::Tree tree;
+
+  void SetUp() override
+  {
+    ctx = std::make_shared<BTContext>();
+    ctx->node = rclcpp::Node::make_shared("test_is_obstacle_stuck");
+
+    blackboard = BT::Blackboard::create();
+    blackboard->set("context", ctx);
+
+    factory.registerNodeType<IsObstacleStuck>("IsObstacleStuck");
+
+    // Wrap in a minimal tree so port defaults are honoured by BT.CPP.
+    static const char* xml = R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+          <IsObstacleStuck min_duration_sec="5.0" max_count="3" cooldown_sec="8.0"/>
+        </BehaviorTree>
+      </root>
+    )";
+    tree = factory.createTreeFromText(xml, blackboard);
+  }
+
+  /// Set collision_monitor_state to STOP, with collision_stop_since
+  /// at `seconds_ago` in the past. Mirrors what the subscriber callback
+  /// in behavior_tree_node.cpp does on a STOP transition.
+  void setStuckFor(double seconds_ago)
+  {
+    ctx->collision_action_type = CollisionMonitorState::STOP;
+    ctx->collision_stop_since =
+        std::chrono::steady_clock::now() -
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+            std::chrono::duration<double>(seconds_ago));
+  }
+
+  void clearStop()
+  {
+    ctx->collision_action_type = CollisionMonitorState::DO_NOTHING;
+    ctx->collision_stop_since = std::chrono::steady_clock::time_point{};
+  }
+
+  BT::NodeStatus tick()
+  {
+    return tree.tickOnce();
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+TEST_F(IsObstacleStuckTest, FailsWhenNotInStop)
+{
+  clearStop();
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 0);
+}
+
+TEST_F(IsObstacleStuckTest, FailsWhenStopBelowMinDuration)
+{
+  setStuckFor(2.0);  // <5 s
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 0);
+}
+
+TEST_F(IsObstacleStuckTest, SucceedsWhenStopExceedsMinDuration)
+{
+  setStuckFor(6.0);  // >5 s
+  EXPECT_EQ(tick(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 1);
+  // last_obstacle_backoff_time must have been stamped on the SUCCESS path.
+  EXPECT_NE(ctx->last_obstacle_backoff_time.time_since_epoch().count(), 0);
+}
+
+TEST_F(IsObstacleStuckTest, IncrementsCounterOnlyOnSuccessPath)
+{
+  // Several FAILURE-path ticks must not bump the counter.
+  clearStop();
+  for (int i = 0; i < 5; ++i)
+  {
+    EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  }
+  EXPECT_EQ(ctx->obstacle_backoff_count, 0);
+
+  setStuckFor(2.0);
+  for (int i = 0; i < 5; ++i)
+  {
+    EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  }
+  EXPECT_EQ(ctx->obstacle_backoff_count, 0);
+
+  // Now cross the threshold — exactly one SUCCESS, then cooldown blocks
+  // further fires.
+  setStuckFor(6.0);
+  EXPECT_EQ(tick(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 1);
+}
+
+TEST_F(IsObstacleStuckTest, FailsWhileInCooldown)
+{
+  // First fire succeeds.
+  setStuckFor(6.0);
+  EXPECT_EQ(tick(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 1);
+
+  // Immediately re-tick with stop still active — cooldown (8 s) blocks.
+  setStuckFor(6.0);
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 1);
+}
+
+TEST_F(IsObstacleStuckTest, SucceedsAgainAfterCooldownElapsed)
+{
+  // Pretend the previous backoff was 9 s ago (>cooldown=8 s).
+  ctx->obstacle_backoff_count = 1;
+  ctx->last_obstacle_backoff_time =
+      std::chrono::steady_clock::now() - std::chrono::seconds(9);
+
+  setStuckFor(6.0);
+  EXPECT_EQ(tick(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 2);
+}
+
+TEST_F(IsObstacleStuckTest, FailsWhenAtMaxCount)
+{
+  // Already hit cap — and pretend cooldown long expired so only the cap
+  // matters.
+  ctx->obstacle_backoff_count = 3;
+  ctx->last_obstacle_backoff_time =
+      std::chrono::steady_clock::now() - std::chrono::seconds(60);
+
+  setStuckFor(60.0);  // wedged for a minute, doesn't matter
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 3);  // unchanged
+}
+
+TEST_F(IsObstacleStuckTest, GuardsAgainstStopTypeWithUnsetTimestamp)
+{
+  // Defensive: if action_type=STOP but collision_stop_since was never
+  // set (subscriber missed the transition), the node should not fire.
+  ctx->collision_action_type = CollisionMonitorState::STOP;
+  ctx->collision_stop_since = std::chrono::steady_clock::time_point{};
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 0);
+}

--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -467,6 +467,33 @@
                             </Sequence>
                           </Fallback>
                         </RetryUntilSuccessful>
+                        <!-- Obstacle wedge recovery. collision_monitor's
+                             PolygonStop can hold the robot motionless for
+                             minutes when LiDAR sees an obstacle inside the
+                             front stop polygon — Nav2 keeps publishing on
+                             /cmd_vel_nav, but /cmd_vel reaches the motors
+                             as zero, so progress_checker only escalates
+                             slowly and MarkBlockedAndSkip then re-plants
+                             the robot on the same obstacle.
+                             When STOP has been continuous for ≥5 s, back
+                             off 0.40 m, clear the local costmap, and let
+                             the outer SegmentLoop fetch a fresh segment
+                             (AlwaysSuccess: don't punish this segment for
+                             an obstacle we just cleared — if the same
+                             wedge persists past max_count/cooldown,
+                             IsObstacleStuck returns FAILURE and the
+                             Fallback advances to MarkBlockedAndSkip). -->
+                        <Sequence name="StuckBackoff">
+                          <IsObstacleStuck min_duration_sec="5.0"
+                                           max_count="3"
+                                           cooldown_sec="8.0"/>
+                          <PublishHighLevelStatus state="2"
+                                                  state_name="OBSTACLE_BACKOFF"/>
+                          <SetMowerEnabled enabled="false"/>
+                          <BackUp backup_dist="0.40" backup_speed="0.15"/>
+                          <ClearCostmap/>
+                          <AlwaysSuccess/>
+                        </Sequence>
                         <!-- Both retry attempts failed. Bump fail_count for
                              the cells along the failed segment (DEAD-promote
                              after 3 consecutive failures), increment skipped

--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -170,6 +170,7 @@
             </Sequence>
           </Fallback>
           <PublishHighLevelStatus state="1" state_name="IDLE_DOCKED"/>
+          <EndSession/>
           <ClearCommand/>
         </Sequence>
 
@@ -502,6 +503,7 @@
                 </Sequence>
               </Fallback>
               <PublishHighLevelStatus state="1" state_name="IDLE_DOCKED"/>
+              <EndSession/>
               <ClearCommand/>
             </Sequence>
           </Fallback>
@@ -513,6 +515,7 @@
           <SaveObstacles/>
           <DockRobot dock_id="home_dock" dock_type="simple_charging_dock"/>
           <PublishHighLevelStatus state="1" state_name="IDLE_DOCKED"/>
+          <EndSession/>
           <ClearCommand/>
         </Sequence>
 
@@ -555,6 +558,7 @@
               </Sequence>
             </ReactiveFallback>
             <PublishHighLevelStatus state="1" state_name="IDLE_DOCKED"/>
+            <EndSession/>
             <ClearCommand/>
           </Sequence>
         </ReactiveSequence>
@@ -604,6 +608,7 @@
             record_rate_hz="2.0"
             is_exclusion_zone="false"/>
           <PublishHighLevelStatus state="1" state_name="RECORDING_COMPLETE"/>
+          <EndSession/>
           <ClearCommand/>
         </ReactiveSequence>
 


### PR DESCRIPTION
## Summary

Adds an obstacle-stuck recovery path to the BT so collision_monitor's `PolygonStop` can no longer hold the robot motionless on an obstacle for minutes at a time.

## Field problem (2026-05-03 session)

The robot drove a coverage strip; LiDAR saw an obstacle inside the front `PolygonStop` zone of `collision_monitor` and `/cmd_vel` got zeroed. Nav2 kept publishing motion commands on `/cmd_vel_nav` but they were blocked. The robot sat motionless for ~414 s of wall-clock time until the obstacle was removed manually:

```
collision_monitor: Robot to stop due to PolygonStop polygon
  -- 414 seconds of motionless wedging --
collision_monitor: Robot to continue normal operation
```

The existing `MowOrSkip` Fallback only escalates to `MarkBlockedAndSkip` after `RetryUntilSuccessful` exhausts both attempts (`progress_checker` slowly times out twice), and `MarkBlockedAndSkip` does `StopMoving + ClearCostmap` with no retreat — so the next requested segment can immediately re-plant the robot on the same obstacle, looping.

## What changes

- New `IsObstacleStuck` BT condition node — returns `SUCCESS` only when:
  - `collision_monitor_state.action_type == STOP` continuously for `min_duration_sec` (default 5 s).
  - `obstacle_backoff_count < max_count` (default 3 per session).
  - At least `cooldown_sec` (default 8 s) has elapsed since the last firing.
  - On `SUCCESS`, increments the counter and stamps the cooldown clock.
- New `StuckBackoff` sequence inside `MowOrSkip`, between `SegmentRetry` and `MarkBlockedAndSkip`:
  ```xml
  <Sequence name="StuckBackoff">
    <IsObstacleStuck min_duration_sec="5.0" max_count="3" cooldown_sec="8.0"/>
    <PublishHighLevelStatus state="2" state_name="OBSTACLE_BACKOFF"/>
    <SetMowerEnabled enabled="false"/>
    <BackUp backup_dist="0.40" backup_speed="0.15"/>
    <ClearCostmap/>
    <AlwaysSuccess/>
  </Sequence>
  ```
- `behavior_tree_node` subscribes to `/collision_monitor_state` (`nav2_msgs/CollisionMonitorState`) and latches `action_type` + a `collision_stop_since` timestamp into `BTContext`. Verified present on the live robot.
- `EndSession::tick()` resets `obstacle_backoff_count` and `last_obstacle_backoff_time` along with the existing per-session counters (lands cleanly on top of #158, which introduced `EndSession`).

## Design constraints respected

- **No blind retreat** — fires only when collision_monitor explicitly reports `STOP` for >=5 s, not on generic Nav2 failures.
- **Capped + cooldowned** — at most 3 firings/session, >=8 s apart. If the same wedge defeats every retreat, `IsObstacleStuck` falls through to `MarkBlockedAndSkip` exactly as before.
- **Coverage states only** — gating is BT-structural: the node lives only inside `SegmentLoop`, so it cannot fire during boundary recovery, docking, undock, or battery emergencies.
- **`AlwaysSuccess` after the sequence**: if BackUp clears the obstacle, we do not want to also mark the segment as blocked. The outer `SegmentLoop` will fetch a fresh `GetNextSegment` with a cleared costmap.

## Stuck-detection approach: subscription, not heuristic

The brief gave a choice between a `/collision_monitor_state` subscription and a `cmd_vel_nav != 0 && cmd_vel == 0` heuristic. I picked the subscription because:
- The topic is published by collision_monitor itself with no extra plumbing.
- Verified present on the live robot (`nav2_msgs/CollisionMonitorState`, fields `action_type` + `polygon_name`).
- It is the authoritative signal — a cmd_vel heuristic would just be a noisier proxy, prone to false positives on every BT-level `StopMoving` and zero-output Nav2 tick.

## Depends on

This lands AFTER #158 — it uses `EndSession` (introduced in #158) to reset the per-session backoff counter. PR is branched off `fix/preserve-yaw-seeded-flag`; please merge #158 first.

## Test plan

- [ ] `colcon build --packages-select mowgli_behavior` succeeds in CI.
- [ ] `colcon test --packages-select mowgli_behavior --event-handlers console_direct+` shows `test_obstacle_recovery` green (8 cases: not-in-stop, sub-threshold duration, success path, counter-increments-only-on-success, in-cooldown, after-cooldown, at-max-count, stop-without-timestamp guard).
- [ ] Manual: drop a cinder block in front of the robot mid-coverage. Verify `collision_monitor` reports STOP, BT logs `IsObstacleStuck: collision_monitor STOP active for 5.x s -- triggering obstacle-backoff (1/3)`, robot reverses 0.40 m, costmap clears, segment loop resumes.
- [ ] Manual (regression): persistent obstacle that defeats 3 backoffs => after the 3rd retreat the cap engages, `IsObstacleStuck` returns FAILURE, and `MarkBlockedAndSkip` fires as it does today.
- [ ] Manual (regression): obstacle is cleared between backoffs => no spurious firings, `obstacle_backoff_count` only resets at the end of the session (`EndSession`).