### PR TITLE
fix(fusion_graph): trust wheel encoder alone for stationary yaw

### DIFF
--- a/ros2/src/fusion_graph/config/fusion_graph.yaml
+++ b/ros2/src/fusion_graph/config/fusion_graph.yaml
@@ -24,14 +24,16 @@ fusion_graph_node:
     # encoders see ~5-10 cm of slip per turn).
     gyro_sigma_theta: 0.005     # rad per node
 
-    # Stationary-yaw drift suppressor (added 2026-05-03 — on-robot
-    # measurement showed +0.43°/min map-frame yaw drift while parked
-    # vs -0.03°/min for the EKF that correctly weights wheel.wz over
-    # IMU.wz). When wheel says no motion AND the per-tick gyro delta
-    # is below the per-tick noise floor, the BetweenFactor uses
-    # dtheta=0 with stationary_sigma_theta. Above either threshold,
-    # the standard wheel/gyro path is used and the behaviour matches
-    # the pre-fix code.
+    # Stationary-yaw drift suppressor (added 2026-05-03, iterated same
+    # day after on-robot measurement showed the AND-gated version drove
+    # yaw -4.28°/min vs +0.43°/min unsuppressed — live IMU residual wz
+    # is ~-1.32°/s, well above any sensible gyro stationary threshold,
+    # so the AND was always false). The gate is now wheel-only: when
+    # the per-tick wheel accumulator (|dx|, |dy|, |dtheta_wheel|) is
+    # under these thresholds, the BetweenFactor uses dtheta=0 with
+    # stationary_sigma_theta regardless of gyro noise. Encoders cannot
+    # slip into stationary, so a zero wheel reading is treated as
+    # ground truth.
     stationary_thresh_xy_m: 0.001
     stationary_thresh_theta: 0.002
     stationary_sigma_theta: 0.001

--- a/ros2/src/fusion_graph/include/fusion_graph/graph_manager.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/graph_manager.hpp
@@ -98,17 +98,20 @@ struct GraphParams
   double stationary_motion_thresh_theta = 0.01;  // rad (~0.6°)
   double stationary_node_period_s = 5.0;  // 1 node / 5 s when still
 
-  // Stationary detection (per-node accumulator thresholds). When the wheel
-  // encoder reports motion strictly under both thresholds AND the gyro
-  // integrator has not seen a meaningful yaw change, the BetweenFactor
-  // uses dtheta=0 with stationary_sigma_theta so the gyro bias residual
-  // (~0.01°/s after hardware_bridge calibration) doesn't accumulate into
-  // a measurable yaw drift while parked. Set stationary_thresh_xy_m to a
-  // value smaller than encoder noise per tick, and stationary_thresh_theta
-  // just above the gyro per-tick noise floor; defaults match the LD06 +
-  // the OpenMower encoders on this robot.
+  // Stationary detection (per-node wheel-accumulator thresholds). When
+  // the wheel encoder reports motion strictly under all three thresholds
+  // (|dx|, |dy|, |dtheta_wheel|), the BetweenFactor uses dtheta=0 with
+  // stationary_sigma_theta — encoders cannot slip "into stationary", so
+  // a zero wheel reading is taken as ground truth and the gyro bias
+  // residual is suppressed regardless of its magnitude. (An earlier
+  // iteration also required |dtheta_gyro| under stationary_thresh_theta;
+  // on the live robot the gyro residual was ~10× the threshold, the AND
+  // never fired, and yaw drift went the wrong way. Wheel-only is the
+  // robust gate.) Set stationary_thresh_xy_m to a value smaller than
+  // encoder noise per tick, and stationary_thresh_theta just above the
+  // wheel-derived dtheta noise floor.
   double stationary_thresh_xy_m = 1.0e-3;  // 1 mm per node tick
-  double stationary_thresh_theta = 2.0e-3;  // 0.11° per node tick (gyro noise floor)
+  double stationary_thresh_theta = 2.0e-3;  // 0.11° per node tick (wheel noise floor)
   double stationary_sigma_theta = 1.0e-3;  // ≈ 0.057° BetweenFactor sigma when stationary
 };
 

