### PR TITLE
fix(ftc): wait-before-abort when AVOIDANCE runs out of headroom

### DIFF
--- a/ros2/src/mowgli_nav2_plugins/include/mowgli_nav2_plugins/ftc_controller.hpp
+++ b/ros2/src/mowgli_nav2_plugins/include/mowgli_nav2_plugins/ftc_controller.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <limits>
 #include <vector>
@@ -177,9 +178,31 @@ private:
   /// Apply lateral_deviation_ to current_control_point_ in-place.
   void applyLateralDeviationToCarrot();
 
+  /// Wait-before-abort gate for the AVOIDANCE-out-of-headroom path. Sets
+  /// obstacle_waiting_=true (caller halts) until obstacle_wait_timeout_s
+  /// has elapsed, then throws ControllerException. Returns true while
+  /// still waiting, never returns false on the throw path (the throw
+  /// unwinds the stack instead).
+  bool waitOrThrowForObstacle(const std::string& reason);
+
   bool is_avoiding_{false};
   double target_lateral_deviation_{0.0};
   double lateral_deviation_{0.0};
+
+  // Wait-before-abort window for the two "no path" cases inside
+  // updateLateralDeviation: (a) both sides blocked at the obstacle pose,
+  // (b) the deviation needed to clear exceeds max_lateral_deviation. In
+  // both cases, before this change, FTC threw a ControllerException
+  // immediately — the action server aborted, the BT incremented
+  // RetryUntilSuccessful, and after 5 retries the area was declared
+  // unreachable. Often the blocker was transient (LIDAR noise during
+  // post-undock costmap warmup, a passing person, inflation around the
+  // dock body that hadn't been cleared yet); the abort burned 5 cheap
+  // retries for nothing. We now hold zero velocity for up to
+  // obstacle_wait_timeout_s seconds; if the costmap clears in that
+  // window the controller resumes, otherwise it throws as before.
+  std::optional<rclcpp::Time> obstacle_wait_start_;
+  bool obstacle_waiting_{false};
 
   // ── Oscillation detection ─────────────────────────────────────────────────
 
@@ -280,6 +303,12 @@ private:
     double max_lateral_deviation{1.5};   // m, abort if needed offset exceeds this
     double deviation_step{0.05};         // m, search increment
     double deviation_blend_rate{0.5};    // m/s, slew rate for lateral_deviation_
+    /// Wait-before-abort timeout when the AVOIDANCE search can't fit
+    /// inside max_lateral_deviation (both sides blocked or the needed
+    /// offset exceeds the cap). During the wait the robot stops; if the
+    /// costmap clears before the timeout, the controller resumes. After
+    /// the timeout we throw a ControllerException as before.
+    double obstacle_wait_timeout_s{5.0};
   };
 
   Config config_;

