### PR TITLE
fix(gps): forward NTRIP RTCM into NMEA receivers and surface stats

### DIFF
--- a/sensors/gps/Dockerfile
+++ b/sensors/gps/Dockerfile
@@ -96,7 +96,8 @@ COPY ros2_entrypoint.sh /ros2_entrypoint.sh
 COPY start_gps.sh /start_gps.sh
 COPY ublox_dgnss.yaml /ublox_dgnss.yaml
 COPY gps_health_aggregator.py /gps_health_aggregator.py
-RUN chmod +x /ros2_entrypoint.sh /start_gps.sh /gps_health_aggregator.py
+COPY rtcm_serial_bridge.py /rtcm_serial_bridge.py
+RUN chmod +x /ros2_entrypoint.sh /start_gps.sh /gps_health_aggregator.py /rtcm_serial_bridge.py
 
 ENTRYPOINT ["/ros2_entrypoint.sh"]
 CMD ["/start_gps.sh"]

--- a/sensors/gps/gps_health_aggregator.py
+++ b/sensors/gps/gps_health_aggregator.py
@@ -28,7 +28,13 @@ from rclpy.node import Node
 from rclpy.qos import QoSProfile, ReliabilityPolicy, DurabilityPolicy
 
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
-from ublox_ubx_msgs.msg import UBXNavStatus, UBXNavSat, UBXRxmRTCM, UBXNavCov
+from rtcm_msgs.msg import Message as RtcmMessage
+
+try:
+    from ublox_ubx_msgs.msg import UBXNavStatus, UBXNavSat, UBXRxmRTCM, UBXNavCov
+    _HAVE_UBX = True
+except ImportError:
+    _HAVE_UBX = False
 
 # Map RTCM "carrSoln" to a label.
 _CARR_SOLN_LABELS = {0: "none", 1: "float", 2: "fixed"}
@@ -51,15 +57,22 @@ class GpsHealthAggregator(Node):
     def __init__(self) -> None:
         super().__init__("gps_health_aggregator")
 
+        self.declare_parameter("protocol", "UBX")
+        self._protocol: str = str(self.get_parameter("protocol").value).upper()
+        self._ubx_enabled = self._protocol == "UBX" and _HAVE_UBX
+
         self._last_status: UBXNavStatus | None = None
         self._last_status_t: float = 0.0
         self._last_sat: UBXNavSat | None = None
         self._last_sat_t: float = 0.0
         self._last_cov: UBXNavCov | None = None
-        # Each entry: (recv_time, msg_type, msg_used, crc_failed)
+        # Each entry: (recv_time, msg_type, msg_used, crc_failed). msg_type and
+        # msg_used are -1 in NMEA mode where the receiver does not echo RTCM
+        # ingestion telemetry — we only know what we forwarded into it.
         self._rtcm: Deque[tuple[float, int, int, bool]] = collections.deque(
             maxlen=512
         )
+        self._rtcm_bytes: int = 0
 
         # ublox_dgnss publishes UBX topics with default QoS (reliable, depth
         # 10). Match it on our side.
@@ -68,15 +81,24 @@ class GpsHealthAggregator(Node):
             reliability=ReliabilityPolicy.RELIABLE,
             durability=DurabilityPolicy.VOLATILE,
         )
-        self.create_subscription(UBXNavStatus, "/ubx_nav_status", self._on_status, qos)
-        self.create_subscription(UBXNavSat, "/ubx_nav_sat", self._on_sat, qos)
-        self.create_subscription(UBXNavCov, "/ubx_nav_cov", self._on_cov, qos)
-        self.create_subscription(UBXRxmRTCM, "/ubx_rxm_rtcm", self._on_rtcm, qos)
+
+        if self._ubx_enabled:
+            self.create_subscription(UBXNavStatus, "/ubx_nav_status", self._on_status, qos)
+            self.create_subscription(UBXNavSat, "/ubx_nav_sat", self._on_sat, qos)
+            self.create_subscription(UBXNavCov, "/ubx_nav_cov", self._on_cov, qos)
+            self.create_subscription(UBXRxmRTCM, "/ubx_rxm_rtcm", self._on_rtcm_ubx, qos)
+        else:
+            # NMEA mode (or UBX msgs unavailable): only the NTRIP/RTCM
+            # diagnostic is meaningful, sourced from the raw NTRIP topic.
+            self.create_subscription(RtcmMessage, "/ntrip_client/rtcm", self._on_rtcm_nmea, 50)
 
         self._pub = self.create_publisher(DiagnosticArray, "/diagnostics", 10)
         self.create_timer(1.0, self._publish)
 