--- a/ros2/src/fusion_graph/src/graph_manager.cpp
+++ b/ros2/src/fusion_graph/src/graph_manager.cpp
@@ -231,12 +231,25 @@ TickOutput GraphManager::CreateNodeLocked(double now_s)
 
   // 1. Build the wheel between-factor: relative pose from X_{k-1} to X_k.
   //    Yaw selection rules:
-  //    a. If the wheel encoder shows the robot stationary AND the gyro
-  //       integrator hasn't seen a meaningful yaw change either, snap
-  //       dtheta to 0 with a tight sigma. This suppresses the residual
-  //       gyro bias (~0.01°/s mean post-hardware_bridge calibration)
-  //       that otherwise accumulates ~0.4°/min of map-frame yaw drift
-  //       while parked at the dock — measured 2026-05-03.
+  //    a. Wheel encoder is ground truth when it reads zero. Encoders
+  //       cannot slip "into stationary" — when the per-tick wheel
+  //       accumulator shows no motion (|dx|, |dy|, |dtheta_wheel| all
+  //       under their thresholds), the robot really isn't moving under
+  //       power. Trust the wheel regardless of residual gyro
+  //       bias / noise and snap dtheta to 0 with a tight sigma. The
+  //       previous version of this block also gated on |dtheta_gyro| <
+  //       stationary_thresh_theta, which on this robot's live IMU
+  //       (residual wz ≈ -0.023 rad/s ≈ -1.32°/s after hardware_bridge
+  //       calibration, dominated by thermal drift) was always false —
+  //       the AND fell through to the gyro path and yaw drifted
+  //       -4.28°/min vs the +0.43°/min pre-suppressor baseline.
+  //
+  //       Edge case: a hand-pushed robot has wheels off the ground but
+  //       is physically rotating. We accept the trade-off — a manually
+  //       repositioned robot will lose its yaw estimate, but it is far
+  //       more common to be parked with a noisy gyro than to be hand
+  //       spun, and the next session's GPS-COG fusion + dock_yaw seed
+  //       re-anchor yaw when the robot starts moving again.
   //    b. Otherwise, prefer gyro: at speed the differential-drive yaw
   //       estimate is dominated by encoder slip and the gyro is strictly
   //       better. The wheel sigma_theta path only fires when no gyro
@@ -245,12 +258,10 @@ TickOutput GraphManager::CreateNodeLocked(double now_s)
       std::abs(accum_.dx) < params_.stationary_thresh_xy_m &&
       std::abs(accum_.dy) < params_.stationary_thresh_xy_m &&
       std::abs(accum_.dtheta_wheel) < params_.stationary_thresh_theta;
-  const bool gyro_stationary =
-      std::abs(accum_.dtheta_gyro) < params_.stationary_thresh_theta;
 
   double dtheta;
   double sigma_theta;
