### PR TITLE
fix(gui): import OpenMower legacy bag-JSON maps

### DIFF
--- a/docs/IMPORT_OPENMOWER_MAP.md
+++ b/docs/IMPORT_OPENMOWER_MAP.md
@@ -13,15 +13,30 @@ This document specifies how a user can take a pre-existing OpenMower
 recorded mowing/navigation areas + docking station across to a fresh
 MowgliNext install without re-driving the boundaries.
 
-Two source formats are addressed:
+Three source formats are addressed:
 
-1. **`map.json`** — the modern OpenMower map persistence format. Stable,
-   self-describing, easy to parse. **Implemented** as a parse + preview
-   path; the actual write is stubbed.
-2. **`map.bag`** — the legacy ROS1 rosbag format that older OpenMower
-   installs still have on disk. **Designed only**; deferred to a
-   follow-up because pure-Go ROS1-bag readers are unmaintained and we
-   would prefer a sidecar.
+1. **`map.json`** (modern) — OpenMower's current persistence format.
+   Lower-case `areas` / `docking_stations` keys, polygons as
+   `outline: [{x, y}]`, dock as a struct with `position` + `heading`.
+   **Implemented** as parse + preview; write step stubbed.
+2. **Legacy bag-JSON** — `mower_map_service`'s rosbag content serialised
+   to JSON (e.g. via the rosbridge JSON encoder or any ROS1→JSON tool).
+   PascalCase fields with `Package: 0` envelopes, top-level
+   `NavigationAreas` / `WorkingArea` arrays of `{Name, Area: {Points:
+   [{X, Y, Z}]}, Obstacles}`, dock as scalar `DockX` / `DockY` /
+   `DockHeading`. **Implemented** as a conversion layer:
+   `tryConvertLegacyOpenMowerMap` rewrites the body in-place to the
+   modern shape before the existing parser runs. WorkingArea entries
+   become mow areas; their nested Obstacles become top-level
+   `type="obstacle"` entries (matched back to their parent by centroid
+   containment); NavigationAreas become nav areas; the scalar dock
+   fields become the single docking station.
+3. **`map.bag`** (raw rosbag bytes) — the original binary container,
+   still found on very old installs that haven't migrated to either
+   form above. **Designed only**; deferred because pure-Go ROS1-bag
+   readers are unmaintained and we'd prefer a sidecar. Users with
+   raw `.bag` files should run OpenMower 1.x once to auto-convert to
+   either the modern `map.json` or the legacy bag-JSON above.
 
 ---
 

--- a/gui/pkg/api/openmower_import.go
+++ b/gui/pkg/api/openmower_import.go
@@ -221,29 +221,214 @@ func postImportOpenMower(rosProvider types.IRosProvider, dbProvider types.IDBPro
 	}
 }
 
