### PR TITLE
perf(gui): multiplex topic subscriptions over a single WebSocket

### DIFF
--- a/gui/pkg/api/mowglinext.go
+++ b/gui/pkg/api/mowglinext.go
@@ -42,7 +42,29 @@ func MowgliNextRoutes(r *gin.RouterGroup, provider types.IRosProvider) {
 	ClearMapRoute(group, provider)
 	ReplaceMapRoute(group, provider)
 	SubscriberRoute(group, provider)
+	MultiplexRoute(group, provider)
 	PublisherRoute(group, provider)
+}
+
+// topicSubscribeInterval returns the throttle interval (ms, -1 = unthrottled)
+// for a known logical topic. Mirrors the per-topic intervals used by
+// SubscriberRoute. The bool flag is false for unknown topics so the
+// multiplex path can ignore subscribe ops for them instead of leaking
+// goroutines on bad input.
+func topicSubscribeInterval(topic string) (int, bool) {
+	switch topic {
+	case "gps", "pose", "imu", "ticks", "wheelOdom", "lidar":
+		return 100, true
+	case "fusionRaw", "cogHeading", "magYaw":
+		return 200, true
+	case "diagnostics", "status", "highLevelStatus", "btLog", "map",
+		"path", "plan", "power", "emergency", "dockingSensor",
+		"robotDescription", "coverageCells", "recordingTrajectory",
+		"obstacles", "fusionDiag":
+		return -1, true
+	default:
+		return -1, false
+	}
 }
 
 // AddMapAreaRoute add a map area
