### PR TITLE
fix(fusion_graph): suppress gyro-bias yaw drift when wheel shows stationary

### DIFF
--- a/ros2/src/fusion_graph/CMakeLists.txt
+++ b/ros2/src/fusion_graph/CMakeLists.txt
@@ -141,6 +141,11 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_persistence fusion_graph_core)
 
+  ament_add_gtest(test_stationary_yaw
+    test/test_stationary_yaw.cpp
+  )
+  target_link_libraries(test_stationary_yaw fusion_graph_core)
+
   # Performance benchmarks. Long-running (~30 s on ARM); only meaningful
   # in Release builds. Output is grep-friendly for tracking regressions.
   ament_add_gtest(test_perf

--- a/ros2/src/fusion_graph/config/fusion_graph.yaml
+++ b/ros2/src/fusion_graph/config/fusion_graph.yaml
@@ -24,6 +24,18 @@ fusion_graph_node:
     # encoders see ~5-10 cm of slip per turn).
     gyro_sigma_theta: 0.005     # rad per node
 
+    # Stationary-yaw drift suppressor (added 2026-05-03 — on-robot
+    # measurement showed +0.43°/min map-frame yaw drift while parked
+    # vs -0.03°/min for the EKF that correctly weights wheel.wz over
+    # IMU.wz). When wheel says no motion AND the per-tick gyro delta
+    # is below the per-tick noise floor, the BetweenFactor uses
+    # dtheta=0 with stationary_sigma_theta. Above either threshold,
+    # the standard wheel/gyro path is used and the behaviour matches
+    # the pre-fix code.
+    stationary_thresh_xy_m: 0.001
+    stationary_thresh_theta: 0.002
+    stationary_sigma_theta: 0.001
+
     # ── GPS unary noise floor ──────────────────────────────────────────
     # Below this sigma, NavSatFix.covariance is treated as unrealistic
     # and clamped. RTK-Fixed reports σ ~3 mm; below that is numerical

--- a/ros2/src/fusion_graph/include/fusion_graph/graph_manager.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/graph_manager.hpp
@@ -97,6 +97,19 @@ struct GraphParams
   double stationary_motion_thresh_m = 0.02;  // m
   double stationary_motion_thresh_theta = 0.01;  // rad (~0.6°)
   double stationary_node_period_s = 5.0;  // 1 node / 5 s when still
+
+  // Stationary detection (per-node accumulator thresholds). When the wheel
+  // encoder reports motion strictly under both thresholds AND the gyro
+  // integrator has not seen a meaningful yaw change, the BetweenFactor
+  // uses dtheta=0 with stationary_sigma_theta so the gyro bias residual
+  // (~0.01°/s after hardware_bridge calibration) doesn't accumulate into
+  // a measurable yaw drift while parked. Set stationary_thresh_xy_m to a
+  // value smaller than encoder noise per tick, and stationary_thresh_theta
+  // just above the gyro per-tick noise floor; defaults match the LD06 +
+  // the OpenMower encoders on this robot.
+  double stationary_thresh_xy_m = 1.0e-3;  // 1 mm per node tick
+  double stationary_thresh_theta = 2.0e-3;  // 0.11° per node tick (gyro noise floor)
+  double stationary_sigma_theta = 1.0e-3;  // ≈ 0.057° BetweenFactor sigma when stationary
 };
 
 // What goes out to the publisher every tick.

--- a/ros2/src/fusion_graph/src/fusion_graph_node.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node.cpp
@@ -65,6 +65,12 @@ FusionGraphNode::FusionGraphNode(const rclcpp::NodeOptions& opts)
   gp.stationary_motion_thresh_theta =
       declare_parameter<double>("stationary_motion_thresh_theta", 0.01);
   gp.stationary_node_period_s = declare_parameter<double>("stationary_node_period_s", 5.0);
+  gp.stationary_thresh_xy_m =
+      declare_parameter<double>("stationary_thresh_xy_m", 1.0e-3);
+  gp.stationary_thresh_theta =
+      declare_parameter<double>("stationary_thresh_theta", 2.0e-3);
+  gp.stationary_sigma_theta =
+      declare_parameter<double>("stationary_sigma_theta", 1.0e-3);
 
   datum_lat_ = declare_parameter<double>("datum_lat", 0.0);
   datum_lon_ = declare_parameter<double>("datum_lon", 0.0);

--- a/ros2/src/fusion_graph/src/graph_manager.cpp
+++ b/ros2/src/fusion_graph/src/graph_manager.cpp
@@ -230,10 +230,42 @@ TickOutput GraphManager::CreateNodeLocked(double now_s)
   }
 
   // 1. Build the wheel between-factor: relative pose from X_{k-1} to X_k.