-// parseImportRequest accepts either the wrapped form (`{"map": {...},
-// "om_datum_lat": ...}`) or the bare-map form (`{"areas": ..., ...}`).
-// The latter lets callers drop the file in directly without rewrapping
-// it client-side.
+// parseImportRequest accepts three shapes:
+//
+//  1. **Wrapped modern**: `{"map": {...}, "om_datum_lat": ...}` — the
+//     in-app GUI sends this, body already contains `om_datum_*` knobs.
+//  2. **Bare modern**: `{"areas": [...], "docking_stations": [...]}` —
+//     a user dropping their `map.json` straight into the upload field.
+//  3. **Legacy bag-JSON**: `{"WorkingArea": [...], "NavigationAreas":
+//     [...], "DockX": ..., "DockY": ..., "DockHeading": ...}` —
+//     OpenMower 1.x's mower_map_service bag content serialised to JSON
+//     (PascalCase fields with `Package: 0` envelopes). Converted in
+//     place to the modern shape so the rest of the pipeline doesn't
+//     need to know about it.
 func parseImportRequest(raw []byte) (ImportOpenMowerRequest, error) {
 	var req ImportOpenMowerRequest
-	// First try the wrapped form.
+	// 1. Wrapped form.
 	if err := json.Unmarshal(raw, &req); err == nil && len(req.Map) > 0 {
+		// The wrapped payload may itself contain a legacy body — try
+		// converting it; harmless if it's already modern.
+		if converted, ok := tryConvertLegacyOpenMowerMap(req.Map); ok {
+			req.Map = converted
+		}
 		return req, nil
 	}
-	// Fall back to the bare form: treat the whole body as the map.
-	// Probe a couple of expected keys so we don't accept random JSON.
+	// 2 / 3. Bare form. Probe expected keys for both modern and legacy
+	// shapes; reject random JSON that matches neither.
 	var probe struct {
 		Areas           json.RawMessage `json:"areas"`
 		DockingStations json.RawMessage `json:"docking_stations"`
+		NavigationAreas json.RawMessage `json:"NavigationAreas"`
+		WorkingArea     json.RawMessage `json:"WorkingArea"`
+		DockX           *float64        `json:"DockX"`
+		DockY           *float64        `json:"DockY"`
 	}
 	if err := json.Unmarshal(raw, &probe); err != nil {
 		return ImportOpenMowerRequest{}, fmt.Errorf("body is not valid JSON: %w", err)
 	}
-	if len(probe.Areas) == 0 && len(probe.DockingStations) == 0 {
-		return ImportOpenMowerRequest{}, errors.New("body has neither {map: ...} envelope nor OpenMower fields (areas, docking_stations)")
+	modernPresent := len(probe.Areas) > 0 || len(probe.DockingStations) > 0
+	legacyPresent := len(probe.NavigationAreas) > 0 || len(probe.WorkingArea) > 0 ||
+		probe.DockX != nil || probe.DockY != nil
+	if !modernPresent && !legacyPresent {
+		return ImportOpenMowerRequest{}, errors.New("body has neither {map: ...} envelope nor OpenMower fields (areas, docking_stations) nor legacy bag fields (NavigationAreas, WorkingArea, DockX)")
+	}
+	if !modernPresent && legacyPresent {
+		converted, ok := tryConvertLegacyOpenMowerMap(raw)
+		if !ok {
+			return ImportOpenMowerRequest{}, errors.New("body looks like a legacy OpenMower bag-JSON map but conversion failed")
+		}
+		return ImportOpenMowerRequest{Map: converted}, nil
 	}
 	return ImportOpenMowerRequest{Map: raw}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Legacy bag-JSON adapter
+// ---------------------------------------------------------------------------
+
+// legacyOpenMowerPoint mirrors geometry_msgs/Point32 the way Go's
+// rosbridge JSON serialiser emits ROS1 messages (PascalCase fields, with
+// each composite carrying a `Package: 0` envelope from the ROS1 msg
+// package tagging). We only care about X/Y; Z is always 0 in OpenMower's
+// map polygons.
+type legacyOpenMowerPoint struct {
+	X float64 `json:"X"`
+	Y float64 `json:"Y"`
+}
+
+// legacyOpenMowerPolygon is a Polygon (geometry_msgs/Polygon).
+type legacyOpenMowerPolygon struct {
+	Points []legacyOpenMowerPoint `json:"Points"`
+}
+
+// legacyOpenMowerMapArea is mower_map/MapArea — one named polygon with
+// optional obstacle polygons nested in the same struct. In the modern
+// map.json schema obstacles are top-level entries; here they live
+// inside their parent.
+type legacyOpenMowerMapArea struct {
+	Name      string                   `json:"Name"`
+	Area      legacyOpenMowerPolygon   `json:"Area"`
+	Obstacles []legacyOpenMowerPolygon `json:"Obstacles"`
+}
+
+// legacyOpenMowerMap is the top-level bag-JSON shape. Only the fields
+// we promote downstream are listed; everything else (Package, MapWidth,
+// MapHeight, MapCenter*) is ignored. WorkingArea is plural because the
+// legacy schema allowed several disjoint mowing zones; we keep that.
+type legacyOpenMowerMap struct {
+	NavigationAreas []legacyOpenMowerMapArea `json:"NavigationAreas"`
+	WorkingArea     []legacyOpenMowerMapArea `json:"WorkingArea"`
+	DockX           *float64                 `json:"DockX"`
+	DockY           *float64                 `json:"DockY"`
+	DockHeading     *float64                 `json:"DockHeading"`
+}
+
+// tryConvertLegacyOpenMowerMap inspects `raw`, and if it's the legacy
+// bag-JSON shape (PascalCase NavigationAreas / WorkingArea / Dock*),
+// returns a re-serialised modern map.json body that the rest of the
+// pipeline can parse. The boolean is true iff a conversion actually
+// happened — callers should still treat the original raw as authoritative
+// when it's false.
+func tryConvertLegacyOpenMowerMap(raw []byte) ([]byte, bool) {
+	var legacy legacyOpenMowerMap
+	if err := json.Unmarshal(raw, &legacy); err != nil {
+		return nil, false
+	}
+	if len(legacy.NavigationAreas) == 0 && len(legacy.WorkingArea) == 0 &&
+		legacy.DockX == nil && legacy.DockY == nil && legacy.DockHeading == nil {
+		// Not a legacy payload — let the modern parser handle it.
+		return nil, false
+	}
+
+	type modernArea struct {
+		ID         string                  `json:"id"`
+		Properties openMowerAreaProperties `json:"properties"`
+		Outline    []openMowerPoint        `json:"outline"`
+	}
+	type modernDock struct {
+		ID         string `json:"id"`
+		Properties struct {
+			Name   string `json:"name"`
+			Active *bool  `json:"active"`
+		} `json:"properties"`
+		Position openMowerPoint `json:"position"`
+		Heading  float64        `json:"heading"`
+	}
+	type modernMap struct {
+		Areas           []modernArea `json:"areas"`
+		DockingStations []modernDock `json:"docking_stations"`
+	}
+
+	toModernOutline := func(poly legacyOpenMowerPolygon) []openMowerPoint {
+		out := make([]openMowerPoint, 0, len(poly.Points))
+		for _, p := range poly.Points {
+			out = append(out, openMowerPoint{X: p.X, Y: p.Y})
+		}
+		return out
+	}
+
+	out := modernMap{}
+
+	// Working areas are mow areas; their nested Obstacles become
+	// top-level type="obstacle" entries (matchObstaclesToParents will
+	// re-attach them to the right parent via centroid containment).
+	for i, w := range legacy.WorkingArea {
+		name := w.Name
+		if name == "" {
+			name = fmt.Sprintf("Mowing area %d", i+1)
+		}
+		out.Areas = append(out.Areas, modernArea{
+			ID:         fmt.Sprintf("legacy-mow-%02d", i+1),
+			Properties: openMowerAreaProperties{Name: name, Type: "mow"},
+			Outline:    toModernOutline(w.Area),
+		})
+		for j, ob := range w.Obstacles {
+			out.Areas = append(out.Areas, modernArea{
+				ID: fmt.Sprintf("legacy-mow-%02d-obs-%02d", i+1, j+1),
+				Properties: openMowerAreaProperties{
+					Name: fmt.Sprintf("%s obstacle %d", name, j+1),
+					Type: "obstacle",
+				},
+				Outline: toModernOutline(ob),
+			})
+		}
+	}
+
+	for i, n := range legacy.NavigationAreas {
+		name := n.Name
+		if name == "" {
+			name = fmt.Sprintf("Navigation area %d", i+1)
+		}
+		out.Areas = append(out.Areas, modernArea{
+			ID:         fmt.Sprintf("legacy-nav-%02d", i+1),
+			Properties: openMowerAreaProperties{Name: name, Type: "nav"},
+			Outline:    toModernOutline(n.Area),
+		})
+		// Navigation areas can also carry obstacles in the bag schema;
+		// keep them for parity even though obstacles inside nav zones
+		// are unusual.
+		for j, ob := range n.Obstacles {
+			out.Areas = append(out.Areas, modernArea{
+				ID: fmt.Sprintf("legacy-nav-%02d-obs-%02d", i+1, j+1),
+				Properties: openMowerAreaProperties{
+					Name: fmt.Sprintf("%s obstacle %d", name, j+1),
+					Type: "obstacle",
+				},
+				Outline: toModernOutline(ob),
+			})
+		}
+	}
+
+	if legacy.DockX != nil && legacy.DockY != nil {
+		yaw := 0.0
+		if legacy.DockHeading != nil {
+			yaw = *legacy.DockHeading
+		}
+		d := modernDock{
+			ID:       "legacy-dock-01",
+			Position: openMowerPoint{X: *legacy.DockX, Y: *legacy.DockY},
+			Heading:  yaw,
+		}
+		d.Properties.Name = "Docking Station"
+		out.DockingStations = append(out.DockingStations, d)
+	}
+
+	converted, err := json.Marshal(out)
+	if err != nil {
+		return nil, false
+	}
+	return converted, true
 }
 
 // ---------------------------------------------------------------------------

--- a/gui/pkg/api/openmower_import_test.go
+++ b/gui/pkg/api/openmower_import_test.go
@@ -317,6 +317,131 @@ func TestPostImportOpenMower_RejectsBadJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
 }
 
+// --- legacy bag-JSON adapter ---------------------------------------------
+
+// sampleLegacyBagMap is a trimmed reproduction of the legacy
+// bag-derived map.json shape Daisy hit on 2026-05-15 — PascalCase
+// fields, `Package: 0` envelopes everywhere, NavigationAreas /
+// WorkingArea split, dock as scalar fields. The fixture covers all
+// three pathways the adapter has to handle:
+//   - a WorkingArea entry (becomes a mow area)
+//   - a WorkingArea obstacle (becomes a top-level type="obstacle")
+//   - a NavigationAreas entry (becomes a nav area)
+//   - DockX/DockY/DockHeading (becomes the single docking station)
+const sampleLegacyBagMap = `{
+  "Package": 0,
+  "MapWidth": 20.0,
+  "NavigationAreas": [
+    {
+      "Package": 0,
+      "Name": "",
+      "Area": {
+        "Package": 0,
+        "Points": [
+          {"Package": 0, "X": -3.0, "Y": 0.0, "Z": 0},
+          {"Package": 0, "X":  0.0, "Y": 0.0, "Z": 0},
+          {"Package": 0, "X":  0.0, "Y": 3.0, "Z": 0},
+          {"Package": 0, "X": -3.0, "Y": 3.0, "Z": 0}
+        ]
+      },
+      "Obstacles": null
+    }
+  ],
+  "WorkingArea": [
+    {
+      "Package": 0,
+      "Name": "",
+      "Area": {
+        "Package": 0,
+        "Points": [
+          {"Package": 0, "X":  0.0, "Y":  0.0, "Z": 0},
+          {"Package": 0, "X": 10.0, "Y":  0.0, "Z": 0},
+          {"Package": 0, "X": 10.0, "Y":  6.0, "Z": 0},
+          {"Package": 0, "X":  0.0, "Y":  6.0, "Z": 0}
+        ]
+      },
+      "Obstacles": [
+        {
+          "Package": 0,
+          "Points": [
+            {"Package": 0, "X": 4.0, "Y": 2.0, "Z": 0},
+            {"Package": 0, "X": 5.0, "Y": 2.0, "Z": 0},
+            {"Package": 0, "X": 5.0, "Y": 3.0, "Z": 0},
+            {"Package": 0, "X": 4.0, "Y": 3.0, "Z": 0}
+          ]
+        }
+      ]
+    }
+  ],
+  "DockX": -0.5,
+  "DockY": 0.2,
+  "DockHeading": 1.5707963267948966
+}`
+
+func TestParseImportRequest_LegacyBareForm(t *testing.T) {
+	req, err := parseImportRequest([]byte(sampleLegacyBagMap))
+	require.NoError(t, err, "legacy bag-JSON should be accepted bare")
+	require.NotEmpty(t, req.Map)
+
+	// The body the rest of the pipeline sees must already be in modern
+	// shape (areas / docking_stations).
+	var modern openMowerMap
+	require.NoError(t, json.Unmarshal(req.Map, &modern))
+	// 1 mow + 1 obstacle (under that mow) + 1 nav = 3 entries.
+	require.Len(t, modern.Areas, 3)
+
+	gotTypes := map[string]int{}
+	for _, a := range modern.Areas {
+		gotTypes[a.Properties.Type]++
+	}
+	assert.Equal(t, 1, gotTypes["mow"])
+	assert.Equal(t, 1, gotTypes["nav"])
+	assert.Equal(t, 1, gotTypes["obstacle"])
+
+	// Dock translated 1:1 from scalar fields.
+	require.Len(t, modern.DockingStations, 1)
+	d := modern.DockingStations[0]
+	assert.InDelta(t, -0.5, d.Position.X, 1e-9)
+	assert.InDelta(t, 0.2, d.Position.Y, 1e-9)
+	assert.InDelta(t, math.Pi/2, d.Heading, 1e-9)
+}
+
+func TestParseImportRequest_LegacyWrappedForm(t *testing.T) {
+	wrapped := []byte(`{"map": ` + sampleLegacyBagMap + `, "om_datum_lat": 48.5, "om_datum_lon": 11.5}`)
+	req, err := parseImportRequest(wrapped)
+	require.NoError(t, err)
+	require.NotEmpty(t, req.Map)
+	require.NotNil(t, req.OmDatumLat)
+	assert.InDelta(t, 48.5, *req.OmDatumLat, 1e-9)
+
+	// Conversion still applied through the wrapper.
+	var modern openMowerMap
+	require.NoError(t, json.Unmarshal(req.Map, &modern))
+	require.Len(t, modern.Areas, 3)
+	require.Len(t, modern.DockingStations, 1)
+}
+
+func TestPostImportOpenMower_LegacyBagPreview(t *testing.T) {
+	mock := types.NewMockRosProvider()
+	router := setupImportRouter(mock, nil)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/import/openmower",
+		bytes.NewReader([]byte(sampleLegacyBagMap)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var summary ImportOpenMowerSummary
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &summary))
+	assert.Equal(t, 1, summary.MowingAreas)
+	assert.Equal(t, 1, summary.NavigationAreas)
+	assert.Equal(t, 1, summary.Obstacles, "WorkingArea[0].Obstacles[0] should re-attach to its parent")
+	assert.Equal(t, 0, summary.OrphanObstacles)
+	require.NotNil(t, summary.DockPose)
+}
+
 // --- helpers --------------------------------------------------------------
 
 // contains is a tiny substring helper to keep the assertions readable


