### PR TITLE
fix(gui): dock calibration 'missing' bug — use db-provided yaml path

### DIFF
--- a/gui/pkg/api/api.go
+++ b/gui/pkg/api/api.go
@@ -41,7 +41,7 @@ func NewAPI(dbProvider types.IDBProvider, dockerProvider types.IDockerProvider, 
 	SetupRoutes(apiGroup, firmwareProvider)
 	SystemRoutes(apiGroup)
 	DiagnosticsRoutes(apiGroup, dockerProvider, rosProvider, dbProvider)
-	CalibrationRoutes(apiGroup, rosProvider)
+	CalibrationRoutes(apiGroup, rosProvider, dbProvider)
 	ScheduleRoutes(apiGroup, dbProvider)
 	ImportRoutes(apiGroup, rosProvider, dbProvider)
 	tileServer, err := dbProvider.Get("system.map.enabled")

--- a/gui/pkg/api/calibration.go
+++ b/gui/pkg/api/calibration.go
@@ -50,11 +50,11 @@ type CalibrateImuYawResponse struct {
 // ---------------------------------------------------------------------------
 
 // CalibrationRoutes registers sensor-calibration endpoints.
-func CalibrationRoutes(r *gin.RouterGroup, rosProvider types.IRosProvider) {
+func CalibrationRoutes(r *gin.RouterGroup, rosProvider types.IRosProvider, dbProvider types.IDBProvider) {
 	group := r.Group("/calibration")
 	group.POST("/imu-yaw", postCalibrateImuYaw(rosProvider))
 	group.POST("/magnetometer", postCalibrateMagnetometer(rosProvider))
-	registerCalibrationStatusRoute(group)
+	registerCalibrationStatusRoute(group, dbProvider)
 }
 
 // ---------------------------------------------------------------------------

--- a/gui/pkg/api/calibration_status.go
+++ b/gui/pkg/api/calibration_status.go
@@ -12,15 +12,21 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
+
+	"github.com/cedbossneo/mowglinext/pkg/types"
 )
 
-// Paths to the runtime calibration artefacts and the robot config that
-// owns the dock pose. Kept as package constants so tests can shadow
-// them via locals if needed.
+// Paths to the runtime calibration artefacts. The mowgli_robot.yaml
+// path is provided at runtime by the DB provider (key
+// system.mower.yamlConfigFile) because it differs between containers
+// (gui sees /mowgli_config/mowgli_robot.yaml, ros2 sees
+// /ros2_ws/config/mowgli_robot.yaml). The earlier hardcoded constant
+// caused this endpoint to silently report Present=false on the gui
+// container, which then surfaced as the "dock calibration missing"
+// banner in the GUI even when the dock pose was correctly persisted.
 const (
-	imuCalibrationPath  = "/ros2_ws/maps/imu_calibration.txt"
-	magCalibrationPath  = "/ros2_ws/maps/mag_calibration.yaml"
-	mowgliRobotYamlPath = "/ros2_ws/config/mowgli_robot.yaml"
+	imuCalibrationPath = "/ros2_ws/maps/imu_calibration.txt"
+	magCalibrationPath = "/ros2_ws/maps/mag_calibration.yaml"
 )
 
 // ---------------------------------------------------------------------------
@@ -77,24 +83,27 @@ type CalibrationStatusResponse struct {
 // ---------------------------------------------------------------------------
 
 // RegisterCalibrationStatusRoute wires GET /calibration/status into the
-// existing calibration group. Called from CalibrationRoutes below via a
-// small extension — the status endpoint is read-only and does not need
-// a ROS provider.
-func registerCalibrationStatusRoute(group *gin.RouterGroup) {
-	group.GET("/status", getCalibrationStatus)
+// existing calibration group. The DB provider is needed so we can
+// resolve the runtime path of mowgli_robot.yaml instead of relying on
+// a hardcoded constant (the gui and ros2 containers mount the file at
+// different paths).
+func registerCalibrationStatusRoute(group *gin.RouterGroup, dbProvider types.IDBProvider) {
+	group.GET("/status", getCalibrationStatus(dbProvider))
 }
 
 // ---------------------------------------------------------------------------
 // GET /calibration/status
 // ---------------------------------------------------------------------------
 
-func getCalibrationStatus(c *gin.Context) {
-	resp := CalibrationStatusResponse{
-		Dock: readDockCalibrationStatus(),
-		Imu:  readImuCalibrationStatus(),
-		Mag:  readMagCalibrationStatus(),
+func getCalibrationStatus(dbProvider types.IDBProvider) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		resp := CalibrationStatusResponse{
+			Dock: readDockCalibrationStatus(dbProvider),
+			Imu:  readImuCalibrationStatus(),
+			Mag:  readMagCalibrationStatus(),
+		}
+		c.JSON(http.StatusOK, resp)
 	}
-	c.JSON(http.StatusOK, resp)
 }
 
 // readDockCalibrationStatus reads dock_pose_x/y/yaw from
@@ -102,8 +111,13 @@ func getCalibrationStatus(c *gin.Context) {
 // calibrate_imu_yaw_node and /map_server_node/set_docking_point.
 // Reports {Present: false} when the file is missing or the dock pose
 // is still all-zero (uninitialised configuration).
-func readDockCalibrationStatus() DockCalibrationStatus {
-	data, err := os.ReadFile(mowgliRobotYamlPath)
+func readDockCalibrationStatus(dbProvider types.IDBProvider) DockCalibrationStatus {
+	mowgliRobotYamlPath, err := dbProvider.Get("system.mower.yamlConfigFile")
+	if err != nil {
+		logrus.Warnf("calibration_status: cannot resolve yaml path from db: %v", err)
+		return DockCalibrationStatus{Present: false, Error: "cannot resolve yaml path"}
+	}
+	data, err := os.ReadFile(string(mowgliRobotYamlPath))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return DockCalibrationStatus{Present: false}


### PR DESCRIPTION
## Summary
`GET /api/calibration/status` was hardcoding the `mowgli_robot.yaml` path to `/ros2_ws/config/mowgli_robot.yaml`. That works inside the `ros2` container but **not** inside the `gui` container, where the file is bind-mounted at `/mowgli_config/mowgli_robot.yaml`.

Result: `os.ReadFile` returned `ErrNotExist`, the handler returned `{Present: false}`, and the GUI surfaced **"dock calibration missing"** even though the dock pose was correctly persisted (visible via `diagnostics/snapshot`, which reads through the db provider with the right path).

## Field confirmation (2026-05-17, gui container)
```
/api/calibration/status   → {"dock": {"present": false}, ...}     ← BUG
/api/diagnostics/snapshot → cross_checks.dock_pose:
                              configured_x: 0.198
                              configured_y: 0.189
                              configured_yaw: -2.293
                              source: mowgli_robot.yaml           ← CORRECT
```

The yaml file inside gui container:
```
$ docker exec mowgli-gui find / -name mowgli_robot.yaml
/mowgli_config/mowgli_robot.yaml      ← real path
                                       ← NOT /ros2_ws/config/...
```

## Fix
Wire `dbProvider` through `CalibrationRoutes → registerCalibrationStatusRoute → getCalibrationStatus → readDockCalibrationStatus`, and resolve the yaml path via `dbProvider.Get("system.mower.yamlConfigFile")` the same way `buildCrossChecks` (diagnostics.go) already does. The two endpoints now read the same file.

## Test plan
- [x] Code edits
- [ ] CI build + Docker push for gui image
- [ ] On the robot: `GET /api/calibration/status` returns `{dock: {present: true, dock_pose_x, ...}}` when `mowgli_robot.yaml` has non-zero dock pose
- [ ] GUI "dock calibration missing" banner clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)