### PR TITLE
fix(install): isolate web presets from previous env

### DIFF
--- a/install/lib/gps.sh
+++ b/install/lib/gps.sh
@@ -50,6 +50,19 @@ pick_serial_by_id() {
   REPLY="${candidates[$((choice - 1))]}"
 }
 
+preset_key_loaded() {
+  local wanted="${1:?preset_key_loaded: missing key}"
+  local key
+
+  [ "${STATE_ACTIVE_PRESET_COUNT:-0}" -gt 0 ] || return 1
+
+  for key in "${STATE_PARSED_KEYS[@]}"; do
+    [ "$key" = "$wanted" ] && return 0
+  done
+
+  return 1
+}
+
 configure_gps() {
   step "GPS configuration"
 
@@ -57,6 +70,8 @@ configure_gps() {
   GPS_UART_RULE=""
   GPS_DEBUG_UART_RULE=""
   : "${GNSS_BACKEND:=gps}"
+  local gnss_preconfigured=false
+  local gps_preconfigured=false
 
   if [[ "${GNSS_BACKEND:-}" == "nmea" ]]; then
     warn_legacy_nmea_backend_once
@@ -64,8 +79,22 @@ configure_gps() {
     GPS_PROTOCOL="NMEA"
   fi
 
+  if [[ "${PRESET_LOADED:-false}" == "true" ]]; then
+    if [ "${STATE_ACTIVE_PRESET_COUNT:-0}" -gt 0 ]; then
+      preset_key_loaded GNSS_BACKEND && gnss_preconfigured=true
+      if preset_key_loaded GPS_CONNECTION && preset_key_loaded GPS_PROTOCOL; then
+        gps_preconfigured=true
+      fi
+    else
+      [ -n "${GNSS_BACKEND:-}" ] && gnss_preconfigured=true
+      if [ -n "${GPS_CONNECTION:-}" ] && [ -n "${GPS_PROTOCOL:-}" ]; then
+        gps_preconfigured=true
+      fi
+    fi
+  fi
+
   # If preset values exist (from web composer or CLI), skip interactive prompts
-  if [[ "${PRESET_LOADED:-false}" == "true" && -n "${GNSS_BACKEND:-}" && -n "${GPS_CONNECTION:-}" && -n "${GPS_PROTOCOL:-}" ]]; then
+  if [[ "$gnss_preconfigured" == "true" ]]; then
     if ! is_supported_gnss_backend "${GNSS_BACKEND}"; then
       error "Invalid GNSS_BACKEND preset: ${GNSS_BACKEND} (expected: $(list_supported_gnss_backends))"
       return 1
@@ -75,6 +104,12 @@ configure_gps() {
       info "Direct GNSS configuration disabled for HARDWARE_BACKEND=${HARDWARE_BACKEND:-mowgli}"
       return 0
     fi
+  fi
+
+  # Skip GPS prompts only when the current preset provided the GPS details.
+  # Stale GPS_* values loaded from docker/.env must not turn --gnss=unicore
+  # into an incomplete USB preset without GPS_BY_ID.
+  if [[ "$gnss_preconfigured" == "true" && "$gps_preconfigured" == "true" ]]; then
 
     : "${GPS_PORT:=/dev/gps}"
     : "${GPS_BY_ID:=}"
@@ -105,29 +140,33 @@ configure_gps() {
       return 0
     fi
 
-    echo ""
-    echo "Select GNSS backend:"
-    echo "  1) Generic GPS (legacy container, UBX or NMEA)"
-    echo "  2) u-blox (F9P, UBX HP + NTRIP bundled)"
-    echo "  3) Unicore (UM98x)"
-    prompt "$MSG_CHOICE" "1"
-    local gnss_choice="$REPLY"
+    if [[ "$gnss_preconfigured" == "true" ]]; then
+      info "GNSS backend pre-configured: ${GNSS_BACKEND}"
+    else
+      echo ""
+      echo "Select GNSS backend:"
+      echo "  1) Generic GPS (legacy container, UBX or NMEA)"
+      echo "  2) u-blox (F9P, UBX HP + NTRIP bundled)"
+      echo "  3) Unicore (UM98x)"
+      prompt "$MSG_CHOICE" "1"
+      local gnss_choice="$REPLY"
 
-    case "$gnss_choice" in
-      1)
-        GNSS_BACKEND="gps"
-        ;;
-      2)
-        GNSS_BACKEND="ublox"
-        ;;
-      3)
-        GNSS_BACKEND="unicore"
-        ;;
-      *)
-        error "Invalid GNSS backend choice"
-        return 1
-        ;;
-    esac
+      case "$gnss_choice" in
+        1)
+          GNSS_BACKEND="gps"
+          ;;
+        2)
+          GNSS_BACKEND="ublox"
+          ;;
+        3)
+          GNSS_BACKEND="unicore"
+          ;;
+        *)
+          error "Invalid GNSS backend choice"
+          return 1
+          ;;
+      esac
+    fi
 
     # Defaults based on PCB / GUI-ready
     : "${GPS_PROTOCOL:=UBX}"

