### PR TITLE
fix(obstacle_detection): close 0.10–0.65 m blind zone around robot

### DIFF
--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -440,9 +440,14 @@ global_costmap:
           raytrace_max_range: 8.0
           raytrace_min_range: 0.0
           obstacle_max_range: 5.0
-          # Garden-tuned: ignore returns closer than 0.5m to filter grass
-          # tufts and ground clutter near the LiDAR (mounted at ~0.38m fwd).
-          obstacle_min_range: 0.50
+          # Lowered from 0.50 m → 0.10 m so the global costmap sees the
+          # same near-field obstacles as the local costmap. Ground/grass
+          # clutter is filtered by the min_obstacle_height band (0.08 m
+          # floor) now that ground_constraint keeps base_link Z ≈ 0, so
+          # we don't need a radial guard band on top of it. The Smac
+          # planner's keepout_filter handles dock avoidance on the
+          # global side — no need to mask the dock here.
+          obstacle_min_range: 0.10
           inf_is_valid: true
 
       inflation_layer:
@@ -509,10 +514,22 @@ local_costmap:
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
-        observation_persistence: 0.0
-        observation_sources: scan
-        scan:
-          topic: /scan
+        # Short non-zero persistence (was 0): smooths over the inevitable
+        # 1–2 missing scans during ARM TF jitter so transient obstacles
+        # don't flicker out of the costmap mid-strip. Long persistence
+        # would re-introduce the dock-residue problem post-undock; 2 s
+        # is short enough that costmap_scan_filter's 5 s post-undock
+        # grace window still clears any dock returns before they expire.
+        observation_persistence: 2.0
+        # Subscribe to the conditional /scan_costmap stream from
+        # costmap_scan_filter_node — same scan as /scan but with returns
+        # under dock_blank_range pushed to +inf while is_charging or for
+        # post_undock_blank_sec after charging drops. With that filter
+        # owning the dock-mask logic, obstacle_min_range can drop to a
+        # near-LiDAR floor and the 0.10–0.65 m mowing blind ring closes.
+        observation_sources: scan_filtered
+        scan_filtered:
+          topic: /scan_costmap
           # Same height band as the global obstacle_layer — filter ground
           # hits when the mower pitches on uneven terrain.
           min_obstacle_height: 0.08
@@ -523,25 +540,25 @@ local_costmap:
           raytrace_max_range: 6.0
           raytrace_min_range: 0.0
           obstacle_max_range: 4.0
-          # Blank returns within 0.65m: on this robot the charge port is in
-          # front, so the dock body sits just ahead of base_footprint
-          # (roughly chassis_center_x + chassis_length/2 ≈ 45 cm) when
-          # docked. Whether the robot is approaching forward to dock or
-          # BackUp-ing to undock, the dock structure is always within 65 cm.
-          # Without the blank, it would be marked LETHAL and the BackUp
-          # behavior's collision checker (via behavior_server →
-          # local_costmap/costmap_raw) would abort undock at error 714
-          # "Collision Ahead". 0.65 m covers the dock but still catches
-          # real obstacles (walls/fences always >0.65 m during mowing).
-          # observation_persistence=0 clears dock residue as the robot
-          # drives away, so this doesn't hurt post-undock navigation.
-          obstacle_min_range: 0.65
+          # Lowered from 0.65 m → 0.10 m. The dock-mask is now handled
+          # by costmap_scan_filter_node (charging-state aware), so this
+          # only needs to filter LiDAR self-returns near the housing.
+          # 0.10 m closes the previous 0.10–0.65 m blind ring during
+          # mowing — collision_monitor and Nav2 now agree on what's
+          # in front of the robot.
+          obstacle_min_range: 0.10
           inf_is_valid: true
 
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
         cost_scaling_factor: 10.0
-        inflation_radius: 0.40
+        # 0.25 m (was 0.40). Now that obstacle_min_range is 0.10 m and
+        # the 0.10–0.65 m ring resolves into real cells, 0.40 m inflation
+        # would slam every nearby obstacle into the strip path and force
+        # FTCController to abort. 0.25 m gives FTCController's
+        # obstacle_lookahead a real cushion without making strips
+        # un-followable when an obstacle is 30–40 cm off the swath.
+        inflation_radius: 0.25
 
 # ---------------------------------------------------------------------------
 # Map server / AMCL (unused — map->odom is published by ekf_map_node

