### PR TITLE
fix(hardware): pulse-modulate sub-deadband linear vx (final dock approach)

### DIFF
--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -1379,6 +1379,55 @@ private:
       rot_pulse_last_sign_ = 0;
     }
 
+    // Same PWM-style pulse modulation, applied to the linear axis. The
+    // motivation is symmetric: at vx < kMinLinVel both wheels' PWM
+    // commands fall under the firmware deadband (PWM_PER_MPS * vx <
+    // ~40), so FTC's slow final-approach commands during DockRobot
+    // WAITING_FOR_GOAL_APPROACH ended up with the wheels not engaging
+    // at all — the robot would park 15-25 cm out from the dock
+    // staging pose and `max_goal_distance_error=0.10m` would abort,
+    // forever. Gated on |wz| being small too: a combined small vx +
+    // big wz is the existing angular case (handled above), and a
+    // medium |wz| is left as a pass-through because the wheel
+    // differential then puts at least one wheel above the deadband
+    // naturally.
+    constexpr double kMinLinVel = 0.13;            // m/s, ≈ PWM 40
+    constexpr double kWzStationaryThreshold = 0.10;  // rad/s
+    if (std::abs(wz) < kWzStationaryThreshold && vx != 0.0 &&
+        std::abs(vx) < kMinLinVel)
+    {
+      const int sign = (vx > 0.0) ? 1 : -1;
+      if (lin_pulse_last_sign_ != 0 && lin_pulse_last_sign_ != sign)
+      {
+        lin_pulse_accumulator_ = 0.0;
+        lin_pulse_burst_remaining_ = 0;
+      }
+      lin_pulse_last_sign_ = sign;
+      lin_pulse_accumulator_ += std::abs(vx) / kMinLinVel;
+
+      if (lin_pulse_burst_remaining_ > 0)
+      {
+        vx = static_cast<double>(sign) * kMinLinVel;
+        --lin_pulse_burst_remaining_;
+      }
+      else if (lin_pulse_accumulator_ >= static_cast<double>(kPulseBurstTicks))
+      {
+        vx = static_cast<double>(sign) * kMinLinVel;
+        lin_pulse_burst_remaining_ = kPulseBurstTicks - 1;
+        lin_pulse_accumulator_ -= static_cast<double>(kPulseBurstTicks);
+      }
+      else
+      {
+        vx = 0.0;
+      }
+    }
+    else
+    {
+      lin_pulse_accumulator_ = 0.0;
+      lin_pulse_burst_remaining_ = 0;
+      lin_pulse_last_sign_ = 0;
+    }
+
     LlCmdVel pkt{};
     pkt.type = PACKET_ID_LL_CMD_VEL;
     pkt.linear_x = static_cast<float>(vx);
@@ -1510,6 +1559,21 @@ private:
   double rot_pulse_accumulator_{0.0};
   int rot_pulse_burst_remaining_{0};
   int rot_pulse_last_sign_{0};
+
+  // Same scheme on the linear axis: vx commands below ~0.13 m/s (= PWM
+  // 40 / PWM_PER_MPS 300) are eaten by the firmware's PWM deadband on
+  // both wheels, so the controller can't drive a "fine" final-approach
+  // motion when the integrated error is < 15 cm. FTC's DockRobot
+  // WAITING_FOR_GOAL_APPROACH was burning retries on this — robot
+  // parked ~15 cm out from the staging pose because nothing under
+  // kMinLinVel actually rolls the wheels. We pulse-modulate vx the
+  // same way wz is handled above: accumulate fractional ticks of
+  // burst owed at kMinLinVel; fire 3-tick bursts; output zero
+  // otherwise. Long-term average matches the requested vx, and each
+  // burst is long enough to overcome stiction.
+  double lin_pulse_accumulator_{0.0};
+  int lin_pulse_burst_remaining_{0};
+  int lin_pulse_last_sign_{0};
 
   // Dock heading anchor: on is_charging false→true transition, publish
   // dock_heading with wide σ=π for a short window so dock_yaw_to_set_pose


