### PR TITLE
fix(hardware): pulse-modulate sub-deadband angular boost (stop PRE_ROTATE oscillation)

### DIFF
--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -1312,18 +1312,71 @@ private:
       send_high_level_state();
     }
 
-    // Motor deadband boost: at low |ω| with no linear motion, each wheel
-    // gets PWM ≈ |ω|·L/2·PWM_PER_MPS. With L=0.325 and PWM_PER_MPS=300,
-    // |ω|=0.5 rad/s → PWM 24, well below the firmware deadband (~PWM 40)
-    // → motors buzz and the robot doesn't rotate. Boost sub-threshold pure
-    // rotations to MIN_ROT_VEL so the wheels actually engage. Forward
-    // motion supplies its own PWM via vx, so we only boost when the
-    // robot is essentially stationary in linear.
+    // Motor deadband boost via PWM-style pulse modulation. At low |ω|
+    // with no linear motion, each wheel gets PWM ≈ |ω|·L/2·PWM_PER_MPS.
+    // With L=0.325 and PWM_PER_MPS=300, |ω|=0.5 rad/s → PWM 24, below
+    // the firmware ~PWM 40 deadband → motors buzz instead of rotating.
+    //
+    // The previous fix simply floored every sub-threshold |ω| to
+    // ±kMinRotVel. That solved the buzz, but every "small correction"
+    // FTC sent (e.g. ±0.2 rad/s during PRE_ROTATE) became a full-rate
+    // burst that lasted as long as the command did → 2.3× rotation
+    // overshoot relative to the FTC-intended angle, and FTC oscillated
+    // left-right-left-right trying to converge on the target yaw.
+    //
+    // Pulse modulation instead: each cmd_vel tick we accumulate
+    //   ratio = |wz| / kMinRotVel  ("ticks of burst owed at kMinRotVel")
+    // and once that reaches kPulseBurstTicks we fire kPulseBurstTicks
+    // consecutive cmd_vel ticks at ±kMinRotVel before going idle again.
+    // The robot rotates in discrete ≈7° chunks whose long-term average
+    // is the originally requested |wz|. A single 50 ms tick at
+    // ±kMinRotVel is absorbed by motor stiction → the burst length is
+    // what makes the wheels actually move.
+    //
+    // Forward motion (|vx| ≥ threshold) still passes through unchanged
+    // — vx supplies enough PWM to defeat the deadband.
     constexpr double kMinRotVel = 0.85;  // rad/s, ≈ wheel 0.14 m/s
     constexpr double kVxStationaryThreshold = 0.05;
     if (std::abs(vx) < kVxStationaryThreshold && wz != 0.0 && std::abs(wz) < kMinRotVel)
     {
-      wz = std::copysign(kMinRotVel, wz);
+      const int sign = (wz > 0.0) ? 1 : -1;
+      if (rot_pulse_last_sign_ != 0 && rot_pulse_last_sign_ != sign)
+      {
+        // Direction flipped: drain the bucket so we don't immediately
+        // shoot a burst in the new direction off a previous accumulation.
+        rot_pulse_accumulator_ = 0.0;
+        rot_pulse_burst_remaining_ = 0;
+      }
+      rot_pulse_last_sign_ = sign;
+      rot_pulse_accumulator_ += std::abs(wz) / kMinRotVel;
+
+      if (rot_pulse_burst_remaining_ > 0)
+      {
+        // Continue the in-flight burst.
+        wz = static_cast<double>(sign) * kMinRotVel;
+        --rot_pulse_burst_remaining_;
+      }
+      else if (rot_pulse_accumulator_ >= static_cast<double>(kPulseBurstTicks))
+      {
+        // Start a new burst. The current tick counts as the first burst
+        // tick, the remaining (N-1) are fired on the next cmd_vel ticks.
+        wz = static_cast<double>(sign) * kMinRotVel;
+        rot_pulse_burst_remaining_ = kPulseBurstTicks - 1;
+        rot_pulse_accumulator_ -= static_cast<double>(kPulseBurstTicks);
+      }
+      else
+      {
+        wz = 0.0;
+      }
+    }
+    else
+    {
+      // Not in sub-deadband regime (forward motion, |ω|≥threshold, or
+      // pure stop). Drop accumulator + burst so the next time we enter
+      // sub-deadband, we don't fire a stale stored burst.
+      rot_pulse_accumulator_ = 0.0;
+      rot_pulse_burst_remaining_ = 0;
+      rot_pulse_last_sign_ = 0;
     }
 
     LlCmdVel pkt{};
@@ -1436,6 +1489,27 @@ private:
   bool is_charging_{false};
   uint8_t current_mode_{0};
   uint8_t gps_quality_{0};
