### PR TITLE
feat(import): activate OpenMower map.json apply path

### DIFF
--- a/docs/IMPORT_OPENMOWER_MAP.md
+++ b/docs/IMPORT_OPENMOWER_MAP.md
@@ -1,12 +1,13 @@
 # Importing an OpenMower map into MowgliNext
 
-> **Status: scaffolded preview, write path stubbed.**
-> The Go importer parses + validates and the React UI shows a confirmation
-> modal, but the write step (`/map_server_node/clear_map` → `add_area` →
-> `save_areas` + `set_docking_point`) is intentionally disabled while we
-> work out the open questions in the last section. See
-> `gui/pkg/api/openmower_import.go` and the **Import OpenMower** action
-> wired into `MapPage.tsx`.
+> **Status: live for `map.json`.** Apply runs
+> `/map_server_node/clear_map` → `add_area` ×N → `save_areas` →
+> `set_docking_point`. Triggered from **More menu → Import from
+> OpenMower** on the map page. `.bag` is still designed-only (§6).
+> Implementation: `gui/pkg/api/openmower_import.go::applyImport`
+> (shares `replaceMapInternal` + `setDockingPointInternal` from
+> `mowglinext.go`) and the React modal at
+> `gui/web/src/pages/map/components/ImportOpenMowerModal.tsx`.
 
 This document specifies how a user can take a pre-existing OpenMower
 1.x deployment (one of the many garden setups out there) and bring its
@@ -244,23 +245,17 @@ can decide whether to confirm.
 
 ---
 
-## 5. Open questions / edge cases
+## 5. Decisions taken when flipping the write path live
 
-These are the things to weigh in on before flipping the write path
-live:
-
-1. **Datum mismatch is silent today.** The current scaffold defaults
-   to "same datum" if the user doesn't supply one, which will look
-   correct but plant the entire lawn 100s of metres off in the
-   different-datum case. Options:
-   - (a) make `om_datum_lat`/`om_datum_lon` **required** on the upload;
-     UI prompts for them.
-   - (b) infer from the dock — if both maps have a dock pose, derive
-     the datum offset from the difference between the existing
-     MowgliNext dock pose and the OpenMower one. Heuristic, but no
-     extra UX.
-   - (c) ship as-is and rely on the existing **Map offset** panel.
-   The current scaffold leaves a TODO in `applyDatumShift`.
+1. **Datum mismatch.** Shipped option (c) from the original tradeoffs:
+   no UI for `om_datum_lat`/`om_datum_lon` yet — the preview modal
+   surfaces the computed datum shift loudly ("Datum shift:
+   east=X m, north=Y m") and the per-area approximate-area column.
+   Combined with the **Map offset / bearing** panel as the manual
+   escape hatch, that is enough to catch obvious frame mismatches
+   before the user clicks Apply. If field experience says otherwise,
+   option (a) (require the OpenMower datum on upload) is a small
+   addition.
 
 2. **Dock yaw convention.** Both stacks use `yaw = atan2(north, east)`,
    so the heading is portable. But OpenMower stores the heading as a
@@ -286,16 +281,19 @@ live:
    drafts in OpenMower are almost always half-recorded sessions the
    user abandoned.
 
-6. **Replace vs merge.** The current scaffold previews-only. When the
-   write path goes live, the default action is **replace** (clear all
-   existing MowgliNext areas, write the imported set). A **merge**
-   mode (append OpenMower areas to existing MowgliNext areas) is
-   technically just skipping the `clear_map` call — easy to add but
-   risks duplicate areas.
+6. **Replace vs merge.** Shipped **replace-only**: Apply calls
+   `clear_map` before adding the imported areas, matching the
+   semantics of the regular *Save* button. Merge mode is a one-line
+   change (skip `clear_map`) but is gated on a real use case — the
+   risk of silent duplicate areas wasn't worth the toggle.
 
-7. **Backup before import.** Strongly recommend the GUI auto-trigger
-   the existing `handleBackupMap` to stash the current MowgliNext map
-   before the user confirms an import. Not yet wired.
+7. **Backup before import.** Not auto-triggered. The modal's confirm
+   alert tells the user to use **Backup Map** (already in the same
+   More menu) first if they want a rollback file; we did not wire an
+   automatic browser-side download into the Apply path because
+   producing a sidecar file as a side-effect of clicking Apply is
+   surprising. If incident rate justifies it later, the change is
+   ~5 lines (call `handleBackupMap` from the modal's `onApply`).
 
 ---
 
@@ -358,11 +356,19 @@ path; the UI shows a "coming soon" notification when the user picks a
 ## 7. Files
 
 - `gui/pkg/api/openmower_import.go` — Gin handler, JSON parse,
-  validation, structured preview log. `applyImport()` is stubbed.
+  validation, structured preview log, live `applyImport()` calling the
+  shared write helpers.
+- `gui/pkg/api/mowglinext.go` — `replaceMapInternal` +
+  `setDockingPointInternal` shared between the public PUT/POST
+  endpoints and the importer.
 - `gui/pkg/api/openmower_import_test.go` — fixture-driven parse +
-  validation tests.
-- `gui/web/src/pages/MapPage.tsx` — wires an "Import from OpenMower"
-  action into the More menu.
+  validation tests, plus an apply-path test that asserts the
+  clear_map → add_area×N → save_areas → set_docking_point sequence.
+- `gui/web/src/pages/MapPage.tsx` — stashes the uploaded file text,
+  wires the modal's `onApply` to `handleApplyOpenMowerImport`.
 - `gui/web/src/pages/map/hooks/useMapFiles.ts` — adds
-  `handleImportOpenMower` (file picker + POST + preview modal).
+  `handleImportOpenMower` (preview) + `handleApplyOpenMowerImport`
+  (re-POST with `apply: true`).
+- `gui/web/src/pages/map/components/ImportOpenMowerModal.tsx` —
+  preview + apply UI with loading / error states.
 - `docs/IMPORT_OPENMOWER_MAP.md` — this file.

--- a/gui/pkg/api/mowglinext.go
+++ b/gui/pkg/api/mowglinext.go
@@ -124,6 +124,41 @@ func ClearMapRoute(group *gin.RouterGroup, provider types.IRosProvider) {
 	})
 }
 
