### PR TITLE
feat(fusion_graph): #14 adaptive process noise on wheel σ_x

### DIFF
--- a/ros2/src/fusion_graph/CMakeLists.txt
+++ b/ros2/src/fusion_graph/CMakeLists.txt
@@ -146,6 +146,11 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_stationary_yaw fusion_graph_core)
 
+  ament_add_gtest(test_adaptive_noise
+    test/test_adaptive_noise.cpp
+  )
+  target_link_libraries(test_adaptive_noise fusion_graph_core)
+
   # Performance benchmarks. Long-running (~30 s on ARM); only meaningful
   # in Release builds. Output is grep-friendly for tracking regressions.
   ament_add_gtest(test_perf

--- a/ros2/src/fusion_graph/config/fusion_graph.yaml
+++ b/ros2/src/fusion_graph/config/fusion_graph.yaml
@@ -71,6 +71,17 @@ fusion_graph_node:
     # any meaningful manual rotation.
     stationary_gyro_thresh_rad_per_s: 0.10
 
+    # ── Adaptive process noise on wheel σ_x ────────────────────────────
+    # Inflates wheel_sigma_x when the |dtheta_wheel - dtheta_gyro|
+    # residual EMA exceeds the floor. Slip on wet grass / slope causes
+    # encoders to over-report distance — without inflation the
+    # iSAM2 wheel between-factor pins the trajectory to that bogus
+    # delta until a GPS observation pulls it back. Set gain to 0 to
+    # disable. See GraphParams comments for sizing details.
+    adaptive_noise_enabled_gain: 10.0
+    adaptive_noise_ema_tau_s: 0.5
+    adaptive_noise_residual_floor_rad: 0.005
+
     # ── RTK wrong-fix detection ───────────────────────────────────────
     # F9P occasionally re-solves carrier-phase ambiguity on a different
     # integer set, jumping the reported position by a few centimetres

--- a/ros2/src/fusion_graph/include/fusion_graph/graph_manager.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/graph_manager.hpp
@@ -148,6 +148,36 @@ struct GraphParams
   // produces residual gyro samples on a truly parked robot.
   double stationary_gyro_thresh_rad_per_s = 0.10;
 
+  // Adaptive process-noise inflation on wheel σ_x.
+  //
+  // Diff-drive encoders report a body-frame translation per tick. If
+  // one wheel slips (wet grass, slope, blade-jam recoil) the encoder
+  // and the chassis disagree, but iSAM2 still treats the wheel
+  // between-factor with the configured σ_x. The mismatch shows up as a
+  // residual: dtheta_wheel ≠ dtheta_gyro when the angular motion was
+  // identical, and the linear-axis equivalent (which we cannot observe
+  // directly without an absolute sensor) is correlated with that yaw
+  // residual on a diff-drive. We use |dtheta_wheel - dtheta_gyro| as a
+  // proxy and inflate wheel_sigma_x when it exceeds a threshold.
+  //
+  // EMA-smoothed over recent ticks to avoid single-tick noise tripping
+  // it; reverts to base sigma when residual decays. Disabled by setting
+  // adaptive_noise_gain to 0.
+  //
+  // Gain interpretation: σ_x_eff = wheel_sigma_x + adaptive_noise_gain *
+  // residual_ema. Default 10 (m per rad), tuned so a 0.1 rad slip event
+  // (~6°) inflates σ_x from 0.05 to 1.05 m — effectively releases the X
+  // constraint, similar to pivot_wheel_sigma_x.
+  double adaptive_noise_enabled_gain = 10.0;
+  // EMA time constant (seconds). 0.5 s = the residual settles within a
+  // few ticks of slip onset; smaller values track faster but pick up
+  // single-tick gyro noise.
+  double adaptive_noise_ema_tau_s = 0.5;
+  // Floor below which residual EMA is treated as zero (no inflation).
+  // 0.005 rad sits at the typical gyro noise floor — anything below
+  // this is dominated by sensor jitter, not real slip.
+  double adaptive_noise_residual_floor_rad = 0.005;
+
   // ICP scan-match quality gates. Result is dropped if any of these
   // fail. Defaults are conservative — drop a few good matches in the
   // sparse-outdoor edge case rather than absorb a degenerate one,
@@ -200,6 +230,12 @@ struct GraphStats
   uint64_t icp_rejects_sanity = 0;   // unphysical delta magnitude
   uint64_t icp_rejects_divergence = 0;  // result far from initial guess
   uint64_t stationary_hand_push = 0;  // wheel stationary but gyro disagrees
+  // Adaptive process-noise telemetry. residual_ema_rad is the
+  // current EMA-smoothed |dtheta_wheel - dtheta_gyro| (rad);
+  // wheel_sigma_x_eff is the inflated σ_x actually used for the most
+  // recent wheel between-factor.
+  double residual_ema_rad = 0.0;
+  double wheel_sigma_x_eff = 0.0;
 };
 
 class GraphManager
