### PR TITLE
fix(launch): wire dock_pose_x/y into dock_yaw_to_set_pose

### DIFF
--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -745,7 +745,13 @@ def generate_launch_description() -> LaunchDescription:
         name="dock_yaw_to_set_pose",
         output="screen",
         parameters=[
+            # dock_pose_x / dock_pose_y added 2026-05-17 (PR #238) — the
+            # node now seeds the SetPose at the calibrated dock pose
+            # instead of the live GPS sample, so it needs the persisted
+            # (x, y) alongside the existing yaw.
             {"use_sim_time": use_sim_time,
+             "dock_pose_x": dock_pose_x,
+             "dock_pose_y": dock_pose_y,
              "dock_pose_yaw": dock_pose_yaw,
              "dock_pose_yaw_sigma_rad": dock_pose_yaw_sigma_rad},
         ],


### PR DESCRIPTION
Follow-up to PR #238 — the new params were declared on the node but the launch wrapper was only passing dock_pose_yaw through. Result: dock_pose_x/y stayed at the 0.0 defaults and seeded the SetPose at (0, 0) instead of the calibrated dock pose. Tiny one-liner fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)