### PR TITLE
tune(mppi): cut batch_size 1500→800, time_steps 40→25 for ARM budget

### DIFF
--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -166,9 +166,15 @@ controller_server:
     # raise once we have a session on the bench to profile.
     FollowPath:
       plugin: "nav2_mppi_controller::MPPIController"
-      time_steps: 40                      # ≈ 2 s horizon at model_dt=0.05
-      model_dt: 0.05
-      batch_size: 1500                    # ARM SoC budget; nav2 default 2000
+      # Field-measured 2026-05-17 (Rockchip RK3588 + Mowgli stack): at
+      # batch_size=1500 + time_steps=40 the control loop ran at 5-19 Hz
+      # instead of the 20 Hz target, and TF extrapolation aborted the
+      # FollowPath action ("Lookup would require extrapolation into the
+      # future"). Cut trajectory count from 1500·40 = 60 k to 800·25 = 20 k
+      # while keeping a comparable 1.5 s horizon (25·0.06 vs 40·0.05).
+      time_steps: 25                      # 1.5 s horizon at model_dt=0.06
+      model_dt: 0.06                      # ≈ control loop tick we can actually hit
+      batch_size: 800                     # 64 % less compute per cycle vs 1500
       vx_std: 0.15
       vy_std: 0.0                         # diff-drive, no lateral
       wz_std: 0.35
@@ -180,7 +186,7 @@ controller_server:
       az_max: 2.0
       iteration_count: 1
       prune_distance: 1.5
-      transform_tolerance: 0.2            # ARM TF jitter envelope
+      transform_tolerance: 0.3            # bumped 0.2→0.3 after ARM extrapolation aborts
       temperature: 0.3
       gamma: 0.015
       motion_model: "DiffDrive"


### PR DESCRIPTION
## Summary
Field-measured fix for MPPI control loop missing rate on ARM hardware (Rockchip RK3588 + Mowgli stack).

## Symptom (session 2026-05-17 post-#225 revert)
Sent CMD=2 HOME from off-dock position. Robot moved briefly, then:

```
controller_server: Control loop missed its desired rate of 20 Hz.
Current loop rate is 5.2 Hz / 7.2 Hz / 8.3 Hz / 11.8 Hz / 17.5 Hz ...
```

Loop ran at 5-19 Hz instead of 20 Hz target. Eventually:

```
controller_server: Exception in transformPose: Lookup would require
extrapolation into the future. Requested time 1779012489.304054 but
the latest data is at time 1779012489.282102, when looking up
transform from frame [map] to frame [odom]
controller_server: Unable to transform goal pose into costmap frame
[follow_path] [ActionServer] Aborting handle. error_code:102
docking_server: Navigation request to staging pose failed.
DockRobot: docking aborted
```

22 ms of TF extrapolation rejected → controller abort → BT back to IDLE.

## Fix
- `time_steps: 40 → 25`, `batch_size: 1500 → 800`, `model_dt: 0.05 → 0.06`
- 3× less compute per cycle (1500·40 = 60 k traj → 800·25 = 20 k traj)
- Comparable horizon (25·0.06 = 1.5 s vs 40·0.05 = 2.0 s)
- `transform_tolerance: 0.2 → 0.3` (belt-and-suspenders for ARM TF jitter)

## Test plan
- [x] Config edit + commit
- [ ] CI build + image push to :main
- [ ] mowgli-pull on robot, recreate container, verify `Control loop missed` warnings are gone or rare (occasional ones at startup are OK)
- [ ] Send CMD=2 HOME and verify docking_server.navigate_to_staging_pose succeeds without extrapolation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)