### PR TITLE
fix(gps): bump ublox_dgnss SHA to reopen FD on USB hot-disconnect

### DIFF
--- a/sensors/gps/Dockerfile
+++ b/sensors/gps/Dockerfile
@@ -22,13 +22,19 @@
 FROM ros:kilted-ros-base AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG UBLOX_DGNSS_REF=feat/serial-transport
+ARG UBLOX_DGNSS_REF=fix/serial-reconnect-on-eio
 # Bump UBLOX_DGNSS_SHA to the current branch tip to bust the docker
 # layer cache when upstream moves. `git clone --branch` accepts only
 # branch/tag names so we clone shallow then checkout the pinned SHA;
 # the SHA also ensures cache-from doesn't reuse a stale layer when
 # the branch moves under us (which is what we hit on 2026-04-26).
-ARG UBLOX_DGNSS_SHA=d768ee4fbeaa0ddcb952298c1b8bfc07fe325995
+# Currently riding the fix/serial-reconnect-on-eio branch (PR
+# cedbossneo/ublox_dgnss#1) so the driver reopens the CDC ACM FD
+# when the F9P briefly disconnects from USB and re-enumerates on a
+# different ttyACM minor — without this we ended up stuck spamming
+# "RTCM write failed: serial write errno=5" until docker restart.
+# Switch back to feat/serial-transport once #1 lands.
+ARG UBLOX_DGNSS_SHA=80dd8db96e1e72d083a983305ef39b27fd74dd6f
 # cedbossneo fork (itself a fork of privatedocs000/ublox_dgnss). Layered
 # customisations over upstream:
 #   * privatedocs000 base — RTK-Fixed detection via UBX-NAV-STATUS.carr_soln:


### PR DESCRIPTION
## Summary

- Bumps `UBLOX_DGNSS_SHA` in `sensors/gps/Dockerfile` to pull in [cedbossneo/ublox_dgnss#1](https://github.com/cedbossneo/ublox_dgnss/pull/1), which adds reopen-on-disconnect logic to the serial transport of the F9P driver.
- Pinned to branch `fix/serial-reconnect-on-eio` (SHA `80dd8db`) until #1 merges back into `feat/serial-transport`.
- Throttles the `RTCM write failed` warning to once per 2 s on the driver side as a bonus, so log rotation doesn't bury the original disconnect cause.

## Why

Today's symptom on the mower (observed 2026-05-16 in `mowgli-gps` logs over the last 36 h):

```
[WARN] [ublox_dgnss]: RTCM write failed: serial write errno=5
```

…spamming continuously at ~17 Hz, the entire log buffer wrapped to this single line. `docker restart mowgli-gps` is the only way back to RTK Fixed.

Confirmed root cause from `dmesg` + `/proc/<pid>/fd`:

- `2026-05-15 15:48:23` — `usb 6-1: USB disconnect, device number 2` (F9P hot-disconnected for ~2 s)
- 2 s later it re-enumerated as `/dev/ttyACM2`, but `ublox_dgnss_node` was still holding `/dev/ttyACM1 (deleted)`
- Every RTCM write since returns `errno=EIO` (kernel says "device gone"); no RTCM reaches the F9P → no RTK Fixed

The fix is in the driver — patched read loop now picks up a reopen flag set by the writer, closes the orphan FD, and re-`open()`s the by-id symlink (which udev has already pointed at the new minor).

## Test plan

- [x] Driver patch builds clean against `ros:kilted-ros-base`
- [ ] CI builds `:main` GPS image with the new SHA
- [ ] On the robot, unplug the F9P USB for 2 s and confirm `/odometry/filtered_map` returns to RTK-Fixed σ within ~10 s without `docker restart mowgli-gps`

## Follow-up

Once cedbossneo/ublox_dgnss#1 is merged back into `feat/serial-transport`, revert `UBLOX_DGNSS_REF` to `feat/serial-transport` and bump `UBLOX_DGNSS_SHA` to that branch tip.