@@ -303,6 +325,131 @@ func PublisherRoute(group *gin.RouterGroup, provider types.IRosProvider) {
 				log.Printf("PublisherRoute: publish error: %v", err)
 				// Don't break — foxglove may reconnect; keep the browser WebSocket alive
 				continue
+			}
+		}
+	})
+}
+
+// MultiplexRoute multiplexes any number of topic subscriptions over one
+// WebSocket so a single browser tab does not need ~25 simultaneous TCP
+// connections. Wire format:
+//
+//	client → server: {"op": "subscribe"|"unsubscribe", "topic": "<key>"}
+//	server → client: {"topic": "<key>", "data": "<base64>"}
+//
+// Per-topic throttling reuses topicSubscribeInterval. Unknown topics are
+// ignored. On disconnect, all live subscriptions are released.
+//
+// @Summary multiplexed topic subscription
+// @Description multiplexed topic subscription
+// @Tags mowglinext
+// @Router /mowglinext/multiplex [get]
+func MultiplexRoute(group *gin.RouterGroup, provider types.IRosProvider) {
+	group.GET("/multiplex", func(c *gin.Context) {
+		conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		type subState struct {
+			id string
+		}
+		var stateMu sync.Mutex
+		state := map[string]*subState{}
+
+		var writeMu sync.Mutex
+		writeFrame := func(topic string, data []byte) {
+			frame := map[string]string{
+				"topic": topic,
+				"data":  base64.StdEncoding.EncodeToString(data),
+			}
+			payload, err := json.Marshal(frame)
+			if err != nil {
+				return
+			}
+			writeMu.Lock()
+			defer writeMu.Unlock()
+			_ = conn.WriteMessage(websocket.TextMessage, payload)
+		}
+
+		subscribeTopic := func(topic string) {
+			interval, known := topicSubscribeInterval(topic)
+			if !known {
+				log.Printf("MultiplexRoute: ignoring unknown topic %q", topic)
+				return
+			}
+			stateMu.Lock()
+			if _, exists := state[topic]; exists {
+				stateMu.Unlock()
+				return
+			}
+			id := uuid.Generate().String()
+			state[topic] = &subState{id: id}
+			stateMu.Unlock()
+
+			err := provider.Subscribe(topic, id, func(msg []byte) {
+				if interval > 0 {
+					time.Sleep(time.Duration(interval) * time.Millisecond)
+				}
+				writeFrame(topic, msg)
+			})
+			if err != nil {
+				log.Printf("MultiplexRoute: subscribe %s: %v", topic, err)
+				stateMu.Lock()
+				delete(state, topic)
+				stateMu.Unlock()
+			}
+		}
+
+		unsubscribeTopic := func(topic string) {
+			stateMu.Lock()
+			s, ok := state[topic]
+			delete(state, topic)
+			stateMu.Unlock()
+			if ok {
+				provider.UnSubscribe(topic, s.id)
+			}
+		}
+
+		// Drain all subscriptions when the connection closes.
+		defer func() {
+			stateMu.Lock()
+			snapshot := make([]struct {
+				topic string
+				id    string
+			}, 0, len(state))
+			for topic, s := range state {
+				snapshot = append(snapshot, struct {
+					topic string
+					id    string
+				}{topic, s.id})
+			}
+			state = map[string]*subState{}
+			stateMu.Unlock()
+			for _, s := range snapshot {
+				provider.UnSubscribe(s.topic, s.id)
+			}
+		}()
+
+		type clientMsg struct {
+			Op    string `json:"op"`
+			Topic string `json:"topic"`
+		}
+		for {
+			_, payload, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var m clientMsg
+			if err := json.Unmarshal(payload, &m); err != nil {
+				continue
+			}
+			switch m.Op {
+			case "subscribe":
+				subscribeTopic(m.Topic)
+			case "unsubscribe":
+				unsubscribeTopic(m.Topic)
 			}
 		}
 	})

--- a/gui/pkg/api/mowglinext_test.go
+++ b/gui/pkg/api/mowglinext_test.go
@@ -2,13 +2,17 @@ package api
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/cedbossneo/mowglinext/pkg/types"
 	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -169,4 +173,98 @@ func TestSetDockingPointRoute(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	require.Len(t, mock.ServiceCalls, 1)
 	assert.Equal(t, "/map_server_node/set_docking_point", mock.ServiceCalls[0].Service)
+}
+
+// dialMultiplex opens the test server's /multiplex WebSocket. Returns the
+// connection plus a teardown closure that closes both the connection and
+// the test server.
+func dialMultiplex(t *testing.T, server *httptest.Server) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/mowglinext/multiplex"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	return conn
+}
+
+func readMultiplexFrame(t *testing.T, conn *websocket.Conn) (string, []byte) {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, raw, err := conn.ReadMessage()
+	require.NoError(t, err)
+	var frame struct {
+		Topic string `json:"topic"`
+		Data  string `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &frame))
+	decoded, err := base64.StdEncoding.DecodeString(frame.Data)
+	require.NoError(t, err)
+	return frame.Topic, decoded
+}
+
+func TestMultiplexRoute_FansOutOnSubscribe(t *testing.T) {
+	mock := types.NewMockRosProvider()
+	server := httptest.NewServer(setupMowgliNextRouter(mock))
+	defer server.Close()
+	conn := dialMultiplex(t, server)
+	defer conn.Close()
+
+	require.NoError(t, conn.WriteJSON(map[string]string{"op": "subscribe", "topic": "highLevelStatus"}))
+	// Give the server's read loop a moment to register the subscription.
+	time.Sleep(50 * time.Millisecond)
+
+	mock.Dispatch("highLevelStatus", []byte(`{"hello":"world"}`))
+
+	topic, payload := readMultiplexFrame(t, conn)
+	assert.Equal(t, "highLevelStatus", topic)
+	assert.JSONEq(t, `{"hello":"world"}`, string(payload))
+}
+
+func TestMultiplexRoute_UnsubscribeStopsDelivery(t *testing.T) {
+	mock := types.NewMockRosProvider()
+	server := httptest.NewServer(setupMowgliNextRouter(mock))
+	defer server.Close()
+	conn := dialMultiplex(t, server)
+	defer conn.Close()
+
+	require.NoError(t, conn.WriteJSON(map[string]string{"op": "subscribe", "topic": "status"}))
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, conn.WriteJSON(map[string]string{"op": "unsubscribe", "topic": "status"}))
+	time.Sleep(50 * time.Millisecond)
+
+	mock.Dispatch("status", []byte(`{"x":1}`))
+
+	_ = conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	_, _, err := conn.ReadMessage()
+	assert.Error(t, err, "no frame should arrive after unsubscribe")
+}
+
+func TestMultiplexRoute_IgnoresUnknownTopic(t *testing.T) {
+	mock := types.NewMockRosProvider()
+	server := httptest.NewServer(setupMowgliNextRouter(mock))
+	defer server.Close()
+	conn := dialMultiplex(t, server)
+	defer conn.Close()
+
+	require.NoError(t, conn.WriteJSON(map[string]string{"op": "subscribe", "topic": "made_up"}))
+	time.Sleep(50 * time.Millisecond)
+
+	mock.Dispatch("made_up", []byte(`x`))
+	_ = conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	_, _, err := conn.ReadMessage()
+	assert.Error(t, err)
+}
+
+func TestMultiplexRoute_DropsSubscriptionsOnDisconnect(t *testing.T) {
+	mock := types.NewMockRosProvider()
+	server := httptest.NewServer(setupMowgliNextRouter(mock))
+	defer server.Close()
+	conn := dialMultiplex(t, server)
+
+	require.NoError(t, conn.WriteJSON(map[string]string{"op": "subscribe", "topic": "imu"}))
+	time.Sleep(50 * time.Millisecond)
+	_ = conn.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	// Dispatch after the client is gone should be a no-op (no panic).
+	mock.Dispatch("imu", []byte(`{"a":1}`))
 }

--- a/gui/web/src/hooks/multiplexedSocket.ts
+++ b/gui/web/src/hooks/multiplexedSocket.ts
@@ -1,0 +1,190 @@
+// Single-connection WebSocket multiplexer for /api/mowglinext/multiplex.
+//
+// Replaces the one-WebSocket-per-topic pattern that opened ~25 connections
+// per browser tab. All callers share one socket; each subscribe() registers
+// a listener and tracks ref-count per topic so the server keeps exactly one
+// upstream subscription per topic per tab.
+//
+// Wire format (matches MultiplexRoute in gui/pkg/api/mowglinext.go):
+//   client → server: {"op": "subscribe"|"unsubscribe", "topic": "<key>"}
+//   server → client: {"topic": "<key>", "data": "<base64>"}
+
+type Listener = (data: string, first: boolean) => void;
+
+interface ServerFrame {
+    topic: string;
+    data: string;
+}
+
+interface ClientOp {
+    op: "subscribe" | "unsubscribe";
+    topic: string;
+}
+
+class MultiplexedSocket {
+    private url: string;
+    private ws: WebSocket | null = null;
+    private state: "idle" | "connecting" | "open" = "idle";
+    private listeners = new Map<string, Set<Listener>>();
+    // Functions that have not yet received their first payload — they get
+    // first=true on the next delivery, then are removed.
+    private pendingFirst = new WeakSet<Listener>();
+    private reconnectAttempt = 0;
+    private reconnectTimer: number | null = null;
+
+    constructor(url: string) {
+        this.url = url;
+    }
+
+    subscribe(topic: string, listener: Listener): () => void {
+        let set = this.listeners.get(topic);
+        const isFirstSubscriberForTopic = !set || set.size === 0;
+        if (!set) {
+            set = new Set();
+            this.listeners.set(topic, set);
+        }
+        set.add(listener);
+        this.pendingFirst.add(listener);
+
+        if (this.state === "idle") {
+            this.connect();
+        } else if (this.state === "open" && isFirstSubscriberForTopic) {
+            this.send({op: "subscribe", topic});
+        }
+
+        return () => this.unsubscribe(topic, listener);
+    }
+
+    private unsubscribe(topic: string, listener: Listener): void {
+        const set = this.listeners.get(topic);
+        if (!set) return;
+        set.delete(listener);
+        this.pendingFirst.delete(listener);
+        if (set.size === 0) {
+            this.listeners.delete(topic);
+            if (this.state === "open") {
+                this.send({op: "unsubscribe", topic});
+            }
+        }
+        if (this.listeners.size === 0) {
+            // Cancel any pending reconnect — nothing to subscribe for.
+            if (this.reconnectTimer != null) {
+                clearTimeout(this.reconnectTimer);
+                this.reconnectTimer = null;
+            }
+            // Close the live socket if open; onclose will not reconnect
+            // because the listeners map is now empty.
+            if (this.state === "open" && this.ws) {
+                try { this.ws.close(); } catch { /* ignore */ }
+            }
+        }
+    }
+
+    private connect(): void {
+        if (this.state !== "idle") return;
+        if (this.listeners.size === 0) return;
+        this.state = "connecting";
+
+        const ws = new WebSocket(this.url);
+        this.ws = ws;
+
+        ws.onopen = () => {
+            this.state = "open";
+            this.reconnectAttempt = 0;
+            // Re-subscribe to every topic that still has listeners.
+            for (const topic of this.listeners.keys()) {
+                this.send({op: "subscribe", topic});
+            }
+        };
+
+        ws.onmessage = (e: MessageEvent) => {
+            let frame: ServerFrame;
+            try {
+                frame = JSON.parse(typeof e.data === "string" ? e.data : "") as ServerFrame;
+            } catch {
+                return;
+            }
+            const set = this.listeners.get(frame.topic);
+            if (!set || set.size === 0) return;
+            let decoded: string;
+            try {
+                decoded = atob(frame.data);
+            } catch {
+                return;
+            }
+            // Snapshot listeners so a callback that unsubscribes mid-iteration
+            // does not affect the current dispatch.
+            const snapshot = Array.from(set);
+            for (const cb of snapshot) {
+                const isFirst = this.pendingFirst.has(cb);
+                if (isFirst) this.pendingFirst.delete(cb);
+                try {
+                    cb(decoded, isFirst);
+                } catch (err) {
+                    console.error("MultiplexedSocket: listener threw", err);
+                }
+            }
+        };
+
+        ws.onerror = () => {
+            try { ws.close(); } catch { /* ignore */ }
+        };
+
+        ws.onclose = () => {
+            this.ws = null;
+            this.state = "idle";
+            // Reconnect only if there's still something to listen for.
+            if (this.listeners.size > 0) {
+                this.scheduleReconnect();
+            }
+        };
+    }
+
+    private scheduleReconnect(): void {
+        if (this.reconnectTimer != null) return;
+        const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempt), 30000);
+        this.reconnectAttempt += 1;
+        this.reconnectTimer = window.setTimeout(() => {
+            this.reconnectTimer = null;
+            this.connect();
+        }, delay);
+    }
+
+    private send(op: ClientOp): void {
+        if (!this.ws || this.state !== "open") return;
+        try {
+            this.ws.send(JSON.stringify(op));
+        } catch (err) {
+            console.warn("MultiplexedSocket: send failed", err);
+        }
+    }
+}
+
+let singleton: MultiplexedSocket | null = null;
+
+function multiplexUrl(): string {
+    const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+    if (import.meta.env.DEV) {
+        return `${protocol}://localhost:4006/api/mowglinext/multiplex`;
+    }
+    return `${protocol}://${window.location.host}/api/mowglinext/multiplex`;
+}
+
+export function getMultiplexedSocket(): MultiplexedSocket {
+    if (singleton == null) {
+        singleton = new MultiplexedSocket(multiplexUrl());
+    }
+    return singleton;
+}
+
+// Match /api/mowglinext/subscribe/<topic> exactly; everything else (e.g.
+// /publish/joy) keeps its dedicated socket.
+const SUBSCRIBE_PREFIX = "/api/mowglinext/subscribe/";
+
+export function isMultiplexableSubscribeUri(uri: string): boolean {
+    return uri.startsWith(SUBSCRIBE_PREFIX) && uri.length > SUBSCRIBE_PREFIX.length;
+}
+
+export function topicFromSubscribeUri(uri: string): string {
+    return uri.slice(SUBSCRIBE_PREFIX.length);
+}