+// replaceMapInternal is the ROS-side flow shared by the public PUT
+// handler and the OpenMower importer. It does clear_map → add_area×N →
+// save_areas; the wrapping (HTTP body decode / response codes) is the
+// caller's job.
+//
+// The save_areas error is annotated so callers can distinguish a
+// partial-success (areas live but not persisted to disk) from a hard
+// failure earlier in the sequence.
+func replaceMapInternal(ctx context.Context, provider types.IRosProvider, req *mowgli.ReplaceMapReq) error {
+	if req == nil {
+		return errors.New("replaceMapInternal: nil request")
+	}
+	if err := provider.CallService(ctx, "/map_server_node/clear_map", &mowgli.ClearMapReq{}, &mowgli.ClearMapRes{}, "std_srvs/srv/Trigger"); err != nil {
+		return err
+	}
+	for _, element := range req.Areas {
+		// Ensure Obstacles is an empty slice, not nil — the bridge rejects
+		// null for repeated fields ("msg is not a list type").
+		if element.Area.Obstacles == nil {
+			element.Area.Obstacles = []geometry.Polygon{}
+		}
+		areaReq := mowgli.AddMowingAreaReq{
+			Area:             element.Area,
+			IsNavigationArea: element.IsNavigationArea,
+		}
+		if err := provider.CallService(ctx, "/map_server_node/add_area", &areaReq, &mowgli.AddMowingAreaRes{}, "mowgli_interfaces/srv/AddMowingArea"); err != nil {
+			return err
+		}
+	}
+	if err := provider.CallService(ctx, "/map_server_node/save_areas", &mowgli.ClearMapReq{}, &mowgli.ClearMapRes{}, "std_srvs/srv/Trigger"); err != nil {
+		return fmt.Errorf("areas added but save_areas failed: %w", err)
+	}
+	return nil
+}
+
 // ReplaceMapRoute clear the map and insert areas
 //
 // @Summary Delete the current map and replace all areas