--- a/install/lib/state.sh
+++ b/install/lib/state.sh
@@ -117,6 +117,17 @@ load_env_defaults_file() {
   info "Loaded previous configuration from ${file}"
 }
 
+backup_env_defaults_file() {
+  local file="${1:-$REPO_DIR/docker/.env}"
+  local backup
+
+  [ -f "$file" ] || return 0
+
+  backup="${file}.old.$(date +%Y%m%d_%H%M%S)"
+  mv "$file" "$backup"
+  info "Moved previous runtime environment aside: ${file} -> ${backup}"
+}
+
 load_preset_file() {
   local file="${1:-$(preset_file_path)}"
   local i key value

--- a/install/lib/udev.sh
+++ b/install/lib/udev.sh
@@ -203,7 +203,10 @@ install_udev_rules() {
   rm -f "$tmpfile"
 
   # Verify symlinks were created — UART devices may not exist until reboot
+  local gnss_backend
   local needs_reboot=false
+
+  gnss_backend="$(effective_gnss_backend 2>/dev/null || true)"
 
   if [ "$gnss_backend" != "disabled" ] && [ "${GPS_CONNECTION:-usb}" = "uart" ] && [ -n "${GPS_UART_DEVICE:-}" ]; then
     if [ ! -e "$GPS_UART_DEVICE" ]; then

--- a/install/mowglinext.sh
+++ b/install/mowglinext.sh
@@ -50,6 +50,34 @@ load_preset() {
   fi
 }
 
+load_install_state() {
+  local preset_file
+  local preset_attempted=false
+
+  preset_file="$(preset_file_path)"
+
+  if ! $CHECK_ONLY && [ -f "$preset_file" ]; then
+    preset_attempted=true
+    load_preset
+
+    if [ "${PRESET_LOADED:-false}" = "true" ] && [ -n "${STATE_ACTIVE_PRESET_FILE:-}" ]; then
+      if [ -f "$REPO_DIR/docker/.env" ]; then
+        warn "Web preset detected; existing docker/.env will be backed up and ignored for this install run."
+        backup_env_defaults_file "$REPO_DIR/docker/.env"
+      fi
+      return 0
+    fi
+  fi
+
+  if [ -f "$REPO_DIR/docker/.env" ]; then
+    load_env_defaults_file "$REPO_DIR/docker/.env"
+  fi
+
+  if ! $CHECK_ONLY && [ "$preset_attempted" != "true" ]; then
+    load_preset
+  fi
+}
+
 main() {
   show_banner
   load_locale
@@ -57,21 +85,17 @@ main() {
   assert_supported_platform || return 1
   print_platform_summary
 
-  if [ -f "$REPO_DIR/docker/.env" ]; then
-    load_env_defaults_file "$REPO_DIR/docker/.env"
-  fi
-
   if ! $CHECK_ONLY; then
     local TOTAL_STEPS=15
 
-    # Language selection, load previous env, then load preset
+    # Language selection, load previous env unless a web preset intentionally
+    # starts a fresh runtime configuration.
     select_language
+    load_install_state
 
     # Image refs are tied to the install script version — never inherit
     # stale paths from older installs (e.g. mowgli-docker, openmower-gui).
     unset MOWGLI_ROS2_IMAGE GPS_IMAGE UNICORE_IMAGE LIDAR_IMAGE MAVROS_IMAGE NMEA_IMAGE GUI_IMAGE
-
-    load_preset
 
     progress_run_interactive 1 "$TOTAL_STEPS" "Updating system" \
       run_system_update
@@ -119,6 +143,8 @@ main() {
       run_startup_step_live
 
   else
+    load_install_state
+
     if [ ! -f "$INSTALL_DIR/compose/docker-compose.base.yml" ]; then
       error "No installation sources found at $INSTALL_DIR — run without --check first"
       return 1

--- a/install/tests/test_gps_matrix.sh
+++ b/install/tests/test_gps_matrix.sh
@@ -133,6 +133,56 @@ case "$unicore_fragments" in
   *)                        pass "unicore: NO legacy gps fragment" ;;
 esac
 
+# ── Web composer Unicore preset must not reuse stale GPS USB defaults ─────
+section "gnss=unicore web preset with stale GPS USB config"
+
+repo="$SANDBOX/repo_unicore_web_stale_env"
+sandbox_repo "$repo"
+harness_init "$repo"
+
+serial_dir="$SANDBOX/serial-unicore"
+serial_target="$SANDBOX/ttyUSB-unicore"
+mkdir -p "$serial_dir"
+touch "$serial_target"
+ln -s "$serial_target" "$serial_dir/usb-Unicore_UM980"
+
+export SERIAL_BY_ID_DIR="$serial_dir"
+export PRESET_LOADED=true
+export STATE_ACTIVE_PRESET_COUNT=1
+STATE_PARSED_KEYS=(GNSS_BACKEND)
+STATE_PARSED_VALUES=(unicore)
+
+GNSS_BACKEND=unicore
+GPS_CONNECTION=usb
+GPS_PROTOCOL=UBX
+GPS_BY_ID=""
+pick_serial_called=false
+
+prompt_count=0
+prompt() {
+  prompt_count=$((prompt_count + 1))
+  case "$prompt_count" in
+    1) REPLY="1" ;; # connection: USB
+    2) REPLY="1" ;; # by-id candidate
+    3) REPLY="1" ;; # protocol: UBX
+    *) REPLY="${2:-}" ;;
+  esac
+}
+pick_serial_by_id() {
+  pick_serial_called=true
+  REPLY="$serial_dir/usb-Unicore_UM980"
+}
+
+if configure_gps >/dev/null 2>&1; then
+  pass "unicore web preset ignores stale GPS USB preset values"
+else
+  fail "unicore web preset ignores stale GPS USB preset values"
+fi
+assert_eq "unicore web preset asks for by-id selection" "true" "$pick_serial_called"
+assert_eq "unicore web preset selects by-id interactively" "$serial_dir/usb-Unicore_UM980" "${GPS_BY_ID:-}"
+assert_eq "unicore web preset keeps backend" "unicore" "${GNSS_BACKEND:-}"
+unset SERIAL_BY_ID_DIR
+
 # ── Invalid GNSS backend name should fail ──────────────────────────────────
 section "Invalid gnss backend is rejected"
 

