### PR TITLE
feat(fusion_graph): #15 high-rate pose extrapolation publisher

### DIFF
--- a/ros2/src/fusion_graph/CMakeLists.txt
+++ b/ros2/src/fusion_graph/CMakeLists.txt
@@ -151,6 +151,11 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_adaptive_noise fusion_graph_core)
 
+  ament_add_gtest(test_pose_extrapolator
+    test/test_pose_extrapolator.cpp
+  )
+  target_link_libraries(test_pose_extrapolator fusion_graph_core)
+
   # Performance benchmarks. Long-running (~30 s on ARM); only meaningful
   # in Release builds. Output is grep-friendly for tracking regressions.
   ament_add_gtest(test_perf

--- a/ros2/src/fusion_graph/config/fusion_graph.yaml
+++ b/ros2/src/fusion_graph/config/fusion_graph.yaml
@@ -132,6 +132,16 @@ fusion_graph_node:
     odom_frame: odom
     base_frame: base_footprint
 
+    # ── High-rate extrapolated pose (item #15) ────────────────────────
+    # When > 0, fusion_graph_node publishes /odometry/filtered_map_fast
+    # at this rate (Hz), with yaw projected forward from the latest
+    # iSAM2-published pose using the most recent IMU gyro_z sample.
+    # Off by default (0) — opt in from yaml when display latency is
+    # the bottleneck (e.g. operator GUI during pivots). Consumers that
+    # need precise pose for control should keep using
+    # /odometry/filtered_map at 50 Hz.
+    fast_pose_publish_rate_hz: 0.0
+
     # ── TF publish lead time ──────────────────────────────────────────
     # Default 0.0 = HARDWARE-correct (no forward extrapolation).
     # sim_full_system.launch.py overrides to 0.1 because under

--- a/ros2/src/fusion_graph/include/fusion_graph/fusion_graph_node.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/fusion_graph_node.hpp
@@ -33,6 +33,7 @@
 #include <tf2_ros/transform_listener.h>
 
 #include "fusion_graph/graph_manager.hpp"
+#include "fusion_graph/pose_extrapolator.hpp"
 #include "fusion_graph/scan_matcher.hpp"
 #include <Eigen/Core>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
@@ -182,6 +183,11 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub_fg_yaw_;
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr pub_diag_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_markers_;
+  // High-rate extrapolated pose (item #15). Same Odometry shape as
+  // /odometry/filtered_map but at 100 Hz, with yaw projected forward
+  // by the latest IMU gyro sample. Position is the unmodified last
+  // fusion-published value. See PoseExtrapolator for the math.
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_odom_fast_;
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
   // TF for odom->base_footprint (we publish map->odom; need to compose
@@ -193,6 +199,12 @@ private:
   rclcpp::TimerBase::SharedPtr diag_timer_;
   rclcpp::TimerBase::SharedPtr periodic_save_timer_;
   rclcpp::TimerBase::SharedPtr maintenance_timer_;
+  // 100 Hz high-rate pose republisher (item #15). Only runs when
+  // fast_pose_publish_rate_hz_ > 0 in yaml; default off so existing
+  // installs aren't surprised by extra topic traffic.
+  rclcpp::TimerBase::SharedPtr fast_pose_timer_;
+  PoseExtrapolator pose_extrap_;
+  double fast_pose_publish_rate_hz_ = 0.0;
 
   // Memory + compute bounding parameters.
   uint64_t scan_retention_nodes_ = 18000;  // 30 min @ 10 Hz

--- a/ros2/src/fusion_graph/include/fusion_graph/pose_extrapolator.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/pose_extrapolator.hpp
@@ -1,0 +1,112 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// PoseExtrapolator — constant-rate forward propagation of a Pose2
+// between iSAM2 graph ticks.
+//
+// fusion_graph publishes /odometry/filtered_map at 50 Hz today. For
+// display-latency-sensitive consumers (operator GUI, foxglove panels)
+// the 20 ms gap between iSAM2 ticks shows up as a perceptible yaw
+// lag during pivots — IMU is available at 91 Hz, but the graph
+// optimiser doesn't expose pose between ticks.
+//
+// This helper class lives between the IMU callback and the high-rate
+// republisher: it caches the latest fusion-published pose and the
+// latest IMU gyro_z sample, and exposes Extrapolate(query_t) that
+// returns the pose with yaw projected forward by gyro_z·dt.
+//
+// Position is NOT extrapolated. Wheel velocity isn't part of the
+// inputs here, and the small position change between ticks (<2 cm
+// at 0.3 m/s × 20 ms) is well under typical display tolerances —
+// while yaw can swing 5-10° at the same rate during pivots, which
+// IS visible.
+//
+// Single-threaded — caller must serialize OnFusionPose / OnImuGyro /
+// Extrapolate. fusion_graph_node uses a single rclcpp executor, so
+// no locking inside.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include <gtsam/geometry/Pose2.h>
+
+namespace fusion_graph
+{
+
+class PoseExtrapolator
+{
+public:
+  PoseExtrapolator() = default;
+
+  // Record a fresh fusion-published pose. Subsequent Extrapolate
+  // calls take this as the new baseline. Timestamp is in seconds
+  // (steady_clock or ROS clock — caller decides, only matters that
+  // it agrees with OnImuGyro stamps).
+  void OnFusionPose(double timestamp_s, const gtsam::Pose2& pose)
+  {
+    last_fusion_stamp_s_ = timestamp_s;
+    last_fusion_pose_ = pose;
+  }
+
+  // Update the latest gyro_z rate (rad/s). Constant-rate model: we
+  // assume gyro_z stays at this value until the next sample. At
+  // 91 Hz IMU and ≤ 20 ms extrapolation window we'll integrate at
+  // most 1-2 samples' worth, so the constant assumption costs at
+  // most ~5 % yaw error on aggressive pivots.
+  void OnImuGyro(double timestamp_s, double wz_rad_per_s)
+  {
+    last_gyro_stamp_s_ = timestamp_s;
+    last_gyro_wz_ = wz_rad_per_s;
+  }
+
+  // Return the extrapolated pose at query_timestamp_s. Returns
+  // nullopt if no fusion pose has been seen yet. Position is the
+  // last fusion position unchanged; yaw is fusion_yaw + gyro * dt
+  // where dt = query - last_fusion_stamp. Negative dt (query in the
+  // past) returns the unmodified fusion pose.
+  std::optional<gtsam::Pose2> Extrapolate(double query_timestamp_s) const
+  {
+    if (!last_fusion_pose_)
+      return std::nullopt;
+
+    const double dt = query_timestamp_s - last_fusion_stamp_s_;
+    if (dt <= 0.0 || !last_gyro_stamp_s_)
+      return last_fusion_pose_;
+
+    // Sanity: cap forward extrapolation at 200 ms. If the caller
+    // has stalled and dt is larger than that, the gyro-constant
+    // assumption is no longer trustworthy; just return the baseline.
+    constexpr double kMaxExtrapolationS = 0.2;
+    if (dt > kMaxExtrapolationS)
+      return last_fusion_pose_;
+
+    const double dyaw = last_gyro_wz_ * dt;
+    return gtsam::Pose2(last_fusion_pose_->x(),
+                        last_fusion_pose_->y(),
+                        last_fusion_pose_->theta() + dyaw);
+  }
+
+  // Diagnostic accessors — used by /fusion_graph/diagnostics + tests.
+  bool HasFusionPose() const
+  {
+    return last_fusion_pose_.has_value();
+  }
+  double LastFusionStamp() const
+  {
+    return last_fusion_stamp_s_;
+  }
+  double LastGyroWz() const
+  {
+    return last_gyro_wz_;
+  }
+
+private:
+  std::optional<gtsam::Pose2> last_fusion_pose_;
+  double last_fusion_stamp_s_ = 0.0;
+  std::optional<double> last_gyro_stamp_s_;
+  double last_gyro_wz_ = 0.0;
+};
+
+}  // namespace fusion_graph

--- a/ros2/src/fusion_graph/src/fusion_graph_node.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node.cpp
@@ -218,6 +218,54 @@ FusionGraphNode::FusionGraphNode(const rclcpp::NodeOptions& opts)
 
   // ── Pubs/subs ─────────────────────────────────────────────────────
   pub_odom_ = create_publisher<nav_msgs::msg::Odometry>("/odometry/filtered_map", 10);
+
+  // High-rate extrapolated pose (item #15). Off by default — set
+  // fast_pose_publish_rate_hz > 0 in yaml to enable. 100 Hz is the
+  // intended use; the publisher reuses the latest fusion pose and
+  // projects yaw forward by latest IMU gyro_z. Marked as a
+  // best-effort feed because consumers should fall back to the
+  // canonical /odometry/filtered_map for control loops.
+  fast_pose_publish_rate_hz_ =
+      declare_parameter<double>("fast_pose_publish_rate_hz", 0.0);
+  if (fast_pose_publish_rate_hz_ > 0.0)
+  {
+    pub_odom_fast_ = create_publisher<nav_msgs::msg::Odometry>(
+        "/odometry/filtered_map_fast", rclcpp::SensorDataQoS());
+    const auto period =
+        std::chrono::duration<double>(1.0 / fast_pose_publish_rate_hz_);
+    fast_pose_timer_ = create_wall_timer(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(period),
+        [this]()
+        {
+          if (!pose_extrap_.HasFusionPose())
+            return;
+          const double now_s = this->now().seconds();
+          auto extrap = pose_extrap_.Extrapolate(now_s);
+          if (!extrap)
+            return;
+          nav_msgs::msg::Odometry msg;
+          msg.header.stamp = this->now();
+          msg.header.frame_id = map_frame_;
+          msg.child_frame_id = base_frame_;
+          msg.pose.pose.position.x = extrap->x();
+          msg.pose.pose.position.y = extrap->y();
+          msg.pose.pose.position.z = 0.0;
+          msg.pose.pose.orientation = QuatFromYaw(extrap->theta());
+          // Loose covariance — this is a display / latency-sensitive
+          // feed, not a primary measurement. Consumers that need
+          // tight σ should subscribe to /odometry/filtered_map.
+          for (int i = 0; i < 36; ++i)
+            msg.pose.covariance[i] = 0.0;
+          msg.pose.covariance[0] = 0.10 * 0.10;
+          msg.pose.covariance[7] = 0.10 * 0.10;
+          msg.pose.covariance[35] = 0.10 * 0.10;
+          pub_odom_fast_->publish(msg);
+        });
+    RCLCPP_INFO(get_logger(),
+                "fusion_graph: high-rate pose extrapolator enabled at %.1f Hz",
+                fast_pose_publish_rate_hz_);
+  }
+
   // /imu/fg_yaw — yaw-only sensor_msgs/Imu published BEST_EFFORT to
   // match cog_to_imu / mag_yaw_publisher conventions. Lets ekf_map_node
   // (when running as primary in observer mode) subscribe as a yaw
@@ -610,6 +658,10 @@ void FusionGraphNode::OnImu(sensor_msgs::msg::Imu::ConstSharedPtr msg)
     }
   }
   last_imu_stamp_ = stamp;