-  //    Pose2(dx, dy, dtheta_gyro) — gyro for yaw, wheel for translation.
-  //    If gyro accumulator is zero (no IMU received) fall back to wheel.
-  const double dtheta =
-      std::abs(accum_.dtheta_gyro) > 1e-9 ? accum_.dtheta_gyro : accum_.dtheta_wheel;
+  //    Yaw selection rules:
+  //    a. If the wheel encoder shows the robot stationary AND the gyro
+  //       integrator hasn't seen a meaningful yaw change either, snap
+  //       dtheta to 0 with a tight sigma. This suppresses the residual
+  //       gyro bias (~0.01°/s mean post-hardware_bridge calibration)
+  //       that otherwise accumulates ~0.4°/min of map-frame yaw drift
+  //       while parked at the dock — measured 2026-05-03.
+  //    b. Otherwise, prefer gyro: at speed the differential-drive yaw
+  //       estimate is dominated by encoder slip and the gyro is strictly
+  //       better. The wheel sigma_theta path only fires when no gyro
+  //       sample arrived this tick (pre-cog seed window, IMU restart).
+  const bool wheel_stationary =
+      std::abs(accum_.dx) < params_.stationary_thresh_xy_m &&
+      std::abs(accum_.dy) < params_.stationary_thresh_xy_m &&
+      std::abs(accum_.dtheta_wheel) < params_.stationary_thresh_theta;
+  const bool gyro_stationary =
+      std::abs(accum_.dtheta_gyro) < params_.stationary_thresh_theta;
+
+  double dtheta;
+  double sigma_theta;
+  if (wheel_stationary && gyro_stationary)
+  {
+    dtheta = 0.0;
+    sigma_theta = params_.stationary_sigma_theta;
+  }
+  else if (std::abs(accum_.dtheta_gyro) > 1e-9)
+  {
+    dtheta = accum_.dtheta_gyro;
+    sigma_theta = params_.gyro_sigma_theta;
+  }
+  else
+  {
+    dtheta = accum_.dtheta_wheel;
+    sigma_theta = params_.wheel_sigma_theta;
+  }
+
   const gtsam::Pose2 between(accum_.dx, accum_.dy, dtheta);
 
   const auto k_prev = PoseKey(next_index_ - 1);
@@ -254,9 +286,9 @@ TickOutput GraphManager::CreateNodeLocked(double now_s)
   new_values_.insert(k_curr, X_pred);
 
   // 2. Wheel between-factor.