--- a/install/tests/test_state_parsing.sh
+++ b/install/tests/test_state_parsing.sh
@@ -103,6 +103,21 @@ assert_eq ".env export compatibility preserved" "NMEA" "${GPS_PROTOCOL:-}"
 assert_eq ".env numeric text preserved" "115200" "${GPS_BAUD:-}"
 assert_eq ".env quoted empty value preserved" "" "${LIDAR_MODEL-__unset__}"
 
+section ".env backup for web preset installs"
+
+cat > "$SANDBOX_REPO/docker/.env" <<'EOF'
+GNSS_BACKEND=gps
+GPS_CONNECTION=usb
+GPS_PROTOCOL=UBX
+EOF
+
+backup_env_defaults_file "$SANDBOX_REPO/docker/.env"
+assert_file_not_exists ".env moved aside" "$SANDBOX_REPO/docker/.env"
+backup_file="$(find "$SANDBOX_REPO/docker" -maxdepth 1 -name '.env.old.*' | sort | tail -n1)"
+assert_file_exists ".env backup created" "$backup_file"
+backup_content="$(cat "$backup_file")"
+assert_contains ".env backup keeps old GPS_CONNECTION" "GPS_CONNECTION=usb" "$backup_content"
+
 section "preset is consumed only on explicit success path"
 
 cat > "$SANDBOX_REPO/install/.preset" <<'EOF'