@@ -140,44 +175,27 @@ func ReplaceMapRoute(group *gin.RouterGroup, provider types.IRosProvider) {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
 		defer cancel()
 
-		err := provider.CallService(ctx, "/map_server_node/clear_map", &mowgli.ClearMapReq{}, &mowgli.ClearMapRes{}, "std_srvs/srv/Trigger")
-		if err != nil {
-			c.JSON(500, ErrorResponse{Error: err.Error()})
-			return
-		}
-
 		var CallReq mowgli.ReplaceMapReq
-		err = unmarshalROSMessage[*mowgli.ReplaceMapReq](c.Request.Body, &CallReq)
-		if err != nil {
+		if err := unmarshalROSMessage[*mowgli.ReplaceMapReq](c.Request.Body, &CallReq); err != nil {
 			c.JSON(500, ErrorResponse{Error: err.Error()})
 			return
 		}
-		for _, element := range CallReq.Areas {
-			// Ensure Obstacles is an empty slice, not nil — the bridge
-			// rejects null for repeated fields ("msg is not a list type").
-			if element.Area.Obstacles == nil {
-				element.Area.Obstacles = []geometry.Polygon{}
-			}
-			areaReq := mowgli.AddMowingAreaReq{
-				Area:             element.Area,
-				IsNavigationArea: element.IsNavigationArea,
-			}
-			err = provider.CallService(ctx, "/map_server_node/add_area", &areaReq, &mowgli.AddMowingAreaRes{}, "mowgli_interfaces/srv/AddMowingArea")
-			if err != nil {
-				c.JSON(500, ErrorResponse{Error: err.Error()})
-				return
-			}
-		}
-
-		// Persist areas to disk so they survive container restarts
-		err = provider.CallService(ctx, "/map_server_node/save_areas", &mowgli.ClearMapReq{}, &mowgli.ClearMapRes{}, "std_srvs/srv/Trigger")
-		if err != nil {
-			c.JSON(500, ErrorResponse{Error: fmt.Sprintf("areas added but save_areas failed: %v", err)})
+		if err := replaceMapInternal(ctx, provider, &CallReq); err != nil {
+			c.JSON(500, ErrorResponse{Error: err.Error()})
 			return
 		}
-
 		c.JSON(200, OkResponse{})
 	})
+}
+
+// setDockingPointInternal is the ROS-side call shared by the public
+// POST handler and the OpenMower importer. Single service round-trip,
+// no wrapping logic.
+func setDockingPointInternal(ctx context.Context, provider types.IRosProvider, req *mowgli.SetDockingPointReq) error {
+	if req == nil {
+		return errors.New("setDockingPointInternal: nil request")
+	}
+	return provider.CallService(ctx, "/map_server_node/set_docking_point", req, &mowgli.SetDockingPointRes{}, "mowgli_interfaces/srv/SetDockingPoint")
 }
 
 // SetDockingPointRoute set the docking point
@@ -197,16 +215,15 @@ func SetDockingPointRoute(group *gin.RouterGroup, provider types.IRosProvider) {
 		defer cancel()
 
 		var CallReq mowgli.SetDockingPointReq
-		err := unmarshalROSMessage[*mowgli.SetDockingPointReq](c.Request.Body, &CallReq)
-		if err != nil {
+		if err := unmarshalROSMessage[*mowgli.SetDockingPointReq](c.Request.Body, &CallReq); err != nil {
+			c.JSON(500, ErrorResponse{Error: err.Error()})
 			return
 		}
-		err = provider.CallService(ctx, "/map_server_node/set_docking_point", &CallReq, &mowgli.SetDockingPointRes{}, "mowgli_interfaces/srv/SetDockingPoint")
-		if err != nil {
+		if err := setDockingPointInternal(ctx, provider, &CallReq); err != nil {
 			c.JSON(500, ErrorResponse{Error: err.Error()})
-		} else {
-			c.JSON(200, OkResponse{})
+			return
 		}
+		c.JSON(200, OkResponse{})
 	})
 }
 