-  // Use gyro_sigma_theta when gyro contributed, wheel sigma otherwise.
-  const double sigma_theta =
-      std::abs(accum_.dtheta_gyro) > 1e-9 ? params_.gyro_sigma_theta : params_.wheel_sigma_theta;
+  // sigma_theta was already selected above with the same wheel/gyro/
+  // stationary logic that drove dtheta — reuse it here so both halves
+  // of the BetweenFactor stay consistent.
   auto between_noise = MakeDiagonal({
       params_.wheel_sigma_x,
       params_.wheel_sigma_y,

--- a/ros2/src/fusion_graph/test/test_stationary_yaw.cpp
+++ b/ros2/src/fusion_graph/test/test_stationary_yaw.cpp
@@ -1,0 +1,140 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Regression tests for the stationary-yaw drift suppressor in
+// GraphManager::CreateNodeLocked. Motivating failure (measured on the
+// robot 2026-05-03 with the dock charging, RPM=0, encoders idle):
+//
+//   ekf_odom_node (odom-frame)   yaw drift = -0.033°/min   (correct)
+//   fusion_graph_node (map-frame) yaw drift = +0.43°/min    (~13× worse)
+//
+// The map-frame factor graph was selecting the wheel/gyro yaw delta
+// with a single ternary on |dtheta_gyro| > 1e-9. The residual gyro
+// bias (~0.011°/s mean post-hardware_bridge calibration) integrates
+// to ~0.0011° per node tick and always trips that gate, so every
+// BetweenFactor got the gyro delta even when the wheel encoder
+// unambiguously reported "no motion". iSAM2 then propagated the small
+// biased delta across nodes, giving the observed drift.
+//
+// These tests pin the post-fix behaviour:
+//   1. With encoders idle and a realistic gyro-bias drift the graph
+//      yaw must stay within ~0.05° over a 60 s parked window (pre-fix
+//      ≈ 0.66°).
+//   2. With matching wheel + gyro rotation the graph still tracks the
+//      input rotation (the stationary path only kicks in when both
+//      sources agree the robot is at rest).
+
+#include <cmath>
+#include <cstdio>
+
+#include "fusion_graph/graph_manager.hpp"
+#include <gtest/gtest.h>
+
+namespace fg = fusion_graph;
+
+namespace
+{
+
+// Reasonable-but-not-tightest defaults. Mirrors the YAML so test
+// failures bisect to graph_manager.cpp logic, not param differences.
+fg::GraphParams MakeParams()
+{
+  fg::GraphParams gp;
+  gp.node_period_s = 0.1;
+  gp.wheel_sigma_x = 0.05;
+  gp.wheel_sigma_y = 0.005;
+  gp.wheel_sigma_theta = 0.01;
+  gp.gyro_sigma_theta = 0.005;
+  gp.stationary_thresh_xy_m = 1.0e-3;
+  gp.stationary_thresh_theta = 2.0e-3;
+  gp.stationary_sigma_theta = 1.0e-3;
+  // Bypass the node-creation throttle so every Tick produces a node —
+  // this is a yaw-drift test, not a cadence test.
+  gp.stationary_node_period_s = 0.0;
+  gp.stationary_motion_thresh_m = 0.0;
+  gp.stationary_motion_thresh_theta = 0.0;
+  return gp;
+}
+
+}  // namespace
+
+// ─────────────────────────────────────────────────────────────────────
+// 60 s of stationary operation with a 0.011°/s residual gyro bias
+// (a typical post-calibration value from hardware_bridge_node). The
+// pre-fix code drifted ~0.66°; the suppressor must hold yaw to within
+// 0.05°.
+// ─────────────────────────────────────────────────────────────────────
+TEST(StationaryYaw, GyroBiasDoesNotDriftMapYaw)
+{
+  fg::GraphManager gm(MakeParams());
+  // Initialize at a non-zero pose so the test isn't accidentally
+  // hitting any "near-origin" early-exit path in iSAM2 / Pose2.
+  const gtsam::Pose2 X0(1.0, 2.0, 0.5);
+  gm.Initialize(X0, 0.0);
+
+  // 600 ticks × 0.1 s = 60 s. 0.011°/s ≈ 0.0001920 rad/s gyro bias.
+  constexpr int kTicks = 600;
+  constexpr double kDt = 0.1;
+  constexpr double kGyroBias = 0.0001920;  // rad/s, ~0.011°/s
+
+  for (int i = 0; i < kTicks; ++i)
+  {
+    // Encoders flat — robot is parked.
+    gm.AddWheelTwist(0.0, 0.0, 0.0, kDt);
+    // Gyro reports the residual bias.
+    gm.AddGyroDelta(kGyroBias, kDt);
+    gm.Tick(kDt * (i + 1));
+  }
+
+  auto snap = gm.LatestSnapshot();
+  ASSERT_TRUE(snap.has_value());
+  const double yaw_drift_rad = std::abs(snap->pose.theta() - X0.theta());
+  const double yaw_drift_deg = yaw_drift_rad * 180.0 / M_PI;
+
+  std::printf("[StationaryYaw] 60 s parked, bias=%.4f °/s, drift=%.3f° (%.5f rad)\n",
+              kGyroBias * 180.0 / M_PI,
+              yaw_drift_deg,
+              yaw_drift_rad);
+
+  // Hard ceiling: 0.05° over 60 s. Pre-fix value was ~0.66° in the
+  // same setup, so this gives ~13× headroom.
+  EXPECT_LT(yaw_drift_deg, 0.05);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Real rotation must still be tracked: the suppressor is only allowed
+// to fire when BOTH the wheel encoders AND the gyro agree the robot
+// is at rest. Drive a 0.5 rad/s rotation for 6 s and verify the graph
+// yaw lands within ~10% of the expected angle.
+// ─────────────────────────────────────────────────────────────────────
+TEST(StationaryYaw, RotationStillTracked)
+{
+  fg::GraphManager gm(MakeParams());
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 0.0);
+
+  constexpr int kTicks = 60;  // 6 s @ 10 Hz
+  constexpr double kDt = 0.1;
+  constexpr double kWz = 0.5;  // rad/s
+
+  for (int i = 0; i < kTicks; ++i)
+  {
+    gm.AddWheelTwist(0.0, 0.0, kWz, kDt);
+    gm.AddGyroDelta(kWz, kDt);
+    gm.Tick(kDt * (i + 1));
+  }
+
+  auto snap = gm.LatestSnapshot();
+  ASSERT_TRUE(snap.has_value());
+  const double expected = kWz * kDt * kTicks;  // 3.0 rad
+  const double got = snap->pose.theta();
+  // Pose2 wraps to (-pi, pi]; expected 3.0 rad is inside that range.
+  std::printf("[StationaryYaw] 6 s @ %.2f rad/s: expected=%.3f rad, got=%.3f rad\n",
+              kWz,
+              expected,
+              got);
+
+  // 10 % tolerance — between-factor noise + iSAM2 relinearization can
+  // pull a few percent. The point is to catch a regression where the
+  // suppressor wrongly zeroes real motion.
+  EXPECT_NEAR(got, expected, 0.1 * expected);
+}


### PR DESCRIPTION
## Field repro (2026-05-03)

Robot stationary at the dock — `charging=true`, RPM=0, wheel encoder ticks at 0. Measured over a 25 s window:

| Localizer                                  | yaw drift     | verdict |
|--------------------------------------------|---------------|---------|
| `ekf_odom_node` (odom-frame, EKF wheel+gyro) | -0.033°/min  | correct |
| `fusion_graph_node` (map-frame, primary)     | **+0.43°/min** | ~13× worse |

## Why the EKF is fine but the factor graph wasn't

The Kalman update in `ekf_odom_node` weights `wheel.wz` (σ=0.057°/s, declared by `hardware_bridge` on `/wheel_odom`) against `imu.wz` (σ=5.73°/s, declared by the IMU). Wheel evidence wins ~10000×, so the fused `wz` collapses to ≈ 0 at rest and yaw doesn't drift.

`GraphManager::CreateNodeLocked` was choosing the per-node yaw delta with a single ternary:

```cpp
const double dtheta =
    std::abs(accum_.dtheta_gyro) > 1e-9 ? accum_.dtheta_gyro : accum_.dtheta_wheel;
```

After `hardware_bridge` finishes its 20 s calibration the residual gyro bias is ~0.011°/s. Per node (`node_period_s = 0.1`) that integrates to ~0.0011° — always above the 1e-9 gate, so every `BetweenFactor` got the biased gyro delta. The wheel encoder's tight stationary evidence was discarded for yaw. iSAM2 then propagated the small biased delta across ~600 nodes/min → ~0.4°/min, matching the field number.

## Fix

Detect stationary from BOTH accumulators. When `|dx|, |dy|, |dtheta_wheel|` are all under per-tick thresholds AND `|dtheta_gyro|` is under the per-tick noise floor, the BetweenFactor uses `dtheta = 0.0` with a tight `stationary_sigma_theta`. Otherwise the original wheel/gyro selection runs unchanged.

Three new params (defaults sized for LD06 + OpenMower encoders on this robot):

| param                    | default | rationale |
|--------------------------|---------|-----------|
| `stationary_thresh_xy_m`   | 1.0e-3 (1 mm)  | smaller than per-tick encoder noise |
| `stationary_thresh_theta`  | 2.0e-3 rad (~0.11°) | just above gyro per-tick noise floor (bias × dt) |
| `stationary_sigma_theta`   | 1.0e-3 rad (~0.057°) | matches encoder σ_wz × dt — tight enough to dominate the chain at rest |

Above either threshold the wheel/gyro path is restored verbatim, so the only behavioural change is at rest.

## Files

- `ros2/src/fusion_graph/include/fusion_graph/graph_manager.hpp` — three new `GraphParams` fields
- `ros2/src/fusion_graph/src/graph_manager.cpp` — `CreateNodeLocked` yaw selection refactor
- `ros2/src/fusion_graph/src/fusion_graph_node.cpp` — `declare_parameter` for the three new fields
- `ros2/src/fusion_graph/config/fusion_graph.yaml` — defaults + comment block
- `ros2/src/fusion_graph/test/test_stationary_yaw.cpp` — new gtest
- `ros2/src/fusion_graph/CMakeLists.txt` — wire the test

## Test plan

- [x] New `test_stationary_yaw.GyroBiasDoesNotDriftMapYaw`: 60 s parked + 0.011°/s gyro bias → final yaw drift < 0.05° (pre-fix observed ~0.66°).
- [x] New `test_stationary_yaw.RotationStillTracked`: 6 s of `wz=0.5 rad/s` on both wheel and gyro → final yaw within 10% of expected 3.0 rad. Guards against the suppressor swallowing real motion.
- [ ] CI: existing `test_factors`, `test_persistence`, `test_perf` must still pass — the active-motion path is byte-identical.
- [ ] On-robot, post-merge: park at dock for 60 s, confirm `/odometry/filtered_map` yaw drift drops from ~0.4°/min to <0.05°/min (matches `ekf_odom_node`).
- [ ] On-robot, post-merge: drive a short transit + a coverage cell, confirm no regression in heading control vs the pre-fix dev branch.