### PR TITLE
feat(gui): allow Home from IDLE with confirmation prompt

### DIFF
--- a/gui/web/src/components/MowerActions.tsx
+++ b/gui/web/src/components/MowerActions.tsx
@@ -1,5 +1,5 @@
 import {useApi} from "../hooks/useApi.ts";
-import {Card, Col, Divider, Row} from "antd";
+import {App, Card, Col, Divider, Row} from "antd";
 import {PlayCircleOutlined, HomeOutlined, WarningOutlined} from '@ant-design/icons';
 import AsyncButton from "./AsyncButton.tsx";
 import React from "react";
@@ -32,6 +32,49 @@ export const useMowerAction = () => {
 export const MowerActions: React.FC<React.PropsWithChildren<{bare?: boolean}>> = (props) => {
     const {highLevelStatus} = useHighLevelStatus();
     const mowerAction = useMowerAction()
+    const {modal} = App.useApp();
+
+    // Home from IDLE means the robot is somewhere on the lawn (it's been
+    // undocked) and the operator wants it to drive itself back to the dock.
+    // The BT already accepts COMMAND_HOME from any non-charging state via
+    // the HomeSequence guard in main_tree.xml, but we ask the operator to
+    // confirm because the implied autonomous transit can be surprising
+    // (collision_monitor stays active but the robot will plan a path
+    // across whatever is in front of it).
+    const sendHome = mowerAction("high_level_control", {Command: 2});
+    const onHomeClick = async () => {
+        if (highLevelStatus.state_name === "IDLE") {
+            return new Promise<void>((resolve, reject) => {
+                modal.confirm({
+                    title: "Send robot home?",
+                    content: (
+                        <div>
+                            <p>
+                                The robot will plan a path back to the dock and drive itself there.
+                            </p>
+                            <p style={{marginBottom: 0, color: "rgba(0,0,0,0.55)"}}>
+                                Make sure the area between the robot and the dock is clear and the dock pose
+                                is set correctly.
+                            </p>
+                        </div>
+                    ),
+                    okText: "Send home",
+                    okType: "primary",
+                    cancelText: "Cancel",
+                    onOk: async () => {
+                        try {
+                            await sendHome();
+                            resolve();
+                        } catch (e) {
+                            reject(e);
+                        }
+                    },
+                    onCancel: () => resolve(),
+                });
+            });
+        }
+        return sendHome();
+    };
     const actionMenuItems: {
         key: string,
         label: string,
@@ -148,8 +191,13 @@ export const MowerActions: React.FC<React.PropsWithChildren<{bare?: boolean}>> =
                                  onAsyncClick={mowerAction("high_level_control", {Command: 1})}
                     >Start</AsyncButton>
                 ) : null}
-                {highLevelStatus.state_name !== "IDLE" && highLevelStatus.state_name !== "IDLE_DOCKED" ? <AsyncButton icon={<HomeOutlined/>} type="primary" key="btnHLC2"
-                                                                           onAsyncClick={mowerAction("high_level_control", {Command: 2})}
+                {/* Home button is hidden only when the robot is already
+                    docked (IDLE_DOCKED). From IDLE we show it so the operator
+                    can recall the robot from anywhere on the lawn — see #175.
+                    The click handler injects a confirmation modal in IDLE
+                    because the autonomous transit is non-trivial. */}
+                {highLevelStatus.state_name !== "IDLE_DOCKED" ? <AsyncButton icon={<HomeOutlined/>} type="primary" key="btnHLC2"
+                                                                           onAsyncClick={onHomeClick}
                 >Home</AsyncButton> : null}
             </Col>
             <Col>


### PR DESCRIPTION
## Summary

Closes #175.

The BT already accepts COMMAND_HOME from any non-charging state — \`HomeSequence\` in \`main_tree.xml\` gates only on \`IsCommand(2)\` and then runs \`DockRobot\`. The block was purely on the GUI side: \`MowerActions.tsx\` hid the Home button whenever \`state_name\` was \`IDLE\` *or* \`IDLE_DOCKED\`, so an operator who pushed the robot onto the lawn (or recovered it from an error away from the dock) had no way to recall it without first starting a mow.

## Changes

- \`MowerActions.tsx\`: render the Home button whenever the robot is not \`IDLE_DOCKED\` (we still hide it when the robot is already docked — no point offering it).
- When state is \`IDLE\` the click is wrapped in an antd \`Modal.confirm\` — the autonomous transit back to the dock is non-trivial and the user should be reminded to clear the path. From \`AUTONOMOUS\` / \`MOWING\` / \`MANUAL_MOWING\` / \`RECORDING\` the click stays direct as before (no behavior change there).

## Pre-conditions

Already covered by the existing \`HomeSequence\` flow:
- \`dock_pose\` comes from \`mowgli_robot.yaml\` (BT param) — set via the Map page or auto-calibration on first dock.
- \`DockRobot\` uses opennav_docking; \`collision_monitor\` stays active throughout.
- The \"zero-odom only when charging AND idle\" invariant (CLAUDE.md #11) is unaffected — robot is not charging when initiating home from IDLE, so no odom reset is triggered.

## Component

- [x] GUI (\`gui/\`)

## Testing

- [x] \`yarn tsc --noEmit\` passes
- [ ] Manual on-hardware: from IDLE (robot away from dock), confirm dialog appears → confirm → robot drives itself to the dock and transitions to IDLE_DOCKED. Cancel keeps the robot idle. Home from AUTONOMOUS/MOWING still triggers immediately without prompt.

## Notes

No ROS2 or BT changes — the underlying behavior was already correct, this PR just unblocks the operator-facing flow.