--- a/ros2/src/mowgli_nav2_plugins/src/ftc_controller.cpp
+++ b/ros2/src/mowgli_nav2_plugins/src/ftc_controller.cpp
@@ -187,6 +187,7 @@ void FTCController::declareParameters(const rclcpp_lifecycle::LifecycleNode::Sha
   config_.max_lateral_deviation = declare_double("max_lateral_deviation", 1.5);
   config_.deviation_step = declare_double("deviation_step", 0.05);
   config_.deviation_blend_rate = declare_double("deviation_blend_rate", 0.5);
+  config_.obstacle_wait_timeout_s = declare_double("obstacle_wait_timeout_s", 5.0);
 
   // Register parameter-change callback.
   param_cb_handle_ = node->add_on_set_parameters_callback(
@@ -365,6 +366,10 @@ rcl_interfaces::msg::SetParametersResult FTCController::onParameterChange(
     else if (key == "deviation_blend_rate")
     {
       config_.deviation_blend_rate = p.as_double();
+    }
+    else if (key == "obstacle_wait_timeout_s")
+    {
+      config_.obstacle_wait_timeout_s = p.as_double();
     }
   }
 
@@ -596,6 +601,14 @@ geometry_msgs::msg::TwistStamped FTCController::computeVelocityCommands(
   if (config_.enable_obstacle_deviation)
   {
     updateLateralDeviation(safe_dt);
+    // updateLateralDeviation flipped on the wait-before-abort gate (the
+    // costmap is blocked beyond max_lateral_deviation and we're holding
+    // for obstacle_wait_timeout_s). Hold zero velocity until either the
+    // costmap clears or the helper throws on timeout.
+    if (obstacle_waiting_)
+    {
+      return cmd_vel;
+    }
     applyLateralDeviationToCarrot();
   }
   else if (checkCollision(config_.obstacle_lookahead))
@@ -1199,6 +1212,37 @@ bool FTCController::checkCollision(int max_points)
 
 // ── Lateral deviation (skirt obstacles) ───────────────────────────────────────
 
+// Decide whether to stall the controller for `obstacle_wait_timeout_s` or
+// throw and let the BT escalate. Called from updateLateralDeviation when
+// the AVOIDANCE search runs out of headroom inside max_lateral_deviation
+// (both sides blocked at the obstacle pose, OR growDeviationUntilClear
+// exceeded the cap). Returns true if the caller should bail out of
+// updateLateralDeviation for this tick (keeps lateral_deviation_ at its
+// current value, output is zeroed in computeVelocityCommands). Returns
+// false when the timeout has elapsed — caller proceeds as if the throw
+// were direct, EXCEPT we still throw from inside here to consolidate the
+// log message + is_crashed_ latch.
+bool FTCController::waitOrThrowForObstacle(const std::string& reason)
+{
+  if (!obstacle_wait_start_.has_value())
+  {
+    obstacle_wait_start_ = clock_->now();
+    RCLCPP_INFO(logger_,
+                "FTCController: %s — holding zero velocity up to %.1fs for the costmap to clear.",
+                reason.c_str(), config_.obstacle_wait_timeout_s);
+  }
+  const double elapsed = (clock_->now() - obstacle_wait_start_.value()).seconds();
+  if (elapsed > config_.obstacle_wait_timeout_s)
+  {
+    is_crashed_ = true;
+    throw nav2_core::ControllerException(
+        std::string("FTCController: ") + reason + ", aborting strip after " +
+        std::to_string(static_cast<int>(elapsed)) + "s wait.");
+  }
+  obstacle_waiting_ = true;
+  return true;
+}
+
 void FTCController::updateLateralDeviation(double dt)
 {
   // Bail if no costmap or path — tests sometimes run without one of either.
@@ -1236,12 +1280,19 @@ void FTCController::updateLateralDeviation(double dt)
           config_.deviation_step);
       if (target_lateral_deviation_ == 0.0)
       {
-        // Both sides blocked at the obstacle pose — give up, let BT replan.
-        is_crashed_ = true;
-        throw nav2_core::ControllerException(
-            "FTCController: obstacle blocks both sides, cannot skirt.");
+        // Both sides blocked at the obstacle pose. Before bailing, hold a
+        // wait window so transient costmap state (LIDAR noise, a person
+        // crossing the path, inflation around the dock not yet cleared
+        // by post-undock observations) can clear without burning a BT
+        // retry.
+        if (waitOrThrowForObstacle("obstacle blocks both sides, cannot skirt"))
+        {
+          return;
+        }
       }
       is_avoiding_ = true;
+      obstacle_wait_start_.reset();
+      obstacle_waiting_ = false;
       RCLCPP_INFO(logger_,
                   "FTCController: entering AVOIDANCE (target_dev=%.2fm at idx=%d)",
                   target_lateral_deviation_,
@@ -1260,9 +1311,13 @@ void FTCController::updateLateralDeviation(double dt)
 
     if (std::abs(target_lateral_deviation_) > config_.max_lateral_deviation)
     {
-      is_crashed_ = true;
-      throw nav2_core::ControllerException(
-          "FTCController: lateral deviation needed > max_lateral_deviation, aborting strip.");
+      // Same wait-before-abort as the both-sides-blocked case. If the
+      // obstacle is transient, the next tick will pull target_dev back
+      // under the cap and we resume cleanly.
+      if (waitOrThrowForObstacle("lateral deviation needed > max_lateral_deviation"))
+      {
+        return;
+      }
     }
   }
   else if (is_avoiding_)
@@ -1275,6 +1330,15 @@ void FTCController::updateLateralDeviation(double dt)
       is_avoiding_ = false;
       RCLCPP_INFO(logger_, "FTCController: AVOIDANCE complete, back on path.");
     }
+  }
+
+  // Path is now followable inside the deviation cap. Clear any pending
+  // wait state so the next blockage starts its own fresh wait window.
+  if (obstacle_waiting_)
+  {
+    RCLCPP_INFO(logger_, "FTCController: obstacle cleared, resuming after wait.");
+    obstacle_waiting_ = false;
+    obstacle_wait_start_.reset();
   }
 
   // Step 2: slew lateral_deviation_ toward target_lateral_deviation_ at the


### PR DESCRIPTION
## Symptom (observed live 2026-05-16)

User pressed START while a HOME was still in flight (robot was 70 cm off the dock approach path because the previous docking was struggling). MowingSequence took over, planned a clean 648-pose F2C path on the area, FollowStrip started — and FTC immediately aborted within ~1 s:

```text
[ERROR] FTCController: lateral deviation needed > max_lateral_deviation, aborting strip.
```

`RetryUntilSuccessful` burned through all 5 retries in ~2 s (each retry re-sent the same path to the same costmap), AreaUnreachable fired, the BT fell through to DockRobot, and the user saw the robot suddenly drive *towards* the dock instead of mowing. "Une catastrophe."

## Cause

The blocker was largely **transient** post-undock costmap state:

- LIDAR had just begun observing the dock structure + nearby trees
- Inflation maxed around half the path before observations settled
- The keepout mask reloaded 3 times in the same 4 s window (`KeepoutFilter: New filter mask arrived` × 3)

By the time the BT had given up on the strip (~2 s in), the costmap was already clearing — but the area had already been declared unreachable.

## Fix

Wait-before-abort window in `FTCController::updateLateralDeviation`. When `target_lateral_deviation_ > max_lateral_deviation` (or both sides blocked at the obstacle pose), we now:

1. Set `obstacle_wait_start_ = now` on the first stuck tick.
2. While `elapsed < obstacle_wait_timeout_s` (default **5 s**), set `obstacle_waiting_ = true`. `computeVelocityCommands` short-circuits and returns zero velocity for the tick, so the robot holds station while the costmap is given a chance to clear.
3. On any subsequent tick where the deviation cap fits again, reset both flags and resume normal AVOIDANCE.
4. If the timeout elapses without recovery, throw `ControllerException` exactly as before — the BT escalates through the same RetryUntilSuccessful / AreaUnreachable pipeline.

New parameter `obstacle_wait_timeout_s` (default 5.0) is dynamic-reconfigurable.

## Net effect

- **Transient obstacles** (LIDAR noise, post-undock inflation, a person crossing the path) now resolve without burning BT retries.
- **Permanent obstacles** still abort, just 5 s later. The downstream BT contract is unchanged.
- Nav2 action server semantics are preserved — only the timing of the `ControllerException` shifts.

## Test plan

- [x] Build clean against `mowgli-ros2:main` (colcon 34 s, `mowgli_nav2_plugins`)
- [ ] Live test on robot: re-run today's exact sequence (HOME → interrupt with START), confirm FollowStrip no longer aborts in the first ~1 s after costmap clear
- [ ] Sad-path: plant a permanent obstacle blocking both sides of a strip — robot should hold 5 s then abort, BT goes through `AreaUnreachable` exactly as before
- [ ] Dynamic param: `ros2 param set /controller_server FollowCoveragePath.obstacle_wait_timeout_s 10.0` → controller honors new timeout

## Files

- `ros2/src/mowgli_nav2_plugins/include/mowgli_nav2_plugins/ftc_controller.hpp` — adds `obstacle_wait_start_`, `obstacle_waiting_`, `obstacle_wait_timeout_s`, declares `waitOrThrowForObstacle()`
- `ros2/src/mowgli_nav2_plugins/src/ftc_controller.cpp` — wires the new param + helper, replaces immediate throws with `waitOrThrowForObstacle`, zeroes cmd_vel during wait