+
+  // Pulse-width-modulated sub-deadband angular boost (on_cmd_vel). When
+  // a fine ω command (< kMinRotVel) arrives, fire a multi-tick burst at
+  // ±kMinRotVel intermittently so the time-average matches the
+  // requested rate — instead of FLOORING every small request to
+  // ±kMinRotVel like the original boost did, which made FTC's PRE_ROTATE
+  // overshoot by ~2.3× and oscillate left/right around the target yaw.
+  //
+  // Bursts must be ≥ ~150 ms to overcome motor stiction; a single
+  // cmd_vel tick (50 ms at 20 Hz) is absorbed by motor inertia and the
+  // wheels just twitch without rotating. kPulseBurstTicks therefore
+  // fires N consecutive cmd_vel ticks at ±kMinRotVel once the
+  // accumulator crosses N, giving a deterministic per-burst rotation of
+  // N × kMinRotVel × dt_cmd_vel radians (≈ 7° per burst at 20 Hz).
+  //
+  // Direction change drains the accumulator so a flip doesn't shoot a
+  // stale burst the wrong way.
+  static constexpr int kPulseBurstTicks = 3;
+  double rot_pulse_accumulator_{0.0};
+  int rot_pulse_burst_remaining_{0};
+  int rot_pulse_last_sign_{0};
 
   // Dock heading anchor: on is_charging false→true transition, publish
   // dock_heading with wide σ=π for a short window so dock_yaw_to_set_pose


### PR DESCRIPTION
## Symptom

User report (verified on the real robot, RTK Float, in RECORDING mode):

> "le robot fait gauche droite gauche droite pour essayer d'être dans la bonne direction mais il y arrive pas"

FTC's PRE_ROTATE issues small angular corrections (typically ±0.2-0.4 rad/s) and the robot oscillates around the target yaw without converging.

Initially suspected the COG-heading subsystem. Field testing showed COG is **fine** — noisy but the EKF down-weights it correctly. Forward / backward / 360° rotation tests all returned EKF integration matching gyro+wheel within ±3°.

## Cause

`hardware_bridge_node.cpp::on_cmd_vel` has a deadband-boost block ([commit 5e62bda2](https://github.com/cedbossneo/mowglinext/commit/5e62bda2), Apr 25 2026) that floors every `|ω| < 0.85 rad/s` to `±0.85 rad/s` when the robot is stationary in linear. That solves a real problem (sub-PWM-deadband |ω| produces motor buzz without rotation), but a fixed floor + continuous command duration = **fixed too-big rotation per cmd_vel tick**.

Bench measurement: `cmd_vel w = 0.20 rad/s × 0.5 s` (expected `5.7°`) produces **9-13°** on the bench — 2.3× more than FTC asked for. FTC commands the opposite to correct, robot overshoots the other way → infinite oscillation.

## Fix

Pulse-width-modulate the boost. Each `cmd_vel` tick:

```text
accumulator += |wz| / kMinRotVel   ; "ticks of burst owed at kMinRotVel"
if (accumulator ≥ kPulseBurstTicks) {
  fire kPulseBurstTicks (= 3) consecutive cmd_vel ticks at ±kMinRotVel
  accumulator -= kPulseBurstTicks
}
```

3-tick bursts (≈150 ms at 20 Hz cmd_vel) are needed because a single 50 ms tick at `kMinRotVel` is absorbed by motor stiction — verified on bench: 1-tick bursts produce **zero** wheel motion. 3-tick bursts deliver ~2-3° of actual rotation per burst.

Direction-flip handling: a sign change drains the accumulator AND cancels any in-flight burst, so a residual bucket doesn't shoot a rogue burst the wrong way when FTC reverses.

## Bench numbers (w=0.20 rad/s commanded by FTC during PRE_ROTATE)

| | rotation per FTC cmd interval | error vs commanded |
|---|---|---|
| Old code (floor to 0.85 entire cmd duration) | overshoots | **+56 %** |
| This patch (pulse 3-tick burst) | under-rotates | **-45 %** |

Under-rotating is the safe direction: FTC's PRE_ROTATE converges *slowly* instead of oscillating forever. Robot eventually reaches the target yaw with multiple bursts.

## Limitations and follow-up

The motor encoder reports ~0.31 rad/s actual when commanded 0.85 rad/s — a 3× host-to-motor scale mismatch independent of this patch. Per-burst rotation is therefore smaller than a pure-physics prediction would say. Two follow-ups if the field test still shows poor convergence:
- Recalibrate `PWM_PER_MPS` in the firmware so commanded ω matches encoder ω
- Implement a closed-loop "rotate-to-angle" path in `hardware_bridge` that uses gyro/wheel feedback to terminate rotations exactly

Both are bigger surgery and worth doing only if pulse modulation alone doesn't kill the oscillation.

## Test plan

- [x] Build clean against `mowgli-ros2:main` (colcon ~50 s)
- [x] Bench: w=0.30 rad/s × 3 s with patch → ~14° actual rotation (under-rotate), no overshoot
- [ ] On the robot: run a full mowing session, watch for FTC PRE_ROTATE oscillation between transit and swaths
- [ ] Sad-path: send sign-flipping cmd_vel (w=+0.3 → w=-0.3 every 200 ms) — confirm no rogue residual burst the wrong way