@@ -478,6 +514,13 @@ private:
   uint64_t stats_icp_rejects_sanity_ = 0;
   uint64_t stats_icp_rejects_divergence_ = 0;
   uint64_t stats_hand_push_ = 0;
+
+  // Adaptive process-noise state.
+  // residual_ema_ tracks the EMA-smoothed |dtheta_wheel - dtheta_gyro|
+  // residual across ticks. Each Tick() updates it and reads back the
+  // current σ_x inflation. Exposed via Stats() for diagnostics.
+  double residual_ema_ = 0.0;
+  double last_wheel_sigma_x_eff_ = 0.0;
 
   // ── Async-rebase pipeline ───────────────────────────────────────
   // RebaseISAM2 rebuilds the iSAM2 Bayes tree from scratch with one

--- a/ros2/src/fusion_graph/src/fusion_graph_node.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node.cpp
@@ -78,6 +78,12 @@ FusionGraphNode::FusionGraphNode(const rclcpp::NodeOptions& opts)
       declare_parameter<double>("pivot_wheel_sigma_x", 0.5);
   gp.stationary_gyro_thresh_rad_per_s =
       declare_parameter<double>("stationary_gyro_thresh_rad_per_s", 0.10);
+  gp.adaptive_noise_enabled_gain =
+      declare_parameter<double>("adaptive_noise_enabled_gain", 10.0);
+  gp.adaptive_noise_ema_tau_s =
+      declare_parameter<double>("adaptive_noise_ema_tau_s", 0.5);
+  gp.adaptive_noise_residual_floor_rad =
+      declare_parameter<double>("adaptive_noise_residual_floor_rad", 0.005);
 
   // RTK wrong-fix detection (handled in OnGnss, not in graph_manager).
   rtk_wrongfix_max_jump_m_ =
@@ -442,6 +448,14 @@ FusionGraphNode::FusionGraphNode(const rclcpp::NodeOptions& opts)
                               std::to_string(stats.icp_rejects_divergence));
                           add("stationary_hand_push",
                               std::to_string(stats.stationary_hand_push));