-        self.get_logger().info("gps_health_aggregator running")
+        self.get_logger().info(
+            f"gps_health_aggregator running (protocol={self._protocol}, "
+            f"ubx_enabled={self._ubx_enabled})"
+        )
 
     # ── Subscribers ──────────────────────────────────────────────────
     def _now(self) -> float:
@@ -93,18 +115,35 @@ class GpsHealthAggregator(Node):
     def _on_cov(self, msg: UBXNavCov) -> None:
         self._last_cov = msg
 
-    def _on_rtcm(self, msg: UBXRxmRTCM) -> None:
+    def _on_rtcm_ubx(self, msg: UBXRxmRTCM) -> None:
+        # UBX path: the receiver tells us which RTCM type it ingested and
+        # whether the CRC validated. msg_used == 2 means the frame was
+        # accepted and applied.
         self._rtcm.append(
             (self._now(), int(msg.msg_type), int(msg.msg_used), bool(msg.crc_failed))
         )
+
+    def _on_rtcm_nmea(self, msg: RtcmMessage) -> None:
+        # NMEA path: ntrip_client publishes the raw RTCM3 frame. We only
+        # know it was forwarded — the receiver does not report ingestion.
+        # msg.message is the raw RTCM3 byte stream; msg type is the 12-bit
+        # field starting at bit 24 of the frame (preamble 0xD3 + 6 reserved
+        # bits + 10 length bits + 12 type bits).
+        self._rtcm_bytes += len(msg.message)
+        msg_type = -1
+        if len(msg.message) >= 5:
+            b3, b4 = msg.message[3], msg.message[4]
+            msg_type = ((b3 << 4) | (b4 >> 4)) & 0x0FFF
+        self._rtcm.append((self._now(), msg_type, -1, False))
 
     # ── Publisher ────────────────────────────────────────────────────
     def _publish(self) -> None:
         now = self._now()
         arr = DiagnosticArray()
         arr.header.stamp = self.get_clock().now().to_msg()
-        arr.status.append(self._fix_status(now))
-        arr.status.append(self._sat_status(now))
+        if self._ubx_enabled:
+            arr.status.append(self._fix_status(now))
+            arr.status.append(self._sat_status(now))
         arr.status.append(self._rtcm_status(now))
         self._pub.publish(arr)
 
@@ -230,38 +269,57 @@ class GpsHealthAggregator(Node):
 
         n = len(self._rtcm)
         rate = n / _RTCM_WINDOW_S
-        used_count = sum(1 for _, _, used, _ in self._rtcm if used == 2)
-        crc_fail = sum(1 for _, _, _, crc in self._rtcm if crc)
         types: collections.Counter[int] = collections.Counter(
-            t for _, t, _, _ in self._rtcm
+            t for _, t, _, _ in self._rtcm if t >= 0
         )
         types_str = ", ".join(f"{t}({c})" for t, c in sorted(types.items()))
         last_age = now - self._rtcm[-1][0]
-        used_pct = 100.0 * used_count / n if n else 0.0
 
         s.values = [
             KeyValue(key="msgs_per_sec", value=f"{rate:.1f}"),
-            KeyValue(key="msgs_used_pct", value=f"{used_pct:.0f}"),
             KeyValue(key="age_of_last_corr_s", value=f"{last_age:.1f}"),
-            KeyValue(key="crc_failed_count", value=str(crc_fail)),
             KeyValue(key="types_seen", value=types_str),
         ]
 