### PR DESCRIPTION
## Summary
Lets users import OpenMower 1.x maps that were exported as JSON via the bag-derived path (PascalCase \`NavigationAreas\` / \`WorkingArea\` / scalar \`DockX\`/\`DockY\`/\`DockHeading\` with \`Package: 0\` envelopes everywhere), not just the modern \`map.json\` shape.

The import handler previously 400'd on these payloads because the bare-form probe only matched \`areas\` / \`docking_stations\`.

## What changed
- \`tryConvertLegacyOpenMowerMap\` rewrites the legacy payload to the modern shape before the rest of the pipeline runs. WorkingArea → mow areas, nested Obstacles → top-level type="obstacle" (re-parented by centroid), NavigationAreas → nav areas, scalar dock → \`docking_stations[0]\`.
- Wrapped form (\`{"map": ..., "om_datum_*": ...}\`) is handled too — conversion runs after the wrapper is unwrapped.
- Tests: 3 new (\`LegacyBareForm\`, \`LegacyWrappedForm\`, \`LegacyBagPreview\`). All existing tests still pass.

## Verified on
Daisy's 2026-05-15 sample (3 WorkingArea + 1 NavigationArea + 1 obstacle + scalar dock): preview returns \`mowing=3, nav=1, obstacles=1 (re-parented), orphans=0, dock=(-2.777, 1.688) yaw=-77°\`.

## Test plan
- [x] \`go test ./pkg/api/ -run "Legacy|TestParseImport|TestPostImport|TestBuild|TestCompute"\` — all pass
- [ ] Import the same JSON via the GUI's "Import from OpenMower" action, confirm the preview modal renders the right area / dock counts