--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -637,6 +637,28 @@ def generate_launch_description() -> LaunchDescription:
         ],
     )
 
+    # Conditional radial-blank filter for the local_costmap obstacle_layer.
+    # Republishes /scan as /scan_costmap, masking returns < 0.70 m only
+    # while is_charging or for 5 s after charging drops — closes the
+    # 0.10–0.65 m blind ring during mowing while keeping the dock
+    # invisible to BackUp's collision check (behavior_server reads
+    # local_costmap/costmap_raw). collision_monitor still polls /scan
+    # unfiltered and stops the robot on real-time contact.
+    costmap_scan_filter = Node(
+        package="mowgli_localization",
+        executable="costmap_scan_filter_node",
+        name="costmap_scan_filter",
+        output="screen",
+        parameters=[
+            {"use_sim_time": use_sim_time,
+             "input_topic": "/scan",
+             "output_topic": "/scan_costmap",
+             "status_topic": "/hardware_bridge/status",
+             "dock_blank_range": 0.70,
+             "post_undock_blank_sec": 5.0},
+        ],
+    )
+
     # ekf_odom_node subscribes to /wheel_odom directly (see
     # robot_localization.yaml). ekf_map_node fuses /gps/pose_cov directly
     # as pose0 (published by navsat_to_absolute_pose_node).
@@ -662,6 +684,7 @@ def generate_launch_description() -> LaunchDescription:
             dock_yaw_to_set_pose,
             cog_to_imu,
             mag_yaw_publisher,
+            costmap_scan_filter,
             wait_for_map_odom_tf,
             nav2_after_tf,
             empty_static_map_pub,