+  // Feed the high-rate extrapolator (item #15) too. Safe even when
+  // fast_pose_timer_ is null — the extrapolator is just a value
+  // cache.
+  pose_extrap_.OnImuGyro(stamp.seconds(), msg->angular_velocity.z);
 }
 
 void FusionGraphNode::OnGnss(sensor_msgs::msg::NavSatFix::ConstSharedPtr msg)
@@ -1210,6 +1262,11 @@ void FusionGraphNode::PublishOutputs(const TickOutput& out)
   odom.pose.covariance[21] = 1e-9;
   odom.pose.covariance[28] = 1e-9;
   pub_odom_->publish(odom);
+
+  // Rebaseline the high-rate extrapolator (item #15). The fast
+  // publisher will project yaw forward from this pose until the
+  // next fusion tick.
+  pose_extrap_.OnFusionPose(this->now().seconds(), out.pose);
 
   // 1b. /imu/fg_yaw — yaw-only sensor_msgs/Imu (cov_yaw, others 1e6
   //     to disable). Published in both primary and observer mode so

--- a/ros2/src/fusion_graph/test/test_pose_extrapolator.cpp
+++ b/ros2/src/fusion_graph/test/test_pose_extrapolator.cpp
@@ -1,0 +1,105 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Unit tests for PoseExtrapolator. Pure logic, no ROS plumbing.
+
+#include <cmath>
+
+#include "fusion_graph/pose_extrapolator.hpp"
+#include <gtest/gtest.h>
+
+namespace fg = fusion_graph;
+
+TEST(PoseExtrapolator, ReturnsNulloptBeforeFirstFusion)
+{
+  fg::PoseExtrapolator ex;
+  EXPECT_FALSE(ex.Extrapolate(1.0).has_value());
+}
+
+TEST(PoseExtrapolator, ReturnsBaselineWhenNoGyro)
+{
+  fg::PoseExtrapolator ex;
+  const gtsam::Pose2 baseline(1.0, 2.0, 0.5);
+  ex.OnFusionPose(10.0, baseline);
+
+  auto out = ex.Extrapolate(10.020);
+  ASSERT_TRUE(out.has_value());
+  // No IMU sample yet → no extrapolation, baseline returned as-is.
+  EXPECT_DOUBLE_EQ(out->x(), baseline.x());
+  EXPECT_DOUBLE_EQ(out->y(), baseline.y());
+  EXPECT_DOUBLE_EQ(out->theta(), baseline.theta());
+}
+
+TEST(PoseExtrapolator, ExtrapolatesYawAtConstantRate)
+{
+  fg::PoseExtrapolator ex;
+  const gtsam::Pose2 baseline(0.0, 0.0, 0.0);
+  ex.OnFusionPose(10.0, baseline);
+  // Pivot at 0.5 rad/s.
+  ex.OnImuGyro(10.005, 0.5);
+
+  // 10 ms in the future of fusion → expected yaw = 0 + 0.5 × 0.010
+  auto out = ex.Extrapolate(10.010);
+  ASSERT_TRUE(out.has_value());
+  EXPECT_DOUBLE_EQ(out->x(), 0.0);
+  EXPECT_DOUBLE_EQ(out->y(), 0.0);
+  EXPECT_NEAR(out->theta(), 0.005, 1.0e-9);
+
+  // 20 ms forward → 0.010 rad.
+  out = ex.Extrapolate(10.020);
+  ASSERT_TRUE(out.has_value());
+  EXPECT_NEAR(out->theta(), 0.010, 1.0e-9);
+}
+
+TEST(PoseExtrapolator, NegativeDtReturnsBaseline)
+{
+  fg::PoseExtrapolator ex;
+  ex.OnFusionPose(10.0, gtsam::Pose2(0.0, 0.0, 0.3));
+  ex.OnImuGyro(9.9, 1.0);
+  // Query BEFORE the fusion stamp — no time-travel, return baseline.
+  auto out = ex.Extrapolate(9.95);
+  ASSERT_TRUE(out.has_value());
+  EXPECT_DOUBLE_EQ(out->theta(), 0.3);
+}
+
+TEST(PoseExtrapolator, CapsExtrapolationAt200ms)
+{
+  fg::PoseExtrapolator ex;
+  ex.OnFusionPose(10.0, gtsam::Pose2(0.0, 0.0, 0.0));
+  ex.OnImuGyro(10.0, 1.0);
+  // 300 ms forward — beyond the 200 ms cap. Caller stalled; we
+  // return the baseline rather than a wildly extrapolated value.
+  auto out = ex.Extrapolate(10.300);
+  ASSERT_TRUE(out.has_value());
+  EXPECT_DOUBLE_EQ(out->theta(), 0.0);
+}
+
+TEST(PoseExtrapolator, RebaselinesOnFreshFusionPose)
+{
+  fg::PoseExtrapolator ex;
+  // First baseline, integrate yaw forward.
+  ex.OnFusionPose(10.0, gtsam::Pose2(0.0, 0.0, 0.0));
+  ex.OnImuGyro(10.0, 1.0);
+  auto first = ex.Extrapolate(10.050);
+  ASSERT_TRUE(first.has_value());
+  EXPECT_NEAR(first->theta(), 0.050, 1.0e-9);
+
+  // New fusion pose arrives. The integration window resets.
+  ex.OnFusionPose(10.040, gtsam::Pose2(0.10, 0.0, 0.040));
+  auto second = ex.Extrapolate(10.060);
+  ASSERT_TRUE(second.has_value());
+  // dt = 20 ms × 1 rad/s = 0.020 rad on top of the new baseline 0.040.
+  EXPECT_NEAR(second->theta(), 0.060, 1.0e-9);
+  EXPECT_NEAR(second->x(), 0.10, 1.0e-9);
+}
+
+TEST(PoseExtrapolator, NegativeGyroDoesYawNegative)
+{
+  fg::PoseExtrapolator ex;
+  ex.OnFusionPose(10.0, gtsam::Pose2(0.0, 0.0, 1.0));
+  ex.OnImuGyro(10.0, -2.0);
+  auto out = ex.Extrapolate(10.010);
+  ASSERT_TRUE(out.has_value());
+  // 10 ms × -2 rad/s = -0.020 added to baseline 1.0
+  EXPECT_NEAR(out->theta(), 0.980, 1.0e-9);
+}


