### PR TITLE
fix(unicore): bump UM982_SHA to pick up GSV freshness window fix

### DIFF
--- a/sensors/unicore/Dockerfile
+++ b/sensors/unicore/Dockerfile
@@ -11,7 +11,7 @@ ARG UM982_REF=main
 # Bump UM982_SHA to bust the docker layer cache when the fork moves.
 # `git clone --branch` is cacheable per ARG value, so without a SHA
 # pin we rebuild against stale code.
-ARG UM982_SHA=8b9e25e6027039a52f6fc4d6932678b422084ffa
+ARG UM982_SHA=f2c8776fd8882607f3259740c82c60b5c58246e4
 
 FROM ros:kilted-ros-base AS builder
 


### PR DESCRIPTION
## Summary
Bumps `UM982_SHA` to `f2c8776` — the merge commit of [cedbossneo/unicore-ros2#2](https://github.com/cedbossneo/unicore-ros2/pull/2).

Upstream change: `gps_satellites_status()` now uses `satellite_diag_timeout_sec_` (5 s default) for the GSV burst freshness check, instead of the 1 s default. This eliminates the `constellations_used: GPS=8/0, GLO=6/0, … ↔ GPS=0/0, GLO=0/0, …` alternation observed in the GUI (visible `used/visible = 22/27 ↔ 22/0` flipping every diagnostic tick), caused by phase drift between 1 Hz GSV bursts and the 1 Hz diagnostic tick landing them just outside the original 1 s freshness window.

## Test plan
- [x] `docker build sensors/unicore/` succeeds against the bumped SHA.
- [ ] On-hardware: confirm `constellations_used` populated counts persist across consecutive 1 Hz diagnostic ticks; no more `22/27 ↔ 22/0` flicker in the GUI's GPS satellites panel.