### PR DESCRIPTION
## Symptom (observed live 2026-05-17)

After PR #221 (angular pulse modulation) + PR #222 (FTC wait-before-abort) shipped, a full mowing run was attempted with the post-merge :main image. The undock + initial mowing went well — pulse modulation kept PRE_ROTATE from oscillating, FTC wait-before-abort kicked in once at t=77 s and recovered cleanly from a transient costmap obstacle.

But on the return-to-dock, the robot got stuck **1.5 m in front of the dock** (user observation), with FTC repeatedly aborting on:

```text
FTCController: WAITING_FOR_GOAL_APPROACH (dist=0.159m > max_goal_distance_error=0.100m); aborting strip.
```

Path of 4 poses sent, robot rotates a few degrees, FTC aborts on goal-tolerance, new 4-pose path sent, repeat forever. Position oscillated 5-10 cm without converging.

## Cause

fusion_graph reports sub-cm precision (cov_xx ≈ 0, cov_yy = 0.0001), so localization is **not** the issue. The bottleneck is below the localizer: FTC's fine final-approach commands sit at `vx ≈ 0.05 m/s`, which translates to PWM = 0.05 × 300 (PWM_PER_MPS) = 15 — well under the firmware's ~PWM 40 deadband on each wheel. The wheels never engage, the robot can't close the last 15 cm of gap, the BT bounces on WAITING_FOR_GOAL_APPROACH timeouts forever.

This is the **symmetric sibling** of PR #221, which fixed the same problem on the angular axis. Same root cause (firmware PWM deadband), same physics, same fix.

## Fix

Apply the existing PWM-pulse-modulation pattern to the linear axis. Each cmd_vel tick:

```
ratio = |vx| / kMinLinVel       ; "ticks of burst owed at kMinLinVel"
accumulator += ratio
if accumulator >= kPulseBurstTicks:
    fire kPulseBurstTicks consecutive ticks at ±kMinLinVel
    accumulator -= kPulseBurstTicks
else:
    vx = 0
```

Constants:
- `kMinLinVel = 0.13 m/s` (= firmware PWM deadband 40 / PWM_PER_MPS 300)
- `kPulseBurstTicks = 3` (= ≈150 ms at 20 Hz cmd_vel, long enough to overcome motor stiction)

Per-burst translation: 3 × 0.13 m/s × 0.05 s = **2 cm**. The 10 cm goal tolerance is reachable in a few bursts.

Gating:
- `|wz| < kWzStationaryThreshold (0.10 rad/s)` — don't compete with the angular modulator. A combined small-vx + big-wz scenario falls under the angular regime and is handled there.
- `vx != 0 && |vx| < kMinLinVel` — only fire when the FTC actually requested fine forward motion.
- Direction-flip drains the accumulator so a reversal doesn't fire a stale burst the wrong way.
- The else branch resets state so no stale accumulator carries across regime changes.

## Test plan

- [x] Builds clean against `mowgli-ros2:main`
- [ ] On the robot: re-run the dock approach (CMD=2 from anywhere near the staging pose) and verify the robot now converges to within 10 cm and triggers the SimpleChargingDock final stage instead of looping on WAITING_FOR_GOAL_APPROACH.
- [ ] Sad-path: send a strong reverse vx (-0.30 m/s) followed immediately by +0.05 m/s — confirm accumulator drains on direction flip, no stale forward burst.

## Known gap

Combined-tiny motion: when both `|vx|` and `|wz|` are below their thresholds but vx ≥ kVxStationaryThreshold (= 0.05) OR vice versa, neither modulator fires today and the robot stalls. Not the live scenario above, but documented for follow-up.

## Files

- `ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp` — adds `lin_pulse_accumulator_`, `lin_pulse_burst_remaining_`, `lin_pulse_last_sign_`; new linear pulse block right after the existing angular one in `on_cmd_vel`.