-  if (wheel_stationary && gyro_stationary)
+  if (wheel_stationary)
   {
     dtheta = 0.0;
     sigma_theta = params_.stationary_sigma_theta;

--- a/ros2/src/fusion_graph/test/test_stationary_yaw.cpp
+++ b/ros2/src/fusion_graph/test/test_stationary_yaw.cpp
@@ -8,21 +8,33 @@
 //   ekf_odom_node (odom-frame)   yaw drift = -0.033°/min   (correct)
 //   fusion_graph_node (map-frame) yaw drift = +0.43°/min    (~13× worse)
 //
-// The map-frame factor graph was selecting the wheel/gyro yaw delta
-// with a single ternary on |dtheta_gyro| > 1e-9. The residual gyro
-// bias (~0.011°/s mean post-hardware_bridge calibration) integrates
-// to ~0.0011° per node tick and always trips that gate, so every
-// BetweenFactor got the gyro delta even when the wheel encoder
-// unambiguously reported "no motion". iSAM2 then propagated the small
-// biased delta across nodes, giving the observed drift.
+// First iteration (PR #161) gated the suppressor on
+// wheel_stationary AND gyro_stationary. On-robot post-deploy:
+//
+//   fusion_graph_node yaw drift = -4.28°/min (worse than no fix at all)
+//
+// Live IMU /imu/data publishes wz ≈ -0.023 rad/s (-1.32°/s) at rest on
+// this robot — hardware_bridge calibration neutralises the cold bias
+// but not the thermal drift — so |dtheta_gyro| was always ~10× above
+// any sensible stationary_thresh_theta, the AND fell through, and the
+// gyro path ran like before. Worse, the original test used a
+// 0.0002 rad/s bias which masked the AND-gate hiding bug entirely.
+//
+// Second iteration (this file): drop the gyro_stationary check.
+// Encoders cannot slip "into" stationary — when |dx|, |dy|,
+// |dtheta_wheel| are all below thresholds the robot is genuinely
+// parked, so trust the wheel and snap dtheta=0 regardless of gyro
+// noise.
 //
 // These tests pin the post-fix behaviour:
-//   1. With encoders idle and a realistic gyro-bias drift the graph
-//      yaw must stay within ~0.05° over a 60 s parked window (pre-fix
-//      ≈ 0.66°).
+//   1. With encoders idle and a realistic 0.025 rad/s gyro bias (the
+//      live residual order of magnitude) the graph yaw must stay
+//      within ~0.05° over a 60 s parked window. The previous test's
+//      0.0002 rad/s bias did NOT exercise the AND gate; this version
+//      would have failed against the PR #161 code.
 //   2. With matching wheel + gyro rotation the graph still tracks the
-//      input rotation (the stationary path only kicks in when both
-//      sources agree the robot is at rest).
+//      input rotation (the stationary path only kicks in when the
+//      wheel encoder reports no motion).
 
 #include <cmath>
 #include <cstdio>
@@ -59,10 +71,12 @@ fg::GraphParams MakeParams()
 }  // namespace
 
 // ─────────────────────────────────────────────────────────────────────
