### PR TITLE
fix(unicore): align runtime with renamed unicore_gnss package

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -64,11 +64,11 @@ rosdep install \
 # Build the workspace.
 # ---------------------------------------------------------------------------
 echo "Building workspace (this may take a few minutes on first run)..."
-# mowgli_unicore_gnss is a stub package.xml under sensors/unicore/ (no
+# unicore_gnss is a stub package.xml under sensors/unicore/ (no
 # CMakeLists in tree — it lives in the GPS Docker image build context).
 # colcon discovers it via the workspace mount and would fail; ignore it.
 colcon build \
-    --packages-ignore mowgli_unicore_gnss \
+    --packages-ignore unicore_gnss \
     --cmake-args \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_TESTING=OFF \

--- a/install/compose/docker-compose.unicore.yaml
+++ b/install/compose/docker-compose.unicore.yaml
@@ -16,11 +16,12 @@
 #
 # The container's CMD (`/start_gps.sh`) is intentionally left as-is —
 # it reads gps_port / gps_baudrate / ntrip_* from /config/mowgli_robot.yaml
-# and runs `ros2 run mowgli_unicore_gnss um982_node` + `ros2 run
-# ntrip_client_node ntrip_client_node` directly. Do NOT override `command:`
-# here with a `ros2 launch mowgli_bringup ...` invocation: there is no
-# unicore launch file in mowgli_bringup, and the Unicore packages aren't
-# in the mowgli-ros2 image anyway.
+# and runs `ros2 run ${UNICORE_ROS_PACKAGE} ${UNICORE_ROS_EXECUTABLE}` +
+# `ros2 run ntrip_client_node ntrip_client_node` directly. Defaults are
+# unicore_gnss / unicore_node (see install/lib/env.sh). Do NOT override
+# `command:` here with a `ros2 launch mowgli_bringup ...` invocation:
+# there is no unicore launch file in mowgli_bringup, and the Unicore
+# packages aren't in the mowgli-ros2 image anyway.
 # -------------------------------------------------------------------------
 x-ros2-env: &ros2-env
   ROS_DOMAIN_ID: ${ROS_DOMAIN_ID}

--- a/sensors/unicore/Dockerfile
+++ b/sensors/unicore/Dockerfile
@@ -6,12 +6,12 @@
 # 'GPS: fix/satellites/NTRIP/RTCM' diagnostics restructure is open.
 # Once merged into mowglifrenchtouch/UM982Driver@mowgli, flip back to
 # the upstream URL.
-ARG UM982_REPO=https://github.com/cedbossneo/UM982Driver.git
-ARG UM982_REF=feat/ntrip-gga-rtk-status-gsv
+ARG UM982_REPO=https://github.com/cedbossneo/unicore-ros2
+ARG UM982_REF=main
 # Bump UM982_SHA to bust the docker layer cache when the fork moves.
 # `git clone --branch` is cacheable per ARG value, so without a SHA
 # pin we rebuild against stale code.
-ARG UM982_SHA=e36c74eaa678dc0f861d8e63e7f52394a243a00a
+ARG UM982_SHA=8a0d98aae8f9b2fc98285352dcab2013523e9410
 
 FROM ros:kilted-ros-base AS builder
 
@@ -58,7 +58,7 @@ RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
       --base-paths src/um982_driver/compass_msgs \
                    src/um982_driver/ntrip_client_node \
                    src/um982_driver \
-      --packages-up-to ntrip_client_node mowgli_unicore_gnss \
+      --packages-up-to ntrip_client_node unicore_gnss \
       --cmake-args \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/sensors/unicore/package.xml
+++ b/sensors/unicore/package.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>mowgli_unicore_gnss</name>
+  <name>unicore_gnss</name>
   <version>0.1.0</version>
-  <description>ROS 2 C++ driver for Unicore UM982 GNSS receivers using NMEA and Unicore extended output.</description>
+  <description>Stub manifest for colcon discovery — the real unicore_gnss package is built inside sensors/unicore/Dockerfile from cedbossneo/unicore-ros2.</description>
   <maintainer email="cedric@mowgli.dev">Cedric</maintainer>
   <license>Apache-2.0</license>
 

--- a/sensors/unicore/start_gps.sh
+++ b/sensors/unicore/start_gps.sh
@@ -244,12 +244,15 @@ if is_truthy "$UNICORE_AUTO_CONFIGURE"; then
   fi
 fi
 
-echo "[start_gps.sh] Launching Unicore UM982 GNSS driver: port=${GPS_PORT} baud=${GPS_BAUD} profile=${UNICORE_PROFILE}"
+UNICORE_ROS_PACKAGE="${UNICORE_ROS_PACKAGE:-unicore_gnss}"
+UNICORE_ROS_EXECUTABLE="${UNICORE_ROS_EXECUTABLE:-unicore_node}"
+
+echo "[start_gps.sh] Launching Unicore GNSS driver: port=${GPS_PORT} baud=${GPS_BAUD} profile=${UNICORE_PROFILE} pkg=${UNICORE_ROS_PACKAGE} exec=${UNICORE_ROS_EXECUTABLE}"
 # diagnostics_topic = /diagnostics — the ROS2 standard aggregator topic
 # (matches gps_health_aggregator.py in the ublox path). The GUI's
 # Diagnostics panel reads from /diagnostics; namespacing under
 # /gps/diagnostics would hide the unicore status from the dashboard.
-ros2 run mowgli_unicore_gnss um982_node --ros-args \
+ros2 run "${UNICORE_ROS_PACKAGE}" "${UNICORE_ROS_EXECUTABLE}" --ros-args \
   -p "port:=${GPS_PORT}" \
   -p "baudrate:=${GPS_BAUD}" \
   -p "frame_id:=gps_link" \


### PR DESCRIPTION
## Summary
- `sensors/unicore/start_gps.sh` was still calling `ros2 run mowgli_unicore_gnss um982_node`, but the Dockerfile (already on `main`) now builds `unicore_gnss` from `cedbossneo/unicore-ros2`. The container started, then `ros2 run` failed with package-not-found.
- Use `${UNICORE_ROS_PACKAGE:-unicore_gnss}` / `${UNICORE_ROS_EXECUTABLE:-unicore_node}` (defaults defined in `install/lib/env.sh:79-80` and injected by `install/compose/docker-compose.unicore.yaml`).
- Rename the stub `sensors/unicore/package.xml` to `unicore_gnss` so colcon discovery in the devcontainer matches the real package name, and update `.devcontainer/post-create.sh --packages-ignore` accordingly.
- Refresh the now-incorrect comment in `docker-compose.unicore.yaml`.

## Test plan
- [x] `docker build -t mowgli-unicore-test:local sensors/unicore/` succeeds.
- [x] Inside the built image: `ros2 pkg list` shows `unicore_gnss`, `ntrip_client_node`, `compass_msgs`; `ros2 pkg executables unicore_gnss` lists `unicore_node` and `um982_node`.
- [x] Running `/start_gps.sh` with a minimal `/config/mowgli_robot.yaml` logs `pkg=unicore_gnss exec=unicore_node` and the driver initialises (`Unicore node configured: …`); the only error is `Unable to open Unicore serial port /dev/null`, expected without hardware.
- [ ] Smoke test on real UM98x hardware (operator).