### PR TITLE
fix(nav2): drop controller_server min_*_velocity_threshold floors

### DIFF
--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -76,11 +76,18 @@ controller_server:
     # 5s vs 0.3s default — ARM scheduler jitter can stall local_costmap
     # updates 2-3s under load; the controller would error out otherwise.
     costmap_update_timeout: 5.0
-    # 0.08 m/s zeroes outputs below the firmware ~PWM 40 deadband so the
-    # motors don't buzz instead of moving. Matches hardware_bridge deadband.
-    min_x_velocity_threshold: 0.08
+    # min_*_velocity_threshold disabled — hardware_bridge now has a
+    # closed-loop deadband compensator (PR #228) that boosts stalled
+    # motors to the firmware ~PWM 40 deadband. Leaving these at the old
+    # 0.08 / 0.001 floors would zero MPPI's ramp-up commands before
+    # they reach hardware_bridge, so the compensator never sees them and
+    # the robot stays parked even though the controllers asked it to
+    # move. Field-observed 2026-05-17 on CMD=2 HOME: MPPI raw output
+    # ≈ (0.05, 0.01) was getting clamped to (0.00, 0.01) by these
+    # filters, leaving the wheels in deadband.
+    min_x_velocity_threshold: 0.0
     min_y_velocity_threshold: 0.0
-    min_theta_velocity_threshold: 0.001
+    min_theta_velocity_threshold: 0.0
     failure_tolerance: 1.0
     progress_checker_plugins: ["progress_checker"]
     goal_checker_plugins: ["stopped_goal_checker", "coverage_goal_checker"]


### PR DESCRIPTION
## Summary
Removes the open-loop velocity floors in `controller_server` (`min_x: 0.08`, `min_theta: 0.001`) that zeroed MPPI's ramp-up commands before the new closed-loop deadband compensator (PR #228) could see them.

## Field-observed symptom (2026-05-17)
After PR #228 was merged and the robot received CMD=2 HOME:
- Robot at (-0.35, +4.11), dock staging at (1.2, 0.64) — 4 m to go
- BT=AUTONOMOUS, plan present, `Passing new path to controller` at 1 Hz
- `cmd=(+0.00, -0.01) wheel=(+0.00, +0.00)` for 100+ seconds — robot parked

MPPI was raw-outputting roughly `(vx=0.05, wz=0.01)` (normal ramp-up from standstill), but `controller_server` clamped vx to 0 (`0.05 < 0.08`). `hardware_bridge` then saw `cmd=(0, 0.01)` — vx zero, so its `sub_db_v` check failed, no boost, motors in deadband.

## Why the floors are now redundant
PR #228's closed-loop compensator does exactly what the floors were trying to do (avoid sub-deadband motor buzz), but at the right layer: it sees the actual wheel response. If MPPI says `vx=0.05` and wheels are stalled, the compensator boosts to deadband; once wheels are spinning, it releases the boost. The 0.08 floor pre-empted that whole loop.

## Test plan
- [x] Config edit + commit
- [ ] CI build + Docker push
- [ ] mowgli-pull on robot, recreate container
- [ ] CMD=2 HOME from ~4 m off-dock — verify robot actually departs (cmd_vx > 0 reaches firmware, wheels engage, robot moves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)