--- a/gui/web/src/hooks/useWS.ts
+++ b/gui/web/src/hooks/useWS.ts
@@ -1,14 +1,32 @@
 import reactUseWebSocketModule from "react-use-websocket";
 import {useRef, useState} from "react";
+import {
+    getMultiplexedSocket,
+    isMultiplexableSubscribeUri,
+    topicFromSubscribeUri,
+} from "./multiplexedSocket.ts";
 
 // Vite 8 CJS interop may wrap the default export differently at runtime
 const useWebSocket = (reactUseWebSocketModule as unknown as { default: typeof reactUseWebSocketModule }).default ?? reactUseWebSocketModule;
 
-export const useWS = <T>(onError: (e: Error) => void, onInfo: (msg: string) => void, onData: (data: T, first?: boolean) => void) => {
-    const [uri, setUri] = useState<string | null>(null);
-    const firstRef = useRef(true);
-
-    // Keep refs to always call the latest callbacks, avoiding stale closures
+/**
+ * useWS — start/stop a stream of payloads from the GUI backend.
+ *
+ * Subscribe URIs (`/api/mowglinext/subscribe/<topic>`) are multiplexed
+ * over a single shared WebSocket via {@link getMultiplexedSocket}.
+ * Other URIs (e.g. `/api/mowglinext/publish/joy`) keep their dedicated
+ * connection because they need bidirectional traffic that the
+ * multiplex protocol does not handle yet.
+ *
+ * The signature is unchanged from before #177 so every existing hook
+ * keeps working without modification.
+ */
+export const useWS = <T>(
+    onError: (e: Error) => void,
+    onInfo: (msg: string) => void,
+    onData: (data: T, first?: boolean) => void,
+) => {
+    // Refs to always invoke the latest callbacks, avoiding stale closures.
     const onDataRef = useRef(onData);
     onDataRef.current = onData;
     const onErrorRef = useRef(onError);
@@ -16,44 +34,76 @@ export const useWS = <T>(onError: (e: Error) => void, onInfo: (msg: string) => v
     const onInfoRef = useRef(onInfo);
     onInfoRef.current = onInfo;
 
-    const ws = useWebSocket(uri, {
+    // Active multiplex unsubscribe (set when start() targets a subscribe URI).
+    const muxUnsubscribeRef = useRef<(() => void) | null>(null);
+
+    // Publish-side socket (only used for non-subscribe URIs).
+    const [pubUri, setPubUri] = useState<string | null>(null);
+    const pubFirstRef = useRef(true);
+    const ws = useWebSocket(pubUri, {
         share: true,
         shouldReconnect: () => true,
         reconnectAttempts: Infinity,
         reconnectInterval: (attempt: number) => Math.min(1000 * Math.pow(2, attempt), 30000),
         onOpen: () => {
-            console.log(`Opened stream ${uri}`)
-            onInfoRef.current("Stream connected")
+            onInfoRef.current("Stream connected");
         },
         onError: () => {
-            console.log(`Error on stream ${uri}`)
-            onErrorRef.current(new Error(`Stream error`))
+            onErrorRef.current(new Error("Stream error"));
         },
         onClose: () => {
-            console.log(`Stream closed ${uri}`)
-            onErrorRef.current(new Error(`Stream closed`))
+            onErrorRef.current(new Error("Stream closed"));
         },
         onMessage: (e: MessageEvent) => {
-            const isFirst = firstRef.current;
-            if (isFirst) {
-                firstRef.current = false;
-            }
+            const isFirst = pubFirstRef.current;
+            if (isFirst) pubFirstRef.current = false;
             onDataRef.current(atob(e.data) as T, isFirst);
-        }
+        },
     });
-    const start = (uri: string) => {
-        firstRef.current = true;
-        const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-        if (import.meta.env.DEV) {
-            setUri(`${protocol}://localhost:4006${uri}`)
-        } else {
-            setUri(`${protocol}://${window.location.host}${uri}`)
+
+    const teardown = () => {
+        if (muxUnsubscribeRef.current) {
+            muxUnsubscribeRef.current();
+            muxUnsubscribeRef.current = null;
+        }
+        if (pubUri !== null) {
+            setPubUri(null);
+            pubFirstRef.current = false;
         }
     };
+
+    const start = (uri: string) => {
+        teardown();
+
+        if (isMultiplexableSubscribeUri(uri)) {
+            const topic = topicFromSubscribeUri(uri);
+            let firstReported = false;
+            muxUnsubscribeRef.current = getMultiplexedSocket().subscribe(
+                topic,
+                (data, isFirst) => {
+                    if (isFirst && !firstReported) {
+                        firstReported = true;
+                        onInfoRef.current("Stream connected");
+                    }
+                    onDataRef.current(data as T, isFirst);
+                },
+            );
+            return;
+        }
+
+        // Publish path: open a dedicated socket as before.
+        pubFirstRef.current = true;
+        const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+        if (import.meta.env.DEV) {
+            setPubUri(`${protocol}://localhost:4006${uri}`);
+        } else {
+            setPubUri(`${protocol}://${window.location.host}${uri}`);
+        }
+    };
+
     const stop = () => {
-        console.log(`Closing stream ${ws.getWebSocket()?.url}`)
-        setUri(null)
-        firstRef.current = false;
-    }
-    return {start, stop, sendJsonMessage: ws.sendJsonMessage}
-}
+        teardown();
+    };
+
+    return {start, stop, sendJsonMessage: ws.sendJsonMessage};
+};


### PR DESCRIPTION
## Summary

Closes #177.

Each \`useWS\` subscription used to open its own WebSocket via \`react-use-websocket\`. With ~25 logical topics (\`pose\`, \`gps\`, \`imu\`, \`ticks\`, \`wheelOdom\`, \`fusionRaw\`, \`lidar\`, \`diagnostics\`, \`fusionDiag\`, \`status\`, \`highLevelStatus\`, \`power\`, \`emergency\`, \`btLog\`, \`map\`, \`path\`, \`plan\`, \`coverageCells\`, \`robotDescription\`, \`recordingTrajectory\`, \`obstacles\`, \`cogHeading\`, \`magYaw\`, \`dockingSensor\`) every browser tab held that many sockets, with N reconnect storms whenever \`foxglove_bridge\` restarted.

This PR multiplexes everything onto **one socket per browser tab**.

## Changes

### Backend
- New endpoint \`/api/mowglinext/multiplex\` (\`MultiplexRoute\`).
- Wire format:
  - client → server: \`{\"op\":\"subscribe\"|\"unsubscribe\",\"topic\":\"<key>\"}\`
  - server → client: \`{\"topic\":\"<key>\",\"data\":\"<base64>\"}\`
- Reuses per-topic throttle intervals from \`SubscriberRoute\` via a new shared \`topicSubscribeInterval\` helper.
- Unknown topics are logged and rejected (no leaked goroutines).
- Disconnect cleans up every active provider subscription owned by that connection.

### Frontend
- \`gui/web/src/hooks/multiplexedSocket.ts\` (new): lazy-initialised singleton.
  - Ref-counts listeners per topic; sends server ops only on the \`0 ↔ ≥1\` transition for each topic.
  - Exponential reconnect backoff capped at 30 s, re-subscribes every active topic on each reconnect.
  - Auto-closes the socket when the listener map drains.
- \`useWS\` keeps the same signature (\`start\`, \`stop\`, \`sendJsonMessage\`).
  - For \`/api/mowglinext/subscribe/<topic>\` URIs it routes through the singleton.
  - For \`/publish/joy\` (and any future bidirectional URIs) it keeps a dedicated socket — \`react-use-websocket\` is still used there because the joystick needs upstream \`sendJsonMessage\`.
  - **No callsite changes anywhere** in the React tree.

### Tests
Four \`httptest\`-based Go tests in \`mowglinext_test.go\`:
- \`TestMultiplexRoute_FansOutOnSubscribe\` — subscribe → dispatch → frame arrives with the right topic + payload.
- \`TestMultiplexRoute_UnsubscribeStopsDelivery\` — subscribe → unsubscribe → no further frames.
- \`TestMultiplexRoute_IgnoresUnknownTopic\` — unknown topic is dropped, no panic.
- \`TestMultiplexRoute_DropsSubscriptionsOnDisconnect\` — closing the WS releases provider subscriptions.

## Component

- [x] GUI (\`gui/\`)

## Testing

- [x] \`go build ./...\` passes
- [x] \`go vet ./...\` passes
- [x] \`go test ./pkg/api/... -run TestMultiplex\` — 4/4 pass
- [x] \`yarn tsc --noEmit\` passes
- [x] \`yarn build\` produces a clean bundle
- [ ] Manual verification: open the GUI, confirm only **one** \`/api/mowglinext/multiplex\` socket in DevTools → Network → WS, confirm dashboard / map / diagnostics still update at the same cadence as before.

## Notes

- Pre-existing failures in \`settings_test.go\` (\`TestGetSettingsSchema_FromUpstream\`, \`TestPostSettingsYAML_MergesExisting\`) are unrelated to this change — they fail on \`dev\` too.
- Future work, deliberately deferred: multiplex the publish path (joystick \`sendJsonMessage\`). It's a single socket and only opens during recording / manual-mowing, so the payoff is small and the protocol is more involved.