-// 60 s of stationary operation with a 0.011°/s residual gyro bias
-// (a typical post-calibration value from hardware_bridge_node). The
-// pre-fix code drifted ~0.66°; the suppressor must hold yaw to within
-// 0.05°.
+// 60 s of stationary operation with a 0.025 rad/s (~1.43°/s) residual
+// gyro bias — the order of magnitude actually seen on /imu/data after
+// hardware_bridge calibration on this robot. Crucially this is well
+// above stationary_thresh_theta (2 mrad/tick → 20 mrad/s @ 10 Hz), so
+// any AND-gated suppressor (PR #161) would fail the test. The wheel-
+// only suppressor must hold yaw to within 0.05°.
 // ─────────────────────────────────────────────────────────────────────
 TEST(StationaryYaw, GyroBiasDoesNotDriftMapYaw)
 {
@@ -72,10 +86,12 @@ TEST(StationaryYaw, GyroBiasDoesNotDriftMapYaw)
   const gtsam::Pose2 X0(1.0, 2.0, 0.5);
   gm.Initialize(X0, 0.0);
 
-  // 600 ticks × 0.1 s = 60 s. 0.011°/s ≈ 0.0001920 rad/s gyro bias.
+  // 600 ticks × 0.1 s = 60 s. 0.025 rad/s ≈ 1.43°/s gyro bias —
+  // matches the live residual measured on /imu/data with the robot
+  // parked at the dock.
   constexpr int kTicks = 600;
   constexpr double kDt = 0.1;
-  constexpr double kGyroBias = 0.0001920;  // rad/s, ~0.011°/s
+  constexpr double kGyroBias = 0.025;  // rad/s, ~1.43°/s
 
   for (int i = 0; i < kTicks; ++i)
   {
@@ -96,16 +112,17 @@ TEST(StationaryYaw, GyroBiasDoesNotDriftMapYaw)
               yaw_drift_deg,
               yaw_drift_rad);
 
-  // Hard ceiling: 0.05° over 60 s. Pre-fix value was ~0.66° in the
-  // same setup, so this gives ~13× headroom.
+  // Hard ceiling: 0.05° over 60 s. With the AND-gated PR #161 code
+  // this test would drift ~86° (60 s × 1.43°/s) — orders of magnitude
+  // out — so the bound is a clean regression catch.
   EXPECT_LT(yaw_drift_deg, 0.05);
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Real rotation must still be tracked: the suppressor is only allowed
-// to fire when BOTH the wheel encoders AND the gyro agree the robot
-// is at rest. Drive a 0.5 rad/s rotation for 6 s and verify the graph
-// yaw lands within ~10% of the expected angle.
+// Real rotation must still be tracked: the suppressor only fires when
+// the wheel encoders report no motion. Drive a 0.5 rad/s rotation for
+// 6 s (wheels + gyro both report it) and verify the graph yaw lands
+// within ~10% of the expected angle.
 // ─────────────────────────────────────────────────────────────────────
 TEST(StationaryYaw, RotationStillTracked)
 {


### PR DESCRIPTION
## Summary

Iteration on PR #161. Post-deploy field measurement at the dock (robot stationary, charging):

| Build | Yaw drift (parked) |
|---|---|
| Pre-#161 (no suppressor) | **+0.43°/min** |
| #161 (`wheel_stationary AND gyro_stationary`) | **-4.28°/min** worse |
| This PR (`wheel_stationary` only) | expected ~ 0 |

## Why the AND hid the suppressor

Live `/imu/data` on this robot publishes `wz ~ -0.023 rad/s` (~ -1.32 deg/s) at rest after `hardware_bridge_node`'s on-dock IMU calibration - the cold bias is removed but thermal drift is not. Per 100 ms tick that's ~2.3 mrad of accumulated `dtheta_gyro`, sitting just above `stationary_thresh_theta = 2 mrad`. So `gyro_stationary` was always `false`, the `AND` collapsed to the gyro branch, and iSAM2 propagated the biased delta into `map -> odom` (and was amplified at startup by the rebase).

The test in #161 used a 0.0002 rad/s bias - three orders of magnitude smaller than reality - and trivially passed both branches.

## Fix

Drop `gyro_stationary` from the gate. Wheel encoders cannot slip "into" stationary: when `|dx|`, `|dy|`, `|dtheta_wheel|` are all below threshold the robot is genuinely parked under power, and we trust that signal regardless of how noisy the gyro is.

`stationary_thresh_theta` stays - it now exclusively bounds the wheel-side `dtheta_wheel` check inside `wheel_stationary` (its original role pre-#161). The yaml comment + header comment are rewritten to reflect the wheel-only gate.

Edge case accepted: a hand-pushed robot (wheels off the ground but rotating) will lose its yaw estimate. This is far less common than parked-with-noisy-gyro, and GPS-COG + `dock_yaw` re-anchor yaw at the next session start.

## Test update

`test_stationary_yaw.cpp` now uses `kGyroBias = 0.025 rad/s` (~ 1.43 deg/s - matches the live `/imu/data` residual order of magnitude). With this bias:
- PR #161 code: `gyro_stationary = false`, gyro path runs, ~86 deg drift over 60 s -> **fails** the 0.05 deg bound.
- This PR: `wheel_stationary = true`, `dtheta = 0` -> drift ~ 0 -> **passes**.

The second test (real rotation tracked) is unchanged in behaviour - comment updated to mention the wheel-only gate.

## Test plan

- [ ] Field: park at dock, run for 5+ minutes, compare `/odometry/filtered_map` yaw to `/odometry/filtered_local`. Drift target: < 0.1 deg/min.
- [ ] Field: drive a known box / square; verify rotation is still tracked correctly (suppressor must not fire while moving).
- [ ] CI: `colcon test --packages-select fusion_graph` - `StationaryYaw.GyroBiasDoesNotDriftMapYaw` and `StationaryYaw.RotationStillTracked` both pass.