### PR TITLE
feat(nav2): switch FollowPath from MPPI to RotationShim + RPP

### DIFF
--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -160,108 +160,77 @@ controller_server:
     # whenever it was already near staging (the planner emits a 2-pose
     # direct line → FTC cancels → action server retries forever).
     #
-    # MPPI is a sampling-based predictive controller. It rolls out
-    # thousands of forward simulations per cycle through the dynamic
-    # model, scores each by a set of critics, and picks the best
-    # weighted control. Practical wins for transit on this robot:
-    #   * Accepts any plan length (including 2-pose direct lines).
-    #   * Anticipates deceleration approaching the goal — no abrupt
-    #     POST_ROTATE phase, no abort-on-residual.
-    #   * Handles obstacle avoidance via sampling around them (vs FTC's
-    #     fixed lateral-deviation cap).
-    #   * Continuous mixed (vx + wz) commands instead of FTC's discrete
-    #     state regimes — the controller naturally side-steps small
-    #     lateral residuals by combining forward + rotational motion.
+    # MPPI was tried in PR #224 but field-measured 2026-05-17 it consistently
+    # emitted ~0.012 m/s cmd_vx for a 3 m navigation — below the firmware
+    # deadband — leaving the robot parked. Root cause not isolated (cost
+    # critics behaving conservatively on the ARM SoC budget, possibly the
+    # combination of small batch_size / short horizon / dense path). MPPI
+    # demands more tuning effort than is justified for transit when simpler
+    # controllers exist.
     #
-    # Caveat: MPPI emits mixed vx + wz, so the host-side pulse
-    # modulators added in PRs #221 / #223 don't fire (they gate on
-    # near-pure-rotation and near-pure-linear respectively). Mowing
-    # remains on FTCController where those patches matter; transit is
-    # MPPI's home turf.
+    # RotationShimController wraps RegulatedPurePursuitController (RPP):
+    #   * RotationShim detects when the next path segment requires a yaw
+    #     change > rotate_to_heading_min_angle and does a pure pivot
+    #     FIRST, then hands off — solves the "FTC PRE_ROTATE / FTC
+    #     fights MPPI's mixed cmds" problem. Pivot phase outputs pure-wz,
+    #     translation phase outputs pure-vx+small-wz (via RPP).
+    #   * RPP is curvature-driven pure pursuit with regulated speed:
+    #     plans a lookahead carrot, computes the steering curvature,
+    #     scales down vx based on lookahead distance + curvature + nearby
+    #     costs. Smooth, well-understood, low-CPU.
+    #   * Both accept any plan length, including 2-pose direct lines
+    #     (RPP samples by distance, not pose index).
     #
-    # Tuning is conservative for the ARM SoC and 0.30 m/s mower
-    # envelope. batch_size=1500 keeps the per-cycle cost ≤ 8 ms;
-    # raise once we have a session on the bench to profile.
+    # Coverage stays on FTC — RPP's lookahead-carrot tracking doesn't
+    # hold the < 10 mm lateral precision needed for the swath spacing
+    # to tile correctly.
     FollowPath:
