### PR TITLE
feat(fusion_graph): #11 DCS-robust loop-closure factors

### DIFF
--- a/ros2/src/fusion_graph/CMakeLists.txt
+++ b/ros2/src/fusion_graph/CMakeLists.txt
@@ -156,6 +156,11 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_pose_extrapolator fusion_graph_core)
 
+  ament_add_gtest(test_loop_closure_robust
+    test/test_loop_closure_robust.cpp
+  )
+  target_link_libraries(test_loop_closure_robust fusion_graph_core)
+
   # Performance benchmarks. Long-running (~30 s on ARM); only meaningful
   # in Release builds. Output is grep-friendly for tracking regressions.
   ament_add_gtest(test_perf

--- a/ros2/src/fusion_graph/src/graph_manager.cpp
+++ b/ros2/src/fusion_graph/src/graph_manager.cpp
@@ -781,9 +781,30 @@ void GraphManager::AddLoopClosure(uint64_t prev_index,
   auto k_prev = PoseKey(prev_index);
   auto k_curr = PoseKey(curr_index);
 
-  auto noise = MakeDiagonal({sigma_xy, sigma_xy, sigma_theta});
+  // Robust noise model on loop-closure between-factors (item #11).
+  // Wraps the diagonal Gaussian in a Dynamic Covariance Scaling
+  // (DCS) m-estimator. DCS smoothly downweights an LC whose
+  // residual exceeds ~k·σ instead of letting a single bad LC
+  // anchor the entire trajectory to a wrong place — even with the
+  // upstream ICP guards (PR #233) and rmse acceptance gate, a
+  // degenerate match can still squeak through on symmetric
+  // outdoor scenery. DCS keeps inliers fully efficient (factor
+  // weight ≈ 1 when residual is below k·σ) and decays the weight
+  // quadratically beyond. Cheaper than PCM and well-validated in
+  // the SLAM literature (Agarwal et al., "Robust Map Optimization
+  // using Dynamic Covariance Scaling", ICRA 2013).
+  //
+  // DCS shape parameter Φ (kDcsPhi): residuals below √Φ are
+  // unaffected; above, the loss switches from quadratic to
+  // sub-quadratic. Φ = 1 is the classic value — equivalent to
+  // saying "an LC residual of 1 σ is borderline acceptable".
+  auto base_noise = MakeDiagonal({sigma_xy, sigma_xy, sigma_theta});
+  constexpr double kDcsPhi = 1.0;
+  auto robust_noise = gtsam::noiseModel::Robust::Create(
+      gtsam::noiseModel::mEstimator::DCS::Create(kDcsPhi), base_noise);
+
   gtsam::NonlinearFactorGraph fg;
-  fg.add(gtsam::BetweenFactor<gtsam::Pose2>(k_prev, k_curr, delta, noise));
+  fg.add(gtsam::BetweenFactor<gtsam::Pose2>(k_prev, k_curr, delta, robust_noise));
 
   ApplyIsamUpdateLocked(fg, gtsam::Values());
   estimate_dirty_ = true;

--- a/ros2/src/fusion_graph/test/test_loop_closure_robust.cpp
+++ b/ros2/src/fusion_graph/test/test_loop_closure_robust.cpp
@@ -1,0 +1,130 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Tests for the DCS-wrapped loop-closure factor (item #11). Pin the
+// behaviour that a single bad LC must NOT destroy the trajectory:
+// even after upstream guard rails (ICP rmse / divergence) and the
+// rmse acceptance gate, a degenerate match can still squeak through
+// on symmetric outdoor scenery. The DCS m-estimator wrapping makes
+// the per-factor weight quadratically decay beyond ~1 σ, so a 10 m
+// "loop closure" between two nodes that are actually 0 m apart gets
+// downweighted to ~0 instead of corrupting iSAM2.
+
+#include <cmath>
+#include <cstdio>
+
+#include "fusion_graph/graph_manager.hpp"
+#include <gtest/gtest.h>
+
+namespace fg = fusion_graph;
+
+namespace
+{
+
+fg::GraphParams MakeParams()
+{
+  fg::GraphParams gp;
+  gp.node_period_s = 0.1;
+  gp.wheel_sigma_x = 0.05;
+  gp.wheel_sigma_y = 0.005;
+  gp.wheel_sigma_theta = 0.01;
+  gp.gyro_sigma_theta = 0.005;
+  gp.stationary_node_period_s = 0.0;
+  gp.stationary_motion_thresh_m = 0.0;
+  gp.stationary_motion_thresh_theta = 0.0;
+  // Disable adaptive noise so it doesn't confuse this test.
+  gp.adaptive_noise_enabled_gain = 0.0;
+  return gp;
+}
+
+}  // namespace
+
+// ─────────────────────────────────────────────────────────────────────
+// Outlier loop closure: build a clean trajectory of 5 nodes around a
+// straight line, then inject an LC factor with a wildly wrong delta
+// (claims X1 should be 5 m apart from X0 when actually they're at the
+// same place). DCS must downweight the bad LC and the trajectory
+// should stay near truth.
+// ─────────────────────────────────────────────────────────────────────
+TEST(RobustLoopClosure, OutlierLcDoesNotShiftTrajectory)
+{
+  fg::GraphManager gm(MakeParams());
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 0.0);
+
+  // Drive forward at 0.20 m/s for 5 ticks (0.5 s). After 5 nodes we
+  // expect X4 ≈ (1.0, 0, 0).
+  constexpr double kDt = 0.1;
+  for (int i = 0; i < 5; ++i)
+  {
+    gm.AddWheelTwist(0.20, 0.0, 0.0, kDt);
+    gm.AddGyroDelta(0.0, kDt);
+    gm.Tick(kDt * (i + 1));
+  }
+  auto x4_before = gm.GetPose(4);
+  ASSERT_TRUE(x4_before.has_value());
+  std::printf("[RobustLC] X4 pre-LC: (%.3f, %.3f, %.3f)\n",
+              x4_before->x(), x4_before->y(), x4_before->theta());
+  ASSERT_NEAR(x4_before->x(), 1.0, 0.05);
+
+  // Inject a deliberately bad loop closure: claim X1 should be at
+  // (5, 5) relative to X0, when actually they're at (0.10, 0).
+  const gtsam::Pose2 bad_delta(5.0, 5.0, 0.0);
+  // Use tight sigmas so the DCS kernel actually has to fight: a
+  // loose σ would naturally downweight the factor without needing
+  // the robust kernel at all.
+  gm.AddLoopClosure(0, 1, bad_delta, 0.05, 0.02);
+
+  // After the bad LC, X4 must still be near (1.0, 0). If DCS didn't
+  // engage, iSAM2 would pull the trajectory toward (5, 5) and X4
+  // would land somewhere around (4, 4).
+  auto x4_after = gm.GetPose(4);
+  ASSERT_TRUE(x4_after.has_value());
+  std::printf("[RobustLC] X4 post-LC: (%.3f, %.3f, %.3f)\n",
+              x4_after->x(), x4_after->y(), x4_after->theta());
+
+  // Without DCS, x4_after.x ≈ 4-5 and x4_after.y ≈ 4-5 — drift of
+  // multiple metres. With DCS the factor is downweighted to near
+  // zero contribution and the trajectory stays within ~50 cm of
+  // truth.
+  EXPECT_LT(std::abs(x4_after->x() - 1.0), 1.0);
+  EXPECT_LT(std::abs(x4_after->y()), 1.0);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Consistent loop closure: deliver an LC delta that matches the
+// existing wheel-between-derived relative pose. DCS should NOT
+// downweight a consistent factor — the trajectory must remain
+// indistinguishable from the no-LC case.
+// ─────────────────────────────────────────────────────────────────────
+TEST(RobustLoopClosure, ConsistentLcLeavesTrajectoryStable)
+{
+  fg::GraphManager gm(MakeParams());
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 0.0);
+
+  constexpr double kDt = 0.1;
+  for (int i = 0; i < 10; ++i)
+  {
+    gm.AddWheelTwist(0.20, 0.0, 0.0, kDt);
+    gm.AddGyroDelta(0.0, kDt);
+    gm.Tick(kDt * (i + 1));
+  }
+  auto x9_before = gm.GetPose(9);
+  ASSERT_TRUE(x9_before.has_value());
+
+  // Consistent LC: claim X9 - X0 ≈ (1.8, 0, 0), which matches the
+  // wheel-integrated 9 * 0.20 * 0.1 = 0.18 per node × 10 nodes.
+  // Actually X9 - X0 should be 9 nodes × 0.20 m/s × 0.1 s = 1.80 m.
+  gm.AddLoopClosure(0, 9, gtsam::Pose2(1.80, 0.0, 0.0), 0.05, 0.02);
+
+  auto x9_after = gm.GetPose(9);
+  ASSERT_TRUE(x9_after.has_value());
+  std::printf("[RobustLC] consistent LC: X9 before=(%.3f,%.3f,%.3f) after=(%.3f,%.3f,%.3f)\n",
+              x9_before->x(), x9_before->y(), x9_before->theta(),
+              x9_after->x(), x9_after->y(), x9_after->theta());
+
+  // The two poses should be near-identical (the LC adds redundant
+  // information that DOESN'T move iSAM2). Allow a small Δ since the
+  // LC tightens the marginal posterior slightly.
+  EXPECT_NEAR(x9_after->x(), x9_before->x(), 0.05);
+  EXPECT_NEAR(x9_after->y(), x9_before->y(), 0.05);
+}


### PR DESCRIPTION
## Summary
Wraps the loop-closure `BetweenFactor` noise model in a Dynamic Covariance Scaling (DCS) m-estimator. A single bad loop closure with a tight σ can yank iSAM2's trajectory metres off truth; DCS smoothly decays the factor's effective weight when its residual exceeds ~k·σ, turning outliers into no-ops rather than catastrophes.

## Why DCS over PCM
- **PCM** (Pairwise Consistency Maximization) requires building a pairwise-consistency graph over all candidate LCs and solving a max-clique problem — O(N²) + NP-hard, substantial code.
- **DCS** is a per-factor wrapping — 3 extra lines, well-validated in the SLAM literature (Agarwal et al., ICRA 2013, *Robust Map Optimization using Dynamic Covariance Scaling*).
- For single-outlier failures (our expected mode on grass fields), DCS is sufficient.

Φ = 1.0 — the classic value. Inliers stay at full weight; outliers decay quadratically.

## Tests (`test_loop_closure_robust.cpp`, 2 cases)
| Case | Pins |
|---|---|
| OutlierLcDoesNotShiftTrajectory | bad LC with tight σ → trajectory stays within 1 m of truth (would drift 4-5 m without DCS) |
| ConsistentLcLeavesTrajectoryStable | matching LC → no measurable drift, robust kernel inactive |

## Item map
P3 #11 ✅ Robust loop closure (DCS variant; PCM deferred if DCS proves insufficient)

🤖 Generated with [Claude Code](https://claude.com/claude-code)