+                          // Adaptive process-noise telemetry.
+                          {
+                            char buf[32];
+                            std::snprintf(buf, sizeof(buf), "%.5f", stats.residual_ema_rad);
+                            add("residual_ema_rad", buf);
+                            std::snprintf(buf, sizeof(buf), "%.4f", stats.wheel_sigma_x_eff);
+                            add("wheel_sigma_x_eff", buf);
+                          }
                           if (snap)
                           {
                             char buf[64];

--- a/ros2/src/fusion_graph/src/graph_manager.cpp
+++ b/ros2/src/fusion_graph/src/graph_manager.cpp
@@ -326,10 +326,43 @@ TickOutput GraphManager::CreateNodeLocked(double now_s)
   // comment) so swap to a loose sigma and let GPS / scan-matching
   // constrain XY. Gating on the gyro (not wheel-derived) dtheta
   // avoids feedback from the same encoder that's misreporting.
-  const double wheel_sigma_x_eff =
+  double wheel_sigma_x_eff =
       std::abs(accum_.dtheta_gyro) > params_.pivot_gate_dtheta_rad
           ? params_.pivot_wheel_sigma_x
           : params_.wheel_sigma_x;
+
+  // Adaptive σ_x inflation from wheel↔gyro residual EMA. Skipped
+  // entirely when adaptive_noise_enabled_gain == 0 (the parameter
+  // defaults to 10 but yaml can disable). Pivot mode already
+  // inflates σ_x to params_.pivot_wheel_sigma_x; in that case the
+  // adaptive term layers on top, but the floor (pivot sigma) is
+  // typically much larger than any residual-driven contribution
+  // so the practical effect is negligible during pivots.
+  if (params_.adaptive_noise_enabled_gain > 0.0)
+  {
+    // |wheel↔gyro residual| this tick. We compare the per-tick yaw
+    // deltas (not the rate) so the noise scales naturally with
+    // node_period_s: longer ticks = more accumulated slip = larger
+    // residual = larger inflation.
+    const double residual = std::abs(accum_.dtheta_wheel - accum_.dtheta_gyro);
+
+    // EMA in continuous time: α = dt / (τ + dt). dt_total here is the
+    // wall time we've been accumulating wheel/gyro samples; safe
+    // approximation of node_period_s when the inputs are arriving on
+    // schedule. Falls back to one full step when dt_total is 0 (rare —
+    // happens on the very first tick before any wheel sample).
+    const double dt = (accum_.dt_total > 0.0) ? accum_.dt_total : params_.node_period_s;
+    const double tau = std::max(params_.adaptive_noise_ema_tau_s, 1.0e-3);
+    const double alpha = dt / (tau + dt);
+    residual_ema_ = (1.0 - alpha) * residual_ema_ + alpha * residual;
+
+    // Floor: anything below this is sensor jitter, not slip.
+    const double net_residual =
+        std::max(0.0, residual_ema_ - params_.adaptive_noise_residual_floor_rad);
+    wheel_sigma_x_eff += params_.adaptive_noise_enabled_gain * net_residual;
+  }
+  last_wheel_sigma_x_eff_ = wheel_sigma_x_eff;
+
   auto between_noise = MakeDiagonal({
       wheel_sigma_x_eff,
       params_.wheel_sigma_y,
@@ -450,6 +483,8 @@ GraphStats GraphManager::Stats() const
   s.icp_rejects_sanity = stats_icp_rejects_sanity_;
   s.icp_rejects_divergence = stats_icp_rejects_divergence_;
   s.stationary_hand_push = stats_hand_push_;
+  s.residual_ema_rad = residual_ema_;
+  s.wheel_sigma_x_eff = last_wheel_sigma_x_eff_;
   return s;
 }
 

--- a/ros2/src/fusion_graph/test/test_adaptive_noise.cpp
+++ b/ros2/src/fusion_graph/test/test_adaptive_noise.cpp
@@ -1,0 +1,198 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Regression tests for the adaptive process-noise inflation on wheel
+// σ_x. Motivating failure mode: encoders over-report distance under
+// slip (wet grass, slope, blade-jam recoil); without inflating σ_x
+// dynamically, iSAM2's wheel between-factor pins the trajectory to
+// the bogus delta until a downstream sensor (GPS / ICP) corrects.
+//
+// The mechanism observed: |dtheta_wheel - dtheta_gyro| is a per-tick
+// proxy for slip. We EMA-smooth it and add `gain * net_residual` (in
+// metres per radian) on top of the configured σ_x baseline.
+//
+// Tests pin three behaviours:
+//   1. Matched wheel + gyro (no slip)         → σ_x stays at baseline.
+//   2. Sustained wheel↔gyro disagreement (slip) → σ_x inflates.
+//   3. Slip event followed by quiet           → EMA decays back, σ_x
+//                                                returns near baseline.
+
+#include <cmath>
+#include <cstdio>
+
+#include "fusion_graph/graph_manager.hpp"
+#include <gtest/gtest.h>
+
+namespace fg = fusion_graph;
+
+namespace
+{
+
+// Defaults mirror the YAML so failures bisect to logic, not params.
+fg::GraphParams MakeParams()
+{
+  fg::GraphParams gp;
+  gp.node_period_s = 0.1;
+  gp.wheel_sigma_x = 0.05;
+  gp.wheel_sigma_y = 0.005;
+  gp.wheel_sigma_theta = 0.01;
+  gp.gyro_sigma_theta = 0.005;
+  gp.stationary_thresh_xy_m = 1.0e-3;
+  gp.stationary_thresh_theta = 2.0e-3;
+  gp.stationary_sigma_theta = 1.0e-3;
+  gp.stationary_node_period_s = 0.0;
+  gp.stationary_motion_thresh_m = 0.0;
+  gp.stationary_motion_thresh_theta = 0.0;
+  gp.adaptive_noise_enabled_gain = 10.0;
+  gp.adaptive_noise_ema_tau_s = 0.5;
+  gp.adaptive_noise_residual_floor_rad = 0.005;
+  return gp;
+}
+
+}  // namespace
+
+// ─────────────────────────────────────────────────────────────────────
+// 1. No slip — wheel and gyro agree, σ_x must stay at baseline.
+// ─────────────────────────────────────────────────────────────────────
+TEST(AdaptiveNoise, NoSlipKeepsBaselineSigma)
+{
+  fg::GraphManager gm(MakeParams());
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 0.0);
+
+  constexpr int kTicks = 50;  // 5 s @ 10 Hz
+  constexpr double kDt = 0.1;
+  constexpr double kVx = 0.20;
+  constexpr double kWz = 0.05;  // gentle turn, well above pivot gate
+
+  for (int i = 0; i < kTicks; ++i)
+  {
+    gm.AddWheelTwist(kVx, 0.0, kWz, kDt);
+    // Gyro matches wheel exactly — no residual.
+    gm.AddGyroDelta(kWz, kDt);
+    gm.Tick(kDt * (i + 1));
+  }
+
+  auto stats = gm.Stats();
+  std::printf("[AdaptiveNoise] no-slip: residual_ema=%.6f rad, σ_x_eff=%.4f m\n",
+              stats.residual_ema_rad,
+              stats.wheel_sigma_x_eff);
+
+  // Residual EMA must stay under the floor (no inflation kicks in).
+  EXPECT_LT(stats.residual_ema_rad, 0.005);
+  // σ_x_eff must equal the configured wheel_sigma_x within a small
+  // numeric epsilon — adaptive gain × (residual − floor) must be 0.
+  EXPECT_NEAR(stats.wheel_sigma_x_eff, 0.05, 1.0e-6);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 2. Slip — wheel reports a forward rotation that the gyro doesn't see.
+//    The residual EMA must climb, and σ_x must inflate proportionally.
+// ─────────────────────────────────────────────────────────────────────
+TEST(AdaptiveNoise, SlipInflatesSigma)
+{
+  fg::GraphManager gm(MakeParams());
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 0.0);
+
+  constexpr int kTicks = 50;
+  constexpr double kDt = 0.1;
+  // Wheel says we're rotating at 0.3 rad/s. Gyro reports 0.0 — the
+  // robot is slipping on a slope and one encoder is spinning free.
+  constexpr double kWheelWz = 0.30;
+  constexpr double kGyroWz = 0.0;
+
+  for (int i = 0; i < kTicks; ++i)
+  {
+    gm.AddWheelTwist(0.0, 0.0, kWheelWz, kDt);
+    gm.AddGyroDelta(kGyroWz, kDt);
+    gm.Tick(kDt * (i + 1));
+  }
+
+  auto stats = gm.Stats();
+  std::printf("[AdaptiveNoise] slip: residual_ema=%.4f rad, σ_x_eff=%.4f m\n",
+              stats.residual_ema_rad,
+              stats.wheel_sigma_x_eff);
+
+  // Per-tick residual is |kWheelWz - kGyroWz| × kDt = 0.03 rad. After
+  // many τ time constants of accumulation the EMA should settle near
+  // 0.03 rad. Allow 20% tolerance for the τ=0.5 s settling response
+  // over 5 s of input.
+  EXPECT_GT(stats.residual_ema_rad, 0.020);
+  EXPECT_LT(stats.residual_ema_rad, 0.040);
+
+  // σ_x_eff = baseline + gain × (residual − floor) ≈ 0.05 + 10 × 0.025 = 0.30 m
+  // Wide bounds — this just checks "inflated meaningfully".
+  EXPECT_GT(stats.wheel_sigma_x_eff, 0.15);
+  EXPECT_LT(stats.wheel_sigma_x_eff, 0.50);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 3. Slip event followed by recovery — σ_x must decay back near
+//    baseline once the EMA bleeds out.
+// ─────────────────────────────────────────────────────────────────────
+TEST(AdaptiveNoise, EmaDecaysAfterSlipEnds)
+{
+  fg::GraphManager gm(MakeParams());
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 0.0);
+
+  constexpr double kDt = 0.1;
+
+  // 2 s of slip: σ_x ramps up.
+  for (int i = 0; i < 20; ++i)
+  {
+    gm.AddWheelTwist(0.0, 0.0, 0.30, kDt);
+    gm.AddGyroDelta(0.0, kDt);
+    gm.Tick(kDt * (i + 1));
+  }
+  auto peak = gm.Stats();
+  std::printf("[AdaptiveNoise] peak slip: residual=%.4f rad, σ_x_eff=%.4f m\n",
+              peak.residual_ema_rad,
+              peak.wheel_sigma_x_eff);
+  ASSERT_GT(peak.wheel_sigma_x_eff, 0.15);
+
+  // 5 s of recovery: matched wheel+gyro at zero. EMA should decay
+  // toward zero with τ=0.5 s — 10 τ = essentially zero.
+  for (int i = 0; i < 50; ++i)
+  {
+    gm.AddWheelTwist(0.0, 0.0, 0.0, kDt);
+    gm.AddGyroDelta(0.0, kDt);
+    gm.Tick(kDt * (20 + i + 1));
+  }
+  auto recovered = gm.Stats();
+  std::printf("[AdaptiveNoise] recovered: residual=%.6f rad, σ_x_eff=%.4f m\n",
+              recovered.residual_ema_rad,
+              recovered.wheel_sigma_x_eff);
+
+  // 10 τ of zero residual collapses the EMA to << floor; σ_x returns
+  // to the configured baseline (0.05).
+  EXPECT_LT(recovered.residual_ema_rad, 0.001);
+  EXPECT_NEAR(recovered.wheel_sigma_x_eff, 0.05, 1.0e-6);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 4. Disabling adaptive noise (gain = 0) — even with slip, σ_x must
+//    stay at baseline. Pins the bypass path so we can disable in
+//    production via yaml without code changes.
+// ─────────────────────────────────────────────────────────────────────
+TEST(AdaptiveNoise, GainZeroDisablesAdaptation)
+{
+  auto gp = MakeParams();
+  gp.adaptive_noise_enabled_gain = 0.0;
+  fg::GraphManager gm(gp);
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 0.0);
+
+  constexpr double kDt = 0.1;
+  for (int i = 0; i < 50; ++i)
+  {
+    gm.AddWheelTwist(0.0, 0.0, 0.30, kDt);
+    gm.AddGyroDelta(0.0, kDt);
+    gm.Tick(kDt * (i + 1));
+  }
+  auto stats = gm.Stats();
+  std::printf("[AdaptiveNoise] gain=0: residual=%.4f rad, σ_x_eff=%.4f m\n",
+              stats.residual_ema_rad,
+              stats.wheel_sigma_x_eff);
+
+  // EMA still tracks (it's a passive measurement), but σ_x_eff
+  // must equal the baseline — the gain=0 short-circuits inflation.
+  EXPECT_NEAR(stats.wheel_sigma_x_eff, 0.05, 1.0e-6);
+}


### PR DESCRIPTION
## Summary
Inflates `wheel_sigma_x` dynamically when wheel and gyro yaw deltas disagree (a slip proxy). Encoders that over-report distance under slip no longer pin iSAM2 to bogus motion.

```
σ_x_eff = wheel_sigma_x + adaptive_noise_enabled_gain *
          max(0, residual_ema - adaptive_noise_residual_floor_rad)
```

EMA τ = 0.5 s; gain 10 m/rad; floor 0.005 rad. Yaml-tunable, disable with `gain: 0.0`.

## Why
Pivot mode already inflates σ_x during fast spins; this picks up the **slower** slip cases — wet grass on a slope, blade-jam recoil, single-wheel free-spin on encoder fault. Without it, the wheel between-factor drags trajectory until a strong GPS/ICP observation corrects.

## Tests (`test_adaptive_noise.cpp`)
| Test | What it pins |
|---|---|
| NoSlipKeepsBaselineSigma | matched wheel+gyro → σ_x = 0.05 (no inflation) |
| SlipInflatesSigma | sustained disagreement → σ_x climbs to ~0.30 m |
| EmaDecaysAfterSlipEnds | peak then quiet → σ_x recovers to baseline |
| GainZeroDisablesAdaptation | yaml gain=0 short-circuits inflation |

## Diagnostics
Two new KV pairs on `/fusion_graph/diagnostics`:
- `residual_ema_rad`
- `wheel_sigma_x_eff`

## Item map (from architecture review)
P2 #14 ✅ Adaptive process noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)