-      plugin: "nav2_mppi_controller::MPPIController"
-      # Field-measured 2026-05-17 (Rockchip RK3588 + Mowgli stack): at
-      # batch_size=1500 + time_steps=40 the control loop ran at 5-19 Hz
-      # instead of the 20 Hz target, and TF extrapolation aborted the
-      # FollowPath action ("Lookup would require extrapolation into the
-      # future"). Cut trajectory count from 1500·40 = 60 k to 800·25 = 20 k
-      # while keeping a comparable 1.5 s horizon (25·0.06 vs 40·0.05).
-      time_steps: 25                      # 1.5 s horizon at model_dt=0.06
-      model_dt: 0.06                      # ≈ control loop tick we can actually hit
-      batch_size: 800                     # 64 % less compute per cycle vs 1500
-      vx_std: 0.15
-      vy_std: 0.0                         # diff-drive, no lateral
-      wz_std: 0.35
-      vx_max: 0.30                        # transit speed cap (m/s)
-      vx_min: -0.25                       # allow brief reverse for tight maneuvers
-      wz_max: 1.0
-      ax_max: 0.6                         # gentle accel for the mower drivetrain
-      ax_min: -0.6
-      az_max: 2.0
-      iteration_count: 1
-      prune_distance: 1.5
-      transform_tolerance: 0.3            # bumped 0.2→0.3 after ARM extrapolation aborts
-      temperature: 0.3
-      gamma: 0.015
-      motion_model: "DiffDrive"
-      visualize: false
-      critics: [
-        "ConstraintCritic",
-        "ObstaclesCritic",
-        "GoalCritic",
-        "GoalAngleCritic",
-        "PathFollowCritic",
-        "PathAngleCritic",
-        "PreferForwardCritic",
-      ]
-      ConstraintCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 4.0
-      GoalCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 5.0
-        threshold_to_consider: 1.2        # m, start "go-to-goal" inside this radius
-      GoalAngleCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 3.0
-        threshold_to_consider: 0.4        # m, align final yaw inside this radius
-      PreferForwardCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 5.0
-        threshold_to_consider: 0.5
-      ObstaclesCritic:
-        enabled: true
-        cost_power: 1
-        repulsion_weight: 1.5
-        critical_weight: 20.0
-        consider_footprint: false        # full footprint check is expensive; circular OK at 0.3 m/s
-        collision_cost: 10000.0
-        collision_margin_distance: 0.10
-        near_goal_distance: 0.5
-        inflation_radius: 0.55
-        cost_scaling_factor: 10.0
-      PathFollowCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 5.0
-        offset_from_furthest: 5
-        threshold_to_consider: 1.2
-      PathAngleCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 2.0
-        offset_from_furthest: 4
-        threshold_to_consider: 0.5
-        max_angle_to_furthest: 1.2
-        mode: 0
+      plugin: "nav2_rotation_shim_controller::RotationShimController"
+      primary_controller: "nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController"
+
+      # --- RotationShim params ---
+      # 0.785 rad (45°) — under this, hand straight to RPP. Above, pivot
+      # in place first. Matches the threshold that opennav_docking's
+      # NavigateToPose typically generates at long-transit endpoints.
+      angular_dist_threshold: 0.785
+      forward_sampling_distance: 0.5
+      rotate_to_heading_angular_vel: 0.6   # ≥ kMinRotVel so the wheels engage
+      max_angular_accel: 1.0
+      simulate_ahead_time: 1.0
+      rotate_to_goal_heading: false        # let RPP handle final heading
+      closed_loop: true                    # use wheel odom feedback for pivot completion
+
+      # --- RegulatedPurePursuitController (primary) params ---
+      transform_tolerance: 0.3            # ARM TF jitter envelope
+      desired_linear_vel: 0.30            # transit speed cap (m/s)
+      min_approach_linear_velocity: 0.13  # ≥ firmware ~PWM 40 deadband (≈ 0.13 m/s)
+      approach_velocity_scaling_dist: 0.6
+      # Lookahead: velocity-scaled. At 0.30 m/s → 0.45 m, at 0.13 m/s → 0.20 m.
+      use_velocity_scaled_lookahead_dist: true
+      lookahead_time: 1.5
+      min_lookahead_dist: 0.30            # short-radius near goal
+      max_lookahead_dist: 0.90
+      # Curvature-based slowdown: when steering radius < 0.9 m, drop to
+      # min 0.20 m/s. Keeps tight turns controllable without stalling.
+      use_regulated_linear_velocity_scaling: true
+      regulated_linear_scaling_min_radius: 0.9
+      regulated_linear_scaling_min_speed: 0.20
+      use_cost_regulated_linear_velocity_scaling: false
+      # Collision sim: project the carrot forward, abort if the path
+      # to the carrot hits an obstacle. 1.0 s look-ahead at 0.3 m/s
+      # = 30 cm projected; collision_monitor handles the close-range case.
+      use_collision_detection: true
+      max_allowed_time_to_collision_up_to_carrot: 1.0
+      # In-place rotation toward heading at large yaw error — RPP's own
+      # rotate-to-heading hand-off complements RotationShim, kicking in
+      # after RotationShim disengages if the path bends mid-trajectory.
+      use_rotate_to_heading: true
+      rotate_to_heading_min_angle: 0.785
+      rotate_to_heading_angular_vel: 0.6
+      max_angular_accel: 1.0
+      allow_reversing: false
+      max_robot_pose_search_dist: 10.0
+      use_interpolation: true
 
     # FollowCoveragePath — strip following. Same FTC plugin, same params as
     # FollowPath (single source of truth). The two slots exist for future


### PR DESCRIPTION
## Summary
Swaps `FollowPath` from `nav2_mppi_controller::MPPIController` to `nav2_rotation_shim_controller::RotationShimController` wrapping `nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController`.

## Why
MPPI on transit (PR #224) could not be made to drive the robot. After three tuning passes (PR #226 ARM batch/horizon, PR #228 closed-loop deadband in hardware_bridge, PR #229 dropping the velocity thresholds), `/cmd_vel_nav` still output:

```
linear.x  =  0.012  m/s
angular.z = -0.0003 rad/s
```

…steady-state, 3 m from the goal. That's an order of magnitude below the firmware deadband, and the cost critics keep converging on near-zero velocity regardless of how the knobs are turned. Tuning MPPI further is open-ended.

## What RotationShim + RPP buys
- **RotationShim** pivots in place when the next path segment is >45° off heading, then hands to RPP. Pure-`wz` output during pivot pairs cleanly with the closed-loop deadband compensator from PR #228.
- **RegulatedPurePursuit** is curvature-driven lookahead-carrot tracking with regulated velocity (slows in curvature, near obstacles, near goal). Accepts 2-pose direct lines (the FTC '2-pose plan reject' failure mode is also fixed by this swap).
- `min_approach_linear_velocity = 0.13` = firmware deadband; PR #228's compensator handles anything below.

Coverage stays on FTC — RPP's lookahead carrot can't hold the <10mm lateral precision needed for swath tiling.

## Test plan
- [x] Config edit + commit
- [ ] CI build + Docker push to :main
- [ ] mowgli-pull, recreate container
- [ ] CMD=2 HOME from ~4m off-dock — verify RotationShim pivots + RPP drives forward
- [ ] CMD=1 START full mow cycle — verify undock → transit → mow → return-home works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)