-        if last_age > 5.0:
-            s.level = DiagnosticStatus.ERROR
-            s.message = f"corrections stalled ({last_age:.1f} s old)"
-        elif crc_fail >= max(2, n // 4):
-            s.level = DiagnosticStatus.WARN
-            s.message = f"{crc_fail} CRC failures in {n} msgs"
-        elif used_pct < 50.0:
-            s.level = DiagnosticStatus.WARN
-            s.message = f"only {used_pct:.0f}% of corrections accepted"
+        if self._ubx_enabled:
+            used_count = sum(1 for _, _, used, _ in self._rtcm if used == 2)
+            crc_fail = sum(1 for _, _, _, crc in self._rtcm if crc)
+            used_pct = 100.0 * used_count / n if n else 0.0
+            s.values.extend([
+                KeyValue(key="msgs_used_pct", value=f"{used_pct:.0f}"),
+                KeyValue(key="crc_failed_count", value=str(crc_fail)),
+            ])
+
+            if last_age > 5.0:
+                s.level = DiagnosticStatus.ERROR
+                s.message = f"corrections stalled ({last_age:.1f} s old)"
+            elif crc_fail >= max(2, n // 4):
+                s.level = DiagnosticStatus.WARN
+                s.message = f"{crc_fail} CRC failures in {n} msgs"
+            elif used_pct < 50.0:
+                s.level = DiagnosticStatus.WARN
+                s.message = f"only {used_pct:.0f}% of corrections accepted"
+            else:
+                s.level = DiagnosticStatus.OK
+                s.message = (
+                    f"{rate:.1f} msg/s, {used_pct:.0f}% used, "
+                    f"last {last_age:.1f} s ago"
+                )
         else:
-            s.level = DiagnosticStatus.OK
-            s.message = (
-                f"{rate:.1f} msg/s, {used_pct:.0f}% used, "
-                f"last {last_age:.1f} s ago"
-            )
+            # NMEA mode: we only know what we forwarded into the receiver.
+            # The bytes counter and message rate confirm the bridge is
+            # alive; downstream correction quality is observable through
+            # NavSatStatus (FIX/SBAS/GBAS) on /gps/fix.
+            s.values.append(KeyValue(key="bytes_total", value=str(self._rtcm_bytes)))
+            if last_age > 5.0:
+                s.level = DiagnosticStatus.ERROR
+                s.message = f"corrections stalled ({last_age:.1f} s old)"
+            else:
+                s.level = DiagnosticStatus.OK
+                s.message = (
+                    f"{rate:.1f} msg/s forwarded to receiver, "
+                    f"last {last_age:.1f} s ago"
+                )
         return s
 
 

--- a/sensors/gps/rtcm_serial_bridge.py
+++ b/sensors/gps/rtcm_serial_bridge.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Forward NTRIP RTCM3 corrections to a serial GPS receiver.
+
+The ntrip_client_node publishes parsed RTCM3 frames on /ntrip_client/rtcm
+(rtcm_msgs/Message). The UBX path (serial_ublox_driver.py) consumes that
+topic directly because it owns the serial port. The NMEA path uses
+nmea_navsat_driver, which is read-only — it never writes RTCM back into
+the receiver. Without this bridge an LC29H or similar NMEA-capable RTK
+receiver gets a fix but stays at autonomous accuracy, even with NTRIP
+configured.
+
+Linux allows multiple processes to hold the same /dev/ttyXXX open. The
+NMEA driver opens it for read with its own baud/termios settings; we
+open it write-only with no termios changes so the kernel keeps the
+driver's baud rate. Writes from this single writer don't race the
+driver's reads.
+
+Subscribes:
+  /ntrip_client/rtcm      rtcm_msgs/Message     RTCM3 corrections from NTRIP
+
+Parameters:
+  device          (string)  default '/dev/gps'   serial device to write to
+
+Publishes nothing — this is a one-way bridge. The gps_health_aggregator
+counts the same /ntrip_client/rtcm topic for diagnostics.
+"""
+from __future__ import annotations
+
+import os
+import time
+
+import rclpy
+from rclpy.node import Node
+
+from rtcm_msgs.msg import Message as RtcmMessage
+
+
+class RtcmSerialBridge(Node):
+    def __init__(self) -> None:
+        super().__init__("rtcm_serial_bridge")
+        self.declare_parameter("device", "/dev/gps")
+        self.device_path: str = self.get_parameter("device").value
+
+        self.fd: int | None = None
+        self._open_device()
+
+        self.bytes_written = 0
+        self.msgs_written = 0
+        self.last_log_t = time.time()
+
+        self.create_subscription(
+            RtcmMessage, "/ntrip_client/rtcm", self._on_rtcm, 50
+        )
+        self.get_logger().info(
+            f"rtcm_serial_bridge: forwarding /ntrip_client/rtcm → {self.device_path}"
+        )
+
+    def _open_device(self) -> None:
+        # Open write-only, non-blocking, no controlling-terminal claim, no
+        # termios reset — the NMEA driver already configured baud/parity.
+        for attempt in range(20):
+            try:
+                self.fd = os.open(
+                    self.device_path,
+                    os.O_WRONLY | os.O_NONBLOCK | os.O_NOCTTY,
+                )
+                self.get_logger().info(f"opened {self.device_path} for RTCM write")
+                return
+            except OSError as e:
+                self.get_logger().warn(
+                    f"open {self.device_path} attempt {attempt + 1}: {e}"
+                )
+                time.sleep(1.0)
+        raise RuntimeError(f"could not open {self.device_path} for write")
+
+    def _on_rtcm(self, msg: RtcmMessage) -> None:
+        if self.fd is None:
+            return
+        data = bytes(msg.message)
+        try:
+            n = os.write(self.fd, data)
+            self.bytes_written += n
+            self.msgs_written += 1
+        except BlockingIOError:
+            self.get_logger().warn("serial write would block — RTCM frame dropped")
+        except OSError as e:
+            self.get_logger().error(f"serial write: {e} — reopening device")
+            try:
+                os.close(self.fd)
+            except OSError:
+                pass
+            self.fd = None
+            self._open_device()
+            return
+
+        now = time.time()
+        if now - self.last_log_t > 5.0:
+            self.get_logger().info(
+                f"forwarded msgs={self.msgs_written} bytes={self.bytes_written}"
+            )
+            self.last_log_t = now
+
+    def destroy_node(self) -> bool:
+        if self.fd is not None:
+            try:
+                os.close(self.fd)
+            except OSError:
+                pass
+            self.fd = None
+        return super().destroy_node()
+
+
+def main() -> None:
+    rclpy.init()
+    node = RtcmSerialBridge()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/sensors/gps/start_gps.sh
+++ b/sensors/gps/start_gps.sh
@@ -47,12 +47,14 @@ GPS_PID=""
 HP_PID=""
 NTRIP_PID=""
 HEALTH_PID=""
+RTCM_BRIDGE_PID=""
 
 cleanup() {
   [ -n "$GPS_PID" ] && kill "$GPS_PID" 2>/dev/null || true
   [ -n "$HP_PID" ] && kill "$HP_PID" 2>/dev/null || true
   [ -n "$NTRIP_PID" ] && kill "$NTRIP_PID" 2>/dev/null || true
   [ -n "$HEALTH_PID" ] && kill "$HEALTH_PID" 2>/dev/null || true
+  [ -n "$RTCM_BRIDGE_PID" ] && kill "$RTCM_BRIDGE_PID" 2>/dev/null || true
 }
 trap cleanup EXIT INT TERM
 
@@ -113,11 +115,10 @@ else
   HP_PID=$!
 fi
 
-# Health aggregator — only useful in UBX mode (consumes /ubx_* topics).
-if [ "$GPS_PROTOCOL" != "NMEA" ]; then
-  python3 /gps_health_aggregator.py &
-  HEALTH_PID=$!
-fi
+# Health aggregator — UBX mode reports fix/satellites/RTCM,
+# NMEA mode reports the RTCM forwarding stream only.
+python3 /gps_health_aggregator.py --ros-args -p "protocol:=${GPS_PROTOCOL}" &
+HEALTH_PID=$!
 
 if [ "$NTRIP_ENABLED" = "true" ]; then
   echo "[start_gps.sh] NTRIP enabled: ${NTRIP_HOST}:${NTRIP_PORT}/${NTRIP_MOUNTPOINT}"
@@ -130,6 +131,14 @@ if [ "$NTRIP_ENABLED" = "true" ]; then
     -p "username:=${NTRIP_USER}" \
     -p "password:=${NTRIP_PASSWORD}" &
   NTRIP_PID=$!
+
+  # NMEA receivers (LC29H, BN-220, …) need RTCM3 bytes written into the
+  # serial port. ublox_dgnss handles this internally for UBX, but
+  # nmea_navsat_driver is read-only — bridge the topic to the device.
+  if [ "$GPS_PROTOCOL" = "NMEA" ]; then
+    python3 /rtcm_serial_bridge.py --ros-args -p "device:=${GPS_PORT}" &
+    RTCM_BRIDGE_PID=$!
+  fi
 fi
 
 wait -n || true


### PR DESCRIPTION
## Summary

Closes #103.

PR #122 added NMEA receiver support but never wired NTRIP **into** the NMEA path. \`nmea_navsat_driver\` is read-only — it reads NMEA from the serial port but never writes RTCM3 back into the receiver. The NTRIP client was running, connecting to the caster, and publishing on \`/ntrip_client/rtcm\`, but on the NMEA path nothing subscribed to it. So receivers like the **LC29H** got a 3D fix but stayed at autonomous accuracy regardless of how the operator configured NTRIP. The GUI's \"Bytes received\" counter also stayed at zero because \`gps_health_aggregator\` was disabled entirely in NMEA mode (it was hard-wired to UBX-specific topics).

## Changes

### \`sensors/gps/rtcm_serial_bridge.py\` (new)
Tiny ROS2 node that subscribes to \`/ntrip_client/rtcm\` (\`rtcm_msgs/Message\`) and writes raw RTCM3 bytes to the GPS serial device. Mirrors what \`serial_ublox_driver.py:cb_rtcm\` does for the UBX path. Opens **write-only, non-blocking, no termios changes** — relies on \`nmea_navsat_driver\` having already configured baud/parity. Linux allows multiple processes on the same TTY; the NMEA driver only reads, this bridge only writes, so there's no race on either side.

### \`sensors/gps/gps_health_aggregator.py\`
- Add a \`protocol\` parameter (default \`UBX\`).
- UBX mode is unchanged: full fix / satellites / NTRIP diagnostics from \`/ubx_*\` topics.
- NMEA mode subscribes to \`/ntrip_client/rtcm\` directly, decodes the RTCM3 type field from the frame header (12-bit field at byte offset 3-4 of each frame), and emits a single \`GPS: NTRIP/RTCM\` diagnostic with \`msgs_per_sec\` / \`age_of_last_corr_s\` / \`types_seen\` / \`bytes_total\`.
- \`ublox_ubx_msgs\` import is now optional so the node also runs on pure-NMEA images.

### \`sensors/gps/start_gps.sh\`
- Aggregator now launches in both modes (was UBX-only) and gets \`-p protocol:=…\` to switch.
- When \`GPS_PROTOCOL=NMEA\` AND \`ntrip_enabled=true\`, also launch \`rtcm_serial_bridge.py\` pointed at the same \`gps_port\` the NMEA driver opened.

### \`sensors/gps/Dockerfile\`
- Copy the new bridge script into the runtime image.

## Component

- [x] Sensors (\`sensors/\`)

## Testing

- [x] \`python3 -m py_compile\` passes for both Python files.
- [x] \`bash -n start_gps.sh\` passes.
- [ ] Hardware verification: needs an LC29H (or similar NMEA RTK receiver) plus a working NTRIP feed. Expected results once deployed:
  - \`/ntrip_client/rtcm\` shows messages.
  - \`mowgli-gps\` logs \`rtcm_serial_bridge: forwarded msgs=… bytes=…\` every 5 s.
  - GUI Diagnostics → GPS section shows \`msgs_per_sec ≈ rate of caster\`, \`age_of_last_corr_s < 5\`, RTCM types matching the mountpoint (e.g. 1004/1077/1087/1097).
  - \`/gps/fix\` \`status.status\` transitions from \`STATUS_FIX\` (0) to \`STATUS_SBAS_FIX\` (1) or \`STATUS_GBAS_FIX\` (2) once the receiver applies corrections.
- [ ] @UltimateGER (issue reporter) can validate on the real LC29H + free NTRIP feed setup.

## Notes

- No firmware or other ROS2 changes — entirely contained in the GPS container.
- The bridge does not echo back to ROS2 — it's one-way. The aggregator counts the upstream NTRIP topic, which is the right vantage point for \"are corrections flowing\".
- For NMEA receivers we cannot tell whether the receiver actually applied a frame (they don't echo per-frame ingestion the way UBX does). The right downstream signal is \`/gps/fix\` transitioning to GBAS_FIX/SBAS_FIX, which the GPS Health badge already surfaces.