### PR DESCRIPTION
## Summary
Adds `/odometry/filtered_map_fast` — a configurable-rate (default off, 100 Hz typical) Odometry stream that projects the latest iSAM2-published pose forward using the most recent IMU gyro_z sample.

Off by default (`fast_pose_publish_rate_hz: 0.0` in yaml).

## Why
Operator-perceived yaw lag during pivots was ~120-150 ms (gps_stability follow-up). After PR #232 bumped fusion to 50 Hz, the within-tick gap is 20 ms. Republishing at 100 Hz with constant-rate yaw extrapolation halves that contribution. Position is NOT extrapolated — small position changes (<2 cm at 0.30 m/s × 20 ms) are under typical display tolerance.

## Design
Pure logic isolated in `PoseExtrapolator` (header-only):
- `OnFusionPose(stamp, pose)` rebaselines
- `OnImuGyro(stamp, wz)` caches latest gyro rate
- `Extrapolate(query_t)` returns `Pose2(x, y, fusion_yaw + wz · dt)`

Sanity caps:
- Negative dt → baseline (no time-travel)
- dt > 200 ms → baseline (constant-gyro assumption invalid)

## Tests (`test_pose_extrapolator.cpp`, 7 cases)
| Case | Pins |
|---|---|
| ReturnsNulloptBeforeFirstFusion | No baseline → returns nullopt |
| ReturnsBaselineWhenNoGyro | No IMU yet → returns fusion pose unchanged |
| ExtrapolatesYawAtConstantRate | 10ms + 20ms windows match `wz * dt` exactly |
| NegativeDtReturnsBaseline | No time-travel |
| CapsExtrapolationAt200ms | Stalled caller → baseline, not wild extrapolation |
| RebaselinesOnFreshFusionPose | Integration window resets correctly |
| NegativeGyroDoesYawNegative | Sign preserved |

## Item map
P3 #15 ✅ High-rate TF publisher with IMU extrapolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)