### PR TITLE
tune(fusion_graph): bump node_period_s 0.04→0.02 (25 Hz → 50 Hz)

### DIFF
--- a/ros2/src/fusion_graph/config/fusion_graph.yaml
+++ b/ros2/src/fusion_graph/config/fusion_graph.yaml
@@ -6,13 +6,18 @@
 fusion_graph_node:
   ros__parameters:
     # ── Graph cadence ──────────────────────────────────────────────────
-    # 25 Hz default = HARDWARE-correct cadence: TF map→odom publishes
-    # 5x faster than the 5 Hz controller queries, well within the
-    # 200 ms transform_tolerance. sim_full_system.launch.py overrides
-    # to 50 Hz (0.02) because under sim_time the publish/lookup phase
-    # offset routinely throws ExtrapolationException at lower rates.
+    # 50 Hz default. Earlier 25 Hz (0.04) was technically sufficient for
+    # the 5 Hz controller queries, but the operator could see a 5-10°
+    # yaw lag in the GUI during in-place pivots (gyro_z is 91 Hz on
+    # /imu/data but fusion only republished its absorbed value every
+    # 40 ms, layered with 80-100 ms of rosbridge + WebSocket + render
+    # latency downstream). Bumping the optimiser to 50 Hz halves the
+    # fusion-side contribution to that lag at modest CPU cost (iSAM2
+    # incremental updates are sub-millisecond on this graph size).
+    # If CPU pressure becomes visible (Nav2 controller frequency
+    # tanks, ekf_odom_node misses cycles), drop back to 0.03 (33 Hz).
     # Override key (set by navigation.launch.py): fusion_graph_node_period_s.
-    node_period_s: 0.04
+    node_period_s: 0.02
 
     # ── Wheel between-factor noise ─────────────────────────────────────
     # Per-node sigmas in body frame. wheel_sigma_y << wheel_sigma_x is


### PR DESCRIPTION
## Summary
Halves the operator-perceived yaw display lag during in-place pivots.

## Why
Operator reported 5-10° of yaw lag visible in the GUI during pivots. Profile:
- `/imu/data` at 91 Hz, `/odometry/filtered_map` at 25 Hz
- Gyro between-factor σ=0.005 vs COG σ=0.05 vs mag σ=0.1 (robust) — **gyro dominates** in fusion, so factor weights aren't the issue
- 25 Hz publish + 80-100 ms rosbridge/WebSocket/render = ~120-140 ms total lag

The fusion publish rate is the only knob that affects what reaches the GUI. iSAM2 incremental updates on the current graph size are sub-ms, so 50 Hz is comfortably within budget.

Fallback if CPU pressure manifests: drop to 0.03 (33 Hz).

## Test plan
- [x] Config edit
- [ ] CI build + Docker push
- [ ] mowgli-pull, recreate ros2 container
- [ ] Verify `ros2 topic hz /odometry/filtered_map` ≈ 50 Hz
- [ ] Verify no new `controller_server: Control loop missed` warnings
- [ ] Subjective: yaw smoother in GUI during pivot

🤖 Generated with [Claude Code](https://claude.com/claude-code)