### PR TITLE
fix(unicore): bump UM982_SHA to pick up timer-driven publish

### DIFF
--- a/sensors/unicore/Dockerfile
+++ b/sensors/unicore/Dockerfile
@@ -11,7 +11,7 @@ ARG UM982_REF=main
 # Bump UM982_SHA to bust the docker layer cache when the fork moves.
 # `git clone --branch` is cacheable per ARG value, so without a SHA
 # pin we rebuild against stale code.
-ARG UM982_SHA=8a0d98aae8f9b2fc98285352dcab2013523e9410
+ARG UM982_SHA=8b9e25e6027039a52f6fc4d6932678b422084ffa
 
 FROM ros:kilted-ros-base AS builder
 


### PR DESCRIPTION
## Summary
Bumps `UM982_SHA` in `sensors/unicore/Dockerfile` to `8b9e25e` — the post-merge commit of [cedbossneo/unicore-ros2#1](https://github.com/cedbossneo/unicore-ros2/pull/1).

The upstream PR makes `/gps/fix` and `/gps/azimuth` publish from a single 10 Hz wall_timer (`publish_hz` parameter) instead of from every fix-bearing parse callback, eliminating the 2×–3× over-publish that field diagnostics surfaced as alternating stale/fresh PVTSLNA on `/gps/fix`.

## Test plan
- [x] `docker build sensors/unicore/` succeeds against the bumped SHA.
- [x] Patched image starts: `start_gps.sh` launches `unicore_gnss/unicore_node`, the node reports `Unicore node configured: …` and exits cleanly with `/dev/null` (expected without hardware).
- [ ] On-hardware: verify `/gps/fix` rate matches `publish_hz` (10 Hz default) instead of the previous 20–30 Hz; confirm `fusion_graph` / `ekf_map_node` consume single fresh updates.