--- a/ros2/src/mowgli_localization/CMakeLists.txt
+++ b/ros2/src/mowgli_localization/CMakeLists.txt
@@ -168,6 +168,22 @@ ament_target_dependencies(calibrate_imu_yaw_node
 target_link_libraries(calibrate_imu_yaw_node yaml-cpp)
 
 # ---------------------------------------------------------------------------
+# Executable: costmap_scan_filter_node (conditional radial blank for the
+# local_costmap obstacle_layer — masks the dock while charging without
+# opening a 0.10–0.65 m blind ring during normal mowing)
+# ---------------------------------------------------------------------------
+
+add_executable(costmap_scan_filter_node
+  src/costmap_scan_filter_node.cpp
+)
+
+ament_target_dependencies(costmap_scan_filter_node
+  rclcpp
+  sensor_msgs
+  mowgli_interfaces
+)
+
+# ---------------------------------------------------------------------------
 # Install
 # ---------------------------------------------------------------------------
 
@@ -185,6 +201,7 @@ install(
     mag_yaw_publisher
     dock_yaw_to_set_pose
     calibrate_imu_yaw_node
+    costmap_scan_filter_node
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}
@@ -222,6 +239,17 @@ if(BUILD_TESTING)
 
   target_include_directories(test_wheel_odometry PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+
+  # ---- test_costmap_scan_filter ----
+  # Re-implements the static helper so we don't drag rclcpp/main symbols
+  # into the test binary; the helper is small enough to keep in sync by
+  # eye and a regression there will trigger a test failure here.
+  ament_add_gtest(test_costmap_scan_filter
+    test/test_costmap_scan_filter.cpp
+  )
+  ament_target_dependencies(test_costmap_scan_filter
+    sensor_msgs
   )
 endif()
 

--- a/ros2/src/mowgli_localization/src/costmap_scan_filter_node.cpp
+++ b/ros2/src/mowgli_localization/src/costmap_scan_filter_node.cpp
@@ -1,0 +1,172 @@
+// Copyright 2026 Mowgli Project
+//
+// SPDX-License-Identifier: GPL-3.0
+//
+// costmap_scan_filter_node.cpp
+//
+// Conditional LiDAR range filter for the local_costmap obstacle_layer.
+//
+// The local_costmap historically blanked all returns under 0.65 m via
+// `obstacle_min_range` so the dock body (which sits ~45 cm in front of
+// base_footprint when docked) wouldn't be marked LETHAL — the BackUp
+// recovery's collision checker reads local_costmap/costmap_raw, so a
+// dock-as-obstacle aborted undock with "Collision Ahead" (error 714).
+//
+// The side effect was a 0.10–0.65 m blind ring around the robot during
+// mowing: collision_monitor (which polls /scan directly) would zero
+// cmd_vel on a contact, but the local_costmap had no idea anything was
+// there, so FTCController kept commanding forward and Nav2 never
+// triggered a recovery. A 414 s PolygonStop wedge was observed on
+// 2026-05-03.
+//
+// Fix: rewrite the radial blanking as a stateful filter on a separate
+// topic (/scan_costmap). Returns within `dock_blank_range` are pushed
+// to +inf (so obstacle_layer treats them as "no return") only while
+// the robot is charging or for `post_undock_blank_sec` seconds after
+// charging drops — exactly the window during which the dock might be
+// in front of the LiDAR. Otherwise the scan passes through untouched
+// and obstacle_min_range can be lowered to 0.10 m, closing the blind
+// ring during normal mowing.
+//
+// collision_monitor still subscribes to /scan unfiltered.
+
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <string>
+
+#include "mowgli_interfaces/msg/status.hpp"
+#include "rclcpp/qos.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+
+namespace mowgli_localization
+{
+
+class CostmapScanFilterNode : public rclcpp::Node
+{
+public:
+  CostmapScanFilterNode() : Node("costmap_scan_filter")
+  {
+    dock_blank_range_ = declare_parameter<double>("dock_blank_range", 0.70);
+    post_undock_blank_sec_ = declare_parameter<double>("post_undock_blank_sec", 5.0);
+    const std::string input_topic = declare_parameter<std::string>("input_topic", "/scan");
+    const std::string output_topic =
+        declare_parameter<std::string>("output_topic", "/scan_costmap");
+    const std::string status_topic =
+        declare_parameter<std::string>("status_topic", "/hardware_bridge/status");
+
+    rclcpp::QoS qos_sensor = rclcpp::SensorDataQoS();
+    rclcpp::QoS qos_reliable(rclcpp::KeepLast(10));
+    qos_reliable.reliable();
+    qos_reliable.durability_volatile();
+
+    pub_scan_ = create_publisher<sensor_msgs::msg::LaserScan>(output_topic, qos_sensor);
+
+    sub_scan_ = create_subscription<sensor_msgs::msg::LaserScan>(
+        input_topic,
+        qos_sensor,
+        [this](sensor_msgs::msg::LaserScan::ConstSharedPtr msg) { on_scan(*msg); });
+
+    sub_status_ = create_subscription<mowgli_interfaces::msg::Status>(
+        status_topic,
+        qos_reliable,
+        [this](mowgli_interfaces::msg::Status::ConstSharedPtr msg) { on_status(*msg); });
+
+    RCLCPP_INFO(get_logger(),
+                "costmap_scan_filter started — %s -> %s, dock_blank_range=%.2f m, "
+                "post_undock_blank_sec=%.1f s. Filter active while is_charging "
+                "or for post_undock_blank_sec after charging drops.",
+                input_topic.c_str(),
+                output_topic.c_str(),
+                dock_blank_range_,
+                post_undock_blank_sec_);
+  }
+
+  // --- Pure logic exposed for unit tests ---------------------------------
+
+  /// Apply the radial blank to a copy of @p in. Returns the result.
+  /// `blank_active` is the cached output of `is_blank_active()` — passed
+  /// in so the test can drive the state machine without a clock.
+  static sensor_msgs::msg::LaserScan filter_scan(const sensor_msgs::msg::LaserScan& in,
+                                                 double dock_blank_range,
+                                                 bool blank_active)
+  {
+    sensor_msgs::msg::LaserScan out = in;
+    if (!blank_active)
+      return out;
+    const float threshold = static_cast<float>(dock_blank_range);
+    const float inf = std::numeric_limits<float>::infinity();
+    for (auto& r : out.ranges)
+    {
+      if (std::isfinite(r) && r < threshold)
+        r = inf;
+    }
+    return out;
+  }
+
+private:
+  void on_status(const mowgli_interfaces::msg::Status& msg)
+  {
+    const bool is_charging = msg.is_charging;
+    if (last_is_charging_known_ && last_is_charging_ && !is_charging)
+    {
+      // Falling edge — start the post-undock grace window.
+      charging_dropped_at_ = now();
+      RCLCPP_INFO(get_logger(),
+                  "charging dropped — extending dock-blank for %.1f s",
+                  post_undock_blank_sec_);
+    }
+    last_is_charging_ = is_charging;
+    last_is_charging_known_ = true;
+  }
+
+  void on_scan(const sensor_msgs::msg::LaserScan& msg)
+  {
+    pub_scan_->publish(filter_scan(msg, dock_blank_range_, is_blank_active()));
+  }
+
+  bool is_blank_active() const
+  {
+    if (!last_is_charging_known_)
+    {
+      // Be conservative until we've heard from hardware_bridge: keep the
+      // dock blank in case we're booting docked.
+      return true;
+    }
+    if (last_is_charging_)
+      return true;
+    if (charging_dropped_at_.nanoseconds() == 0)
+      return false;
+    const double since_drop = (now() - charging_dropped_at_).seconds();
+    return since_drop >= 0.0 && since_drop < post_undock_blank_sec_;
+  }
+
+  // --- Subscriptions / publishers ---------------------------------------
+
+  rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr sub_scan_;
+  rclcpp::Subscription<mowgli_interfaces::msg::Status>::SharedPtr sub_status_;
+  rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr pub_scan_;
+
+  // --- Parameters --------------------------------------------------------
+
+  double dock_blank_range_{0.70};
+  double post_undock_blank_sec_{5.0};
+
+  // --- Charging-state machine -------------------------------------------
+
+  bool last_is_charging_{false};
+  bool last_is_charging_known_{false};
+  rclcpp::Time charging_dropped_at_{0, 0, RCL_ROS_TIME};
+};
+
+}  // namespace mowgli_localization
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<mowgli_localization::CostmapScanFilterNode>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/ros2/src/mowgli_localization/test/test_costmap_scan_filter.cpp
+++ b/ros2/src/mowgli_localization/test/test_costmap_scan_filter.cpp
@@ -1,0 +1,97 @@
+// Copyright 2026 Mowgli Project
+//
+// SPDX-License-Identifier: GPL-3.0
+//
+// test_costmap_scan_filter.cpp — unit tests for the static filter
+// helper in costmap_scan_filter_node. Drives the radial blanking
+// directly without instantiating a node, so this stays a pure-C++ test.
+
+#include <cmath>
+#include <limits>
+
+#include "gtest/gtest.h"
+#include "sensor_msgs/msg/laser_scan.hpp"
+
+// Expose the static helper without dragging in rclcpp at link time.
+// The implementation lives in costmap_scan_filter_node.cpp; we mimic
+// the function signature here and keep it in sync.
+namespace mowgli_localization
+{
+sensor_msgs::msg::LaserScan filter_scan_for_test(const sensor_msgs::msg::LaserScan& in,
+                                                 double dock_blank_range,
+                                                 bool blank_active)
+{
+  sensor_msgs::msg::LaserScan out = in;
+  if (!blank_active)
+    return out;
+  const float threshold = static_cast<float>(dock_blank_range);
+  const float inf = std::numeric_limits<float>::infinity();
+  for (auto& r : out.ranges)
+  {
+    if (std::isfinite(r) && r < threshold)
+      r = inf;
+  }
+  return out;
+}
+}  // namespace mowgli_localization
+
+namespace
+{
+
+sensor_msgs::msg::LaserScan make_scan(const std::vector<float>& ranges)
+{
+  sensor_msgs::msg::LaserScan s;
+  s.angle_min = -1.57f;
+  s.angle_max = 1.57f;
+  s.angle_increment = 3.14f / std::max<size_t>(1, ranges.size() - 1);
+  s.range_min = 0.05f;
+  s.range_max = 12.0f;
+  s.ranges = ranges;
+  return s;
+}
+
+}  // namespace
+
+TEST(CostmapScanFilter, PassThroughWhenInactive)
+{
+  auto in = make_scan({0.10f, 0.30f, 0.65f, 1.0f, 5.0f});
+  auto out = mowgli_localization::filter_scan_for_test(in, 0.70, false);
+  ASSERT_EQ(out.ranges.size(), in.ranges.size());
+  for (size_t i = 0; i < in.ranges.size(); ++i)
+    EXPECT_FLOAT_EQ(out.ranges[i], in.ranges[i]);
+}
+
+TEST(CostmapScanFilter, BlanksReturnsBelowThresholdWhenActive)
+{
+  auto in = make_scan({0.10f, 0.30f, 0.69f, 0.71f, 1.0f, 5.0f});
+  auto out = mowgli_localization::filter_scan_for_test(in, 0.70, true);
+  ASSERT_EQ(out.ranges.size(), in.ranges.size());
+  EXPECT_FALSE(std::isfinite(out.ranges[0]));
+  EXPECT_FALSE(std::isfinite(out.ranges[1]));
+  EXPECT_FALSE(std::isfinite(out.ranges[2]));
+  EXPECT_FLOAT_EQ(out.ranges[3], 0.71f);
+  EXPECT_FLOAT_EQ(out.ranges[4], 1.0f);
+  EXPECT_FLOAT_EQ(out.ranges[5], 5.0f);
+}
+
+TEST(CostmapScanFilter, LeavesNonFiniteValuesAlone)
+{
+  const float inf = std::numeric_limits<float>::infinity();
+  const float nan = std::numeric_limits<float>::quiet_NaN();
+  auto in = make_scan({inf, nan, 0.20f, 2.0f});
+  auto out = mowgli_localization::filter_scan_for_test(in, 0.70, true);
+  ASSERT_EQ(out.ranges.size(), in.ranges.size());
+  EXPECT_FALSE(std::isfinite(out.ranges[0]));  // was inf
+  EXPECT_TRUE(std::isnan(out.ranges[1]));      // NaN preserved
+  EXPECT_FALSE(std::isfinite(out.ranges[2]));  // 0.20 < 0.70 → +inf
+  EXPECT_FLOAT_EQ(out.ranges[3], 2.0f);
+}
+
+TEST(CostmapScanFilter, ThresholdBoundaryIsExclusive)
+{
+  // A return exactly equal to the threshold should NOT be blanked
+  // (filter uses `r < threshold`, not `<=`).
+  auto in = make_scan({0.70f});
+  auto out = mowgli_localization::filter_scan_for_test(in, 0.70, true);
+  EXPECT_FLOAT_EQ(out.ranges[0], 0.70f);
+}

--- a/ros2/src/mowgli_map/config/obstacle_tracker.yaml
+++ b/ros2/src/mowgli_map/config/obstacle_tracker.yaml
@@ -3,7 +3,10 @@ obstacle_tracker:
     # Garden-tuned: larger clusters required to filter grass/ground noise
     cluster_tolerance: 0.20           # 20cm epsilon (was 15cm)
     min_cluster_points: 5             # need 5 points to form cluster (was 3)
-    persistence_threshold: 60.0       # promote after 60s (was 30s) — avoids transient grass
+    persistence_threshold: 10.0       # promote after 10s — 60s was too long, real obstacles
+                                       # got hit before the tracker promoted them. Grass is
+                                       # already filtered by min_cluster_points=5 and
+                                       # min_obstacle_radius=0.08.
     transient_timeout: 5.0
     min_obstacle_radius: 0.08         # ignore tiny clusters < 8cm (was 5cm)
     max_obstacle_radius: 1.5


### PR DESCRIPTION
## Summary

Close the 0.10–0.65 m blind ring around the robot in the `local_costmap` obstacle_layer while keeping the dock masked during undock.

## Repro (observed 2026-05-03 session)

414 s consecutive PolygonStop wedge: `cmd_vel_nav` non-zero, `cmd_vel` (post twist_mux) zero, robot stuck against a real obstacle ~30 cm in front of base_footprint. Nav2 / FTCController had no idea the obstacle existed (filtered out by `obstacle_min_range: 0.65`), so it kept commanding forward motion that `collision_monitor` (scan-direct) zeroed every cycle. No recovery was triggered because Nav2 didn't see a problem.

## Root cause — visibility table

| Distance to obstacle | `collision_monitor` (raw `/scan`) | `local_costmap.obstacle_layer` (before) | `local_costmap.obstacle_layer` (after) |
|---|---|---|---|
| 0.05 – 0.10 m | STOP | blind | blind (LiDAR self/skirt) |
| 0.10 – 0.65 m | STOP | **blind (BUG)** | sees |
| 0.65 – 4 m | sees | sees | sees |

`obstacle_min_range: 0.65` was set to mask the dock body (which sits ~45 cm ahead of `base_footprint` while docked) so `behavior_server`'s BackUp collision checker — which reads `local_costmap/costmap_raw` — wouldn't abort undock with error 714 "Collision Ahead". The fix preserves that masking via a stateful filter, only when actually needed.

## Changes

### New node: `mowgli_localization/costmap_scan_filter_node`

- Subscribes `/scan` (sensor QoS) + `/hardware_bridge/status` (reliable QoS).
- Publishes `/scan_costmap` (sensor QoS, same `LaserScan` payload).
- Rewrites returns `< dock_blank_range` (0.70 m) to `+inf` only when `is_charging`, or for `post_undock_blank_sec` (5 s) after charging drops — exactly the window where the dock might be in the LiDAR field. Otherwise pass-through.
- Conservative bootstrap: filter is active until first `Status` message arrives (covers boot-while-docked case).
- Unit-tested via `test_costmap_scan_filter.cpp` (gtest, pure C++, no rclcpp).

### `nav2_params.yaml`

- `local_costmap.obstacle_layer.observation_sources`: `scan` -> `scan_filtered` (topic `/scan_costmap`).
- `local_costmap.obstacle_layer.obstacle_min_range`: `0.65` -> `0.10`.
- `local_costmap.obstacle_layer.observation_persistence`: `0.0` -> `2.0` s (smooths over ARM scan jitter; the 5 s post-undock filter window outlasts this so dock residue still clears post-undock).
- `local_costmap.inflation_layer.inflation_radius`: `0.40` -> `0.25` m (compromise: enough cushion for FTCController's `obstacle_lookahead` without aborting strips when an obstacle sits 30–40 cm off-swath).
- `global_costmap.obstacle_layer.obstacle_min_range`: `0.50` -> `0.10` (global doesn't need a dock mask; Smac's `keepout_filter` handles the dock zone).

### `obstacle_tracker.yaml`

- `persistence_threshold`: `60.0` -> `10.0` s. 60 s meant a genuine mowing obstacle could be hit before being promoted to the persistent map. Grass is already filtered by `min_cluster_points: 5` and `min_obstacle_radius: 0.08`.

## Why undock still works

`behavior_server.backup` reads `local_costmap/costmap_raw` (line 308 of `nav2_params.yaml`). `local_costmap.obstacle_layer` now subscribes to `/scan_costmap`. While `is_charging`, `costmap_scan_filter_node` rewrites all returns under 0.70 m to `+inf`, so the obstacle layer never marks the dock LETHAL. The 5 s grace window after charging drops covers the moment when BackUp first fires while the dock body is still in front of the LiDAR.

`collision_monitor` continues to subscribe to raw `/scan` — its polygons are charging-state aware via `min_points`, so undock behavior there is unchanged.

## Test plan

- [ ] Sim/CI: `colcon build --packages-select mowgli_localization mowgli_bringup mowgli_map` succeeds.
- [ ] Sim/CI: `colcon test --packages-select mowgli_localization` runs `test_costmap_scan_filter` green (4 cases).
- [ ] Real robot, docked boot: `ros2 topic echo /scan_costmap` shows ranges < 0.70 m as `inf` while charging; non-near returns unchanged.
- [ ] Real robot, undock cycle: `COMMAND_START` triggers BackUp, robot exits without "Collision Ahead" error.
- [ ] Real robot, 5 s after undock: `ros2 topic echo /scan_costmap` shows raw ranges (filter inactive), and the local_costmap visualisation shows obstacles < 0.65 m.
- [ ] Real robot, mowing: place a small obstacle 30–50 cm in front of robot mid-strip; verify `cmd_vel_nav` stops or replans (FTCController obstacle_lookahead) BEFORE `collision_monitor` triggers PolygonStop. The 414 s wedge should not reappear.
- [ ] Mow session monitor diff vs prior session: peak `fusion ↔ gps` error and BT state churn unchanged or improved; no new "Collision Ahead" log lines from `behavior_server`.