--- a/gui/pkg/api/openmower_import.go
+++ b/gui/pkg/api/openmower_import.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/cedbossneo/mowglinext/pkg/msgs/geometry"
 	"github.com/cedbossneo/mowglinext/pkg/msgs/mowgli"
@@ -499,7 +501,7 @@ func buildMowgliNextPayload(omMap openMowerMap, shiftE, shiftN float64) (*mowgli
 		}
 		dockReq = &mowgli.SetDockingPointReq{
 			DockingPose: geometry.Pose{
-				Position: geometry.Point{X: d.Position.X + shiftE, Y: d.Position.Y + shiftN, Z: 0},
+				Position:    geometry.Point{X: d.Position.X + shiftE, Y: d.Position.Y + shiftN, Z: 0},
 				Orientation: yawToQuaternion(d.Heading),
 			},
 		}
@@ -509,21 +511,40 @@ func buildMowgliNextPayload(omMap openMowerMap, shiftE, shiftN float64) (*mowgli
 	return replaceReq, dockReq
 }
 
-// applyImport is the **stub** write path. It intentionally does NOT
-// call /map_server_node/clear_map / add_area / save_areas /
-// set_docking_point yet — see docs/IMPORT_OPENMOWER_MAP.md §5 for the
-// open questions that gate flipping this on.
+// applyImport runs the live write path: clear_map → add_area×N →
+// save_areas, then (if a dock pose came through) set_docking_point.
 //
-// The signature is wired so the only change needed to go live is to
-// replace the `log` block with the existing ReplaceMapRoute /
-// SetDockingPointRoute logic (or refactor those into shared callable
-// helpers and invoke them here).
+// Replace-mode only. Mirrors the same service sequence used by the
+// HTTP-driven ReplaceMapRoute + SetDockingPointRoute via the shared
+// helpers in mowglinext.go, so the importer and the regular save path
+// can't drift apart on what "save" means. A failure mid-sequence
+// surfaces as a 500 to the caller; areas already written before the
+// failure stay in `map_server_node`'s in-memory state (the same
+// partial-write semantics the HTTP route has — there is no transaction).
 func applyImport(c *gin.Context, rosProvider types.IRosProvider, replaceReq *mowgli.ReplaceMapReq, dockReq *mowgli.SetDockingPointReq) error {
-	// TODO(import): wire to provider.CallService(... clear_map / add_area
-	//               / save_areas / set_docking_point ...). Mirrors the
-	//               flow in ReplaceMapRoute / SetDockingPointRoute.
-	logImportPreview(ImportOpenMowerSummary{}, replaceReq, dockReq)
-	return errors.New("apply path is currently disabled — see docs/IMPORT_OPENMOWER_MAP.md (preview-only)")
+	if rosProvider == nil {
+		return errors.New("apply: no ROS provider")
+	}
+	if replaceReq == nil {
+		return errors.New("apply: nil replace request")
+	}
+	// Reuse the gin request context for cancellation propagation, but
+	// give the whole sequence its own 30 s budget — same envelope as
+	// ReplaceMapRoute's timeout. save_areas does disk IO; add_area on a
+	// large polygon walk can take ~1 s each.
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+	defer cancel()
+
+	logImportf("import/openmower applying: %d areas, dock=%v", len(replaceReq.Areas), dockReq != nil)
+	if err := replaceMapInternal(ctx, rosProvider, replaceReq); err != nil {
+		return fmt.Errorf("replace map: %w", err)
+	}
+	if dockReq != nil {
+		if err := setDockingPointInternal(ctx, rosProvider, dockReq); err != nil {
+			return fmt.Errorf("set docking point: %w", err)
+		}
+	}
+	return nil
 }
 
 // logImportPreview emits a structured summary of what the import would

--- a/gui/pkg/api/openmower_import_test.go
+++ b/gui/pkg/api/openmower_import_test.go
@@ -288,7 +288,7 @@ func TestPostImportOpenMower_PreviewReturnsSummary(t *testing.T) {
 	assert.Empty(t, mock.ServiceCalls)
 }
 
