### PR TITLE
fix(nav2): bump controller_server transform_tolerance 0.1→0.5

### DIFF
--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -62,6 +62,17 @@ controller_server:
     # perception-to-action loop by half, useful for the FTC PID lateral
     # corrections at strip endpoints.
     controller_frequency: 20.0
+    # Top-level transform_tolerance is used by controller_server when
+    # transforming the global plan into the costmap frame (separate from
+    # each plugin's own transform_tolerance, which only covers the
+    # plugin-internal pose lookups). Nav2 default is 0.1 s, which is
+    # tighter than our 25 Hz map→odom publish gap (~40 ms) once you add
+    # ARM scheduler jitter; controller_server then throws "Lookup would
+    # require extrapolation into the future" mid-FollowPath and Nav2
+    # aborts the action with error_code 102. 0.5 s gives ~12 fusion_graph
+    # periods of headroom — well past the worst-case stamp drift we have
+    # seen in the field (35-80 ms).
+    transform_tolerance: 0.5
     # 5s vs 0.3s default — ARM scheduler jitter can stall local_costmap
     # updates 2-3s under load; the controller would error out otherwise.
     costmap_update_timeout: 5.0


### PR DESCRIPTION
## Summary
Adds explicit `transform_tolerance: 0.5` at the `controller_server` top-level. The Nav2 default of `0.1 s` was rejecting FollowPath lookups under ARM scheduler jitter, aborting the action with `error_code:102` after ~5 min of motion.

## Field measurement (2026-05-17, post-#226)
```
controller_server: Exception in transformPose: Lookup would require
extrapolation into the future.  Requested time 1779014121.719091
but the latest data is at time 1779014121.684392
controller_server: Unable to transform goal pose into costmap frame
[follow_path] [ActionServer] Aborting handle. error_code:102
docking_server: Navigation request to staging pose failed.
DockRobot: docking aborted
```

35 ms forward extrapolation rejected. `fusion_graph_node` publishes `map → odom` at 25 Hz (`node_period_s = 0.04 s`); the worst-case gap between controller's `now()` and latest TF stamp is ≈ 40 ms.

## Why this isn't fixed by the MPPI plugin's transform_tolerance
The plugin's `transform_tolerance: 0.3` (PR #226) only covers the plugin-internal lookups. `controller_server::transformPose` — the call that fails here — uses the top-level `transform_tolerance` parameter, which was unset and defaulted to `0.1`.

## Test plan
- [x] Config edit + commit
- [ ] CI build + Docker push to `:main`
- [ ] mowgli-pull on robot, recreate container
- [ ] CMD=2 HOME and verify the navigate-to-staging-pose phase doesn't abort with `error_code:102`

🤖 Generated with [Claude Code](https://claude.com/claude-code)