--- a/install/tests/test_udev_install.sh
+++ b/install/tests/test_udev_install.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# =============================================================================
+# install/lib/udev.sh coverage
+# =============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=lib/framework.sh
+source "$SCRIPT_DIR/lib/framework.sh"
+# shellcheck source=lib/mocks.sh
+source "$SCRIPT_DIR/lib/mocks.sh"
+
+setup_sandbox
+install_all_mocks
+
+section "install_udev_rules works with set -u"
+
+repo="$SANDBOX/repo"
+sandbox_repo "$repo"
+
+# shellcheck source=/dev/null
+source "$repo/install/lib/common.sh"
+# shellcheck source=/dev/null
+source "$repo/install/lib/i18n.sh"
+# shellcheck source=/dev/null
+source "$repo/install/lib/config.sh"
+# shellcheck source=/dev/null
+source "$repo/install/lib/platform.sh"
+# shellcheck source=/dev/null
+source "$repo/install/lib/docker.sh"
+# shellcheck source=/dev/null
+source "$repo/install/lib/backend_choice.sh"
+# shellcheck source=/dev/null
+source "$repo/install/lib/range.sh"
+# shellcheck source=/dev/null
+source "$repo/install/lib/env.sh"
+# shellcheck source=/dev/null
+source "$repo/install/lib/udev.sh"
+
+load_locale
+reapply_test_assertions
+
+export UDEV_RULES_FILE="$SANDBOX/99-mowgli.rules"
+export SUDO=""
+
+export HARDWARE_BACKEND="mowgli"
+export GNSS_BACKEND="unicore"
+unset GPS_CONNECTION GPS_PROTOCOL GPS_PORT GPS_BY_ID GPS_UART_DEVICE GPS_BAUD 2>/dev/null || true
+export LIDAR_ENABLED="false"
+export TFLUNA_FRONT_ENABLED="false"
+export TFLUNA_EDGE_ENABLED="false"
+
+mkdir -p "$SANDBOX/dev"
+mkdir -p "$SANDBOX/serial-by-id"
+touch "$SANDBOX/dev/ttyACM0"
+ln -s "$SANDBOX/dev/ttyACM0" "$SANDBOX/serial-by-id/usb-Mowgli_STM32-if00"
+export SERIAL_BY_ID_DIR="$SANDBOX/serial-by-id"
+
+# Reproduce the web composer Unicore path:
+# --backend=mowgli --gnss=unicore --lidar=ldlidar-uart --tfluna=none
+# No --gps flag is emitted, so setup_env fills the runtime GPS defaults
+# before udev verification runs.
+setup_env >/dev/null 2>&1
+touch "$GPS_UART_DEVICE"
+
+set -u
+if output="$(install_udev_rules 2>&1)"; then
+  pass "install_udev_rules handles unicore web preset under set -u"
+else
+  fail "install_udev_rules handles unicore web preset under set -u" "$output"
+fi
+set +u
+
+assert_file_exists "udev rules file written" "$UDEV_RULES_FILE"
+rules="$(cat "$UDEV_RULES_FILE")"
+assert_contains "Mowgli by-id rule generated" 'SYMLINK+="mowgli"' "$rules"
+assert_contains "Mowgli by-id rule uses resolved kernel" 'KERNEL=="ttyACM0"' "$rules"
+assert_contains "gps uart rule generated" 'SYMLINK+="gps"' "$rules"
+assert_eq "GNSS backend remains unicore" "unicore" "$GNSS_BACKEND"
+
+test_summary


### PR DESCRIPTION
## Summary

Fixes follow-up issues found during onboard testing of the web installer flow.

## Changes

- Avoid generating misleading GPS presets for Unicore web installs.
- Isolate new web `.preset` installs from stale `docker/.env` values.
- Fix `udev.sh` `gnss_backend` unbound variable under `set -u`.
- Add coverage for Unicore web preset and Mowgli by-id udev rule generation.

## Component

<!-- Check all that apply -->

- [ ] ROS2 Stack (`ros2/`)
- [ ] GUI (`gui/`)
- [x] Docker (`docker/`)
- [x] Sensors (`sensors/`)
- [ ] Firmware (`firmware/`)
- [x] Documentation (`docs/`)
- [ ] CI/CD (`.github/`)

## Testing

<!-- How was this tested? -->

- [ ] Built successfully
- [ ] Tested on hardware
- [ ] Tested in simulation
- [x] Unit tests pass
- [x] Manual testing

### Tests run

- `bash docs/test_install.sh`
- `bash docs/test_web_composer.sh`
- `bash install/tests/test_state_parsing.sh`
- `bash install/tests/test_gps_matrix.sh`
- `bash install/tests/test_udev_install.sh`
- `bash install/tests/test_hardware_presets.sh`

## Checklist

- [ ] Follows conventional commit format
- [ ] Documentation updated (if user-facing)
- [ ] No hardcoded secrets or credentials
- [ ] No unrelated changes