-func TestPostImportOpenMower_ApplyIsStubbedOff(t *testing.T) {
+func TestPostImportOpenMower_ApplyCallsClearAddSaveAndDock(t *testing.T) {
 	mock := types.NewMockRosProvider()
 	router := setupImportRouter(mock, nil)
 
@@ -298,11 +298,49 @@ func TestPostImportOpenMower_ApplyIsStubbedOff(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	router.ServeHTTP(w, req)
 
-	// Apply path is intentionally disabled — handler should report 500
-	// with the "preview-only" message rather than silently writing.
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var resp ImportOpenMowerSummary
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Applied, "applied flag must be true on the success response")
+
+	// Expected sequence: clear_map → add_area (mow) → add_area (nav) →
+	// save_areas → set_docking_point. The fixture has one mow area
+	// (with one obstacle nested) and one nav area, hence two add_area
+	// calls.
+	services := make([]string, 0, len(mock.ServiceCalls))
+	for _, sc := range mock.ServiceCalls {
+		services = append(services, sc.Service)
+	}
+	assert.Equal(t,
+		[]string{
+			"/map_server_node/clear_map",
+			"/map_server_node/add_area",
+			"/map_server_node/add_area",
+			"/map_server_node/save_areas",
+			"/map_server_node/set_docking_point",
+		},
+		services,
+		"unexpected ROS call sequence",
+	)
+}
+
+func TestPostImportOpenMower_ApplyClearMapErrorPropagates(t *testing.T) {
+	mock := types.NewMockRosProvider()
+	mock.ServiceErr = assert.AnError
+	router := setupImportRouter(mock, nil)
+
+	body := []byte(`{"map": ` + sampleOpenMowerMap + `, "apply": true}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/import/openmower", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
 	require.Equal(t, http.StatusInternalServerError, w.Code, "body=%s", w.Body.String())
-	assert.Contains(t, w.Body.String(), "preview-only")
-	assert.Empty(t, mock.ServiceCalls, "no ROS calls should have fired")
+	// First service call attempted is clear_map and it must abort the rest.
+	require.NotEmpty(t, mock.ServiceCalls)
+	assert.Equal(t, "/map_server_node/clear_map", mock.ServiceCalls[0].Service)
+	assert.Len(t, mock.ServiceCalls, 1, "no further calls after clear_map failure")
 }
 
 func TestPostImportOpenMower_RejectsBadJSON(t *testing.T) {

--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -59,6 +59,10 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
     // OpenMower import preview — populated by handleImportOpenMower after
     // the file is uploaded + parsed server-side. Modal renders when set.
     const [importPreview, setImportPreview] = useState<ImportOpenMowerSummary | null>(null);
+    // Verbatim text of the imported map.json. Stashed at preview time so
+    // the apply step can re-POST byte-identical content (the server then
+    // runs the same parse + validate flow before writing).
+    const [importFileText, setImportFileText] = useState<string | null>(null);
     // Track whether the user actually moved the dock during this edit
     // session. The dock feature is rebuilt from the live /map topic on
     // every render, and saving without this flag would clobber the
@@ -425,6 +429,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
         handleDownloadGeoJSON,
         handleUploadGeoJSON,
         handleImportOpenMower,
+        handleApplyOpenMowerImport,
     } = useMapFiles({
         features,
         setFeatures,
@@ -850,7 +855,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                         onRestoreMap={handleRestoreMap}
                         onDownloadGeoJSON={handleDownloadGeoJSON}
                         onUploadGeoJSON={handleUploadGeoJSON}
-                        onImportOpenMower={() => handleImportOpenMower(setImportPreview)}
+                        onImportOpenMower={() => handleImportOpenMower(setImportPreview, setImportFileText)}
                         onMowArea={(key) => {
                             const item = mowingAreas.find(item => item.key == key)
                             return mowerAction("start_in_area", {
@@ -901,7 +906,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                             onBackupMap={handleBackupMap}
                             onRestoreMap={handleRestoreMap}
                             onDownloadGeoJSON={handleDownloadGeoJSON}
-                            onImportOpenMower={() => handleImportOpenMower(setImportPreview)}
+                            onImportOpenMower={() => handleImportOpenMower(setImportPreview, setImportFileText)}
                             onMowArea={(key) => {
                                 const item = mowingAreas.find(item => item.key == key)
                                 return mowerAction("start_in_area", {
@@ -945,7 +950,16 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
             </div>
             <ImportOpenMowerModal
                 preview={importPreview}
-                onClose={() => setImportPreview(null)}
+                onApply={async () => {
+                    if (!importFileText) {
+                        throw new Error("No imported map text in memory — re-select the file.");
+                    }
+                    await handleApplyOpenMowerImport(importFileText);
+                }}
+                onClose={() => {
+                    setImportPreview(null);
+                    setImportFileText(null);
+                }}
             />
         </div>
     );

--- a/gui/web/src/pages/map/components/ImportOpenMowerModal.tsx
+++ b/gui/web/src/pages/map/components/ImportOpenMowerModal.tsx
@@ -1,49 +1,78 @@
+import {useState} from "react";
 import {Alert, Modal, Statistic, Table, Tag, Typography} from "antd";
 import type {ImportOpenMowerSummary} from "../hooks/useMapFiles.ts";
 
 interface ImportOpenMowerModalProps {
     preview: ImportOpenMowerSummary | null;
+    /**
+     * Apply confirmation. The hook re-POSTs the stashed file body with
+     * `apply: true`; this modal owns the loading + error UI but not the
+     * fetch itself. Returning a rejected promise here surfaces the error
+     * inline (we don't auto-close — the user can read the message and
+     * cancel).
+     */
+    onApply: () => Promise<void>;
     onClose: () => void;
 }
 
 /**
  * Confirmation modal shown after an OpenMower map.json has been parsed
  * server-side. Renders a summary of what *would* be written if the
- * user confirmed — but the confirm button is intentionally disabled in
- * this iteration. See docs/IMPORT_OPENMOWER_MAP.md §5 for the open
- * questions gating the write path.
- *
- * When the apply path goes live this component should:
- *   1. enable the OK button
- *   2. on OK, POST again with `apply: true` and the same body the user
- *      already uploaded
- *   3. on success, refetch the map (parent owns this) and close
+ * user confirms, then runs the live write path on Apply via the
+ * `onApply` callback wired from MapPage / useMapFiles.
  */
-export function ImportOpenMowerModal({preview, onClose}: ImportOpenMowerModalProps) {
+export function ImportOpenMowerModal({preview, onApply, onClose}: ImportOpenMowerModalProps) {
     const open = preview !== null;
     const summary = preview;
+    const [applying, setApplying] = useState(false);
+    const [applyError, setApplyError] = useState<string | null>(null);
+
+    const handleOk = async () => {
+        setApplying(true);
+        setApplyError(null);
+        try {
+            await onApply();
+            // Reset local state before the parent clears `preview`, so
+            // the next import session starts clean.
+            setApplying(false);
+            onClose();
+        } catch (e: any) {
+            setApplyError(e?.message ?? String(e));
+            setApplying(false);
+        }
+    };
+
+    const noMowAreas = (summary?.mowing_areas ?? 0) === 0;
 
     return (
         <Modal
-            title="Import OpenMower map — preview"
+            title="Import OpenMower map"
             open={open}
-            onCancel={onClose}
-            // Apply is intentionally disabled until the design-doc open
-            // questions are resolved (datum mismatch, replace-vs-merge,
-            // backup-before-import). Showing the OK button greyed out
-            // makes the "this is a preview, no writes" state obvious.
-            okText="Apply (disabled — preview only)"
-            okButtonProps={{disabled: true}}
-            cancelText="Close"
+            onCancel={() => {
+                if (applying) return;
+                setApplyError(null);
+                onClose();
+            }}
+            onOk={handleOk}
+            okText={applying ? "Applying…" : "Apply (replaces current map)"}
+            okButtonProps={{
+                disabled: applying || noMowAreas,
+                loading: applying,
+                danger: true,
+            }}
+            cancelButtonProps={{disabled: applying}}
+            cancelText="Cancel"
             width={720}
+            maskClosable={!applying}
+            closable={!applying}
         >
             {!summary ? null : (
                 <div style={{display: "flex", flexDirection: "column", gap: 16}}>
                     <Alert
-                        type="info"
+                        type="warning"
                         showIcon
-                        message="Preview only — nothing has been written yet"
-                        description="The MowgliNext write path is not yet enabled for this importer. Review the parsed contents below; close the modal to discard. See docs/IMPORT_OPENMOWER_MAP.md for the open questions blocking the apply step."
+                        message="Apply replaces the current MowgliNext map"
+                        description="Clicking Apply will clear every existing area and dock pose, then write the areas shown below. Use Backup Map from the More menu first if you want a rollback file."
                     />
 
                     <div style={{display: "flex", gap: 32, flexWrap: "wrap"}}>
@@ -73,6 +102,15 @@ export function ImportOpenMowerModal({preview, onClose}: ImportOpenMowerModalPro
                             type="info"
                             message={`Datum shift: (east=${summary.datum_shift_east_m.toFixed(2)} m, north=${summary.datum_shift_north_m.toFixed(2)} m)`}
                             description="OpenMower coordinates were translated to land in the MowgliNext map frame. If this looks wrong, double-check both datums."
+                        />
+                    ) : null}
+
+                    {noMowAreas ? (
+                        <Alert
+                            type="error"
+                            showIcon
+                            message="No mowing areas in this file"
+                            description="MowgliNext requires at least one mow area. Apply is disabled — close this modal and pick a different map.json."
                         />
                     ) : null}
 
@@ -112,6 +150,15 @@ export function ImportOpenMowerModal({preview, onClose}: ImportOpenMowerModalPro
                                     ))}
                                 </ul>
                             }
+                        />
+                    ) : null}
+
+                    {applyError ? (
+                        <Alert
+                            type="error"
+                            showIcon
+                            message="Apply failed"
+                            description={applyError}
                         />
                     ) : null}
                 </div>

--- a/gui/web/src/pages/map/hooks/useMapFiles.ts
+++ b/gui/web/src/pages/map/hooks/useMapFiles.ts
@@ -236,14 +236,15 @@ export function useMapFiles({
      * an `ImportOpenMowerSummary` which the caller passes to
      * `setImportPreview` so MapPage can render a confirmation modal.
      *
-     * The actual write step is intentionally not invoked here — the
-     * server-side `apply: true` path is also stubbed. Once the open
-     * questions in the design doc are resolved we will:
-     *   1. add a confirm button on the modal that re-POSTs with apply=true
-     *   2. on success, refetch /map and clear the unsaved-changes flag
+     * The picked file body is also stashed via `setImportFileText` so
+     * `handleApplyOpenMowerImport` can re-POST it with `apply: true`
+     * when the user confirms in the modal. Stashing the verbatim text
+     * (instead of re-walking the parsed JSON) keeps the apply payload
+     * byte-identical to what was previewed.
      */
     const handleImportOpenMower = (
         setImportPreview: (preview: ImportOpenMowerSummary | null) => void,
+        setImportFileText: (text: string | null) => void,
     ) => {
         const input = document.createElement("input");
         input.type = "file";
@@ -283,6 +284,7 @@ export function useMapFiles({
                     throw new Error(`HTTP ${res.status}: ${errBody}`);
                 }
                 const summary = (await res.json()) as ImportOpenMowerSummary;
+                setImportFileText(text);
                 setImportPreview(summary);
             } catch (e: any) {
                 notification.error({
@@ -292,6 +294,40 @@ export function useMapFiles({
             }
         });
         input.click();
+    };
+
+    /**
+     * Confirm step of the OpenMower import. Re-POSTs the stashed file
+     * body with `apply: true` so the server runs the same parse +
+     * validate pipeline the user already saw in the preview modal, then
+     * fires clear_map → add_area×N → save_areas → set_docking_point.
+     *
+     * On success the modal closes; `/map` will refresh on its own via
+     * the existing websocket stream — no manual refetch needed. We do
+     * drop the dirty / editMap flags so a previous in-progress local
+     * edit doesn't reappear over the freshly imported areas.
+     */
+    const handleApplyOpenMowerImport = async (importFileText: string): Promise<void> => {
+        if (!importFileText) {
+            throw new Error("no stashed map text — preview must run before apply");
+        }
+        const res = await fetch("/api/import/openmower", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({map: JSON.parse(importFileText), apply: true}),
+        });
+        if (!res.ok) {
+            const errBody = await res.text();
+            throw new Error(`HTTP ${res.status}: ${errBody}`);
+        }
+        // Drop any in-progress edit so the freshly-imported map shows clean.
+        setEditMap(false);
+        setHasUnsavedChanges(false);
+        setDockDirty(false);
+        notification.success({
+            message: "OpenMower map imported",
+            description: "Areas + dock pose written. /map should refresh shortly.",
+        });
     };
 
     const handleUploadGeoJSON = () => {
@@ -371,6 +407,7 @@ export function useMapFiles({
         handleDownloadGeoJSON,
         handleUploadGeoJSON,
         handleImportOpenMower,
+        handleApplyOpenMowerImport,
     };
 }
 


### PR DESCRIPTION
## Summary

- Flips the OpenMower map.json import from preview-only to a live write path.
- Modal **Apply** button is enabled (danger style + replace warning) and runs the server-side `clear_map → add_area×N → save_areas → set_docking_point` sequence — same flow as the existing **Save** button.
- Refactors the ROS-side write logic into `replaceMapInternal` + `setDockingPointInternal` (in `gui/pkg/api/mowglinext.go`) so the regular HTTP routes and the importer can't drift apart on what \"save\" means.
- Frontend stashes the verbatim uploaded file body between preview and apply, so the apply payload is byte-identical to what was previewed.

## Why now

The Go importer + React preview modal have shipped since the scaffold PR — users can already pick a file and see what *would* be written, but the OK button was disabled and the server stub returned `500 preview-only`. That's the longest-standing TODO in `docs/IMPORT_OPENMOWER_MAP.md §5`. This PR closes it.

## Decisions taken on the design-doc's open questions (§5)

| Question | Decision | Rationale |
|---|---|---|
| Datum mismatch handling | No `om_datum_lat/lon` UI yet; preview surfaces the computed shift loudly | The modal already shows `Datum shift: east=X m, north=Y m`. If the value is off by km, the user sees it and cancels. The **Map offset / bearing** panel is the manual escape hatch. |
| Replace vs merge | Replace-only | Matches Save semantics; `clear_map` runs before `add_area`. Merge is a one-line change if/when there's a real use case. |
| Backup before apply | Not auto-triggered | The modal points the user at Backup Map in the same More menu. A side-effect download on Apply is surprising. |

## Test plan

- [x] `go test ./pkg/api/ -run Import` — new apply-path test asserts the exact `clear_map → add_area×N → save_areas → set_docking_point` ROS service sequence, plus the error-propagation test
- [x] `tsc && vite build` clean
- [x] `gofmt -l` clean on touched files
- [ ] On the robot, after `:main` rebuilds: pick a real OpenMower `map.json`, confirm preview shows the same shape it does today, click **Apply**, watch the map refresh on its own through the websocket stream
- [ ] Sad-path probe: `/map_server_node` not running → confirm the Apply error surfaces inline in the modal (instead of silently closing)

## Notes

- The eslint v9 config issue surfaced on `yarn lint` is pre-existing on main, not from this PR. `yarn build` (the gating step in CI) passes.
- Same 6 vitest failures in `MowerStatus.test.tsx` happen on `main` without these changes — flake on the snapshot side, untouched here.

## Files

- `gui/pkg/api/openmower_import.go` — `applyImport` rewired (no more stub error)
- `gui/pkg/api/mowglinext.go` — extracted `replaceMapInternal` + `setDockingPointInternal`
- `gui/pkg/api/openmower_import_test.go` — apply-path + error-propagation tests
- `gui/web/src/pages/map/components/ImportOpenMowerModal.tsx` — enables Apply, adds loading + inline error state
- `gui/web/src/pages/map/hooks/useMapFiles.ts` — adds `handleApplyOpenMowerImport`
- `gui/web/src/pages/MapPage.tsx` — stashes file text, wires `onApply` into the modal
- `docs/IMPORT_OPENMOWER_MAP.md` — updated header + §5 decisions + §7 file list