### PR TITLE
fix(gui): route DiagnosticsPage + GpsComponent through deriveGpsStatus

### DIFF
--- a/gui/web/src/components/GpsComponent.tsx
+++ b/gui/web/src/components/GpsComponent.tsx
@@ -3,6 +3,7 @@ import {useGPS} from "../hooks/useGPS.ts";
 import { booleanFormatter, booleanFormatterInverted } from "./utils.tsx";
 import { AbsolutePoseConstants as Flags } from "../types/ros.ts";
 import {useThemeMode} from "../theme/ThemeContext.tsx";
+import {deriveGpsStatus} from "../utils/gpsStatus.ts";
 
 export function GpsComponent() {
     const {colors} = useThemeMode();
@@ -11,14 +12,13 @@ export function GpsComponent() {
     const flags = gps.flags ?? 0;
     // RTK is active when FIXED or FLOAT bit is set (not just the base RTK/GPS-fix bit)
     const hasRtk = !!((flags & Flags.FLAG_GPS_RTK_FIXED) || (flags & Flags.FLAG_GPS_RTK_FLOAT));
-    let fixType = "\u2013";
-    if ((flags & Flags.FLAG_GPS_RTK_FIXED) != 0) {
-        fixType = "RTK FIX";
-    } else if ((flags & Flags.FLAG_GPS_RTK_FLOAT) != 0) {
-        fixType = "RTK FLOAT";
-    } else if ((flags & Flags.FLAG_GPS_RTK) != 0) {
-        fixType = "GPS FIX";
-    }
+    const gpsStatus = deriveGpsStatus(flags);
+    const fixType = gpsStatus.label;
+    const fixColor =
+        gpsStatus.fixType === "RTK_FIX" ? colors.primary
+        : gpsStatus.fixType === "RTK_FLOAT" ? colors.warning
+        : gpsStatus.fixType === "GPS_FIX" ? colors.primary
+        : colors.danger;
 
     return <>
         <Row gutter={[16, 16]}>
@@ -35,7 +35,7 @@ export function GpsComponent() {
             <Col lg={8} xs={24}><Statistic title="RTK" value={hasRtk ? "Yes" : "No"}
                                         formatter={booleanFormatter}/></Col>
             <Col lg={8} xs={24}><Statistic title="Fix type" value={fixType}
-                                        valueStyle={{color: fixType.includes("FIX") ? colors.primary : fixType.includes("FLOAT") ? colors.warning : colors.danger}}/></Col>
+                                        valueStyle={{color: fixColor}}/></Col>
             <Col lg={8} xs={24}><Statistic title="Dead reckoning" value={(flags & Flags.FLAG_GPS_DEAD_RECKONING) != 0 ? "Yes" : "No"}
                                         formatter={booleanFormatterInverted}/></Col>
         </Row>

--- a/gui/web/src/pages/DiagnosticsPage.tsx
+++ b/gui/web/src/pages/DiagnosticsPage.tsx
@@ -43,7 +43,7 @@ import {useDiagnosticsSnapshot} from "../hooks/useDiagnosticsSnapshot.ts";
 import {useDiagnostics} from "../hooks/useDiagnostics.ts";
 import {useThemeMode} from "../theme/ThemeContext.tsx";
 import {useIsMobile} from "../hooks/useIsMobile";
-import {AbsolutePoseConstants} from "../types/ros.ts";
+import {deriveGpsStatus} from "../utils/gpsStatus.ts";
 import {useEffect, useMemo, useState} from "react";
 import {useSettings} from "../hooks/useSettings.ts";
 import {computeBatteryPercent} from "../utils/battery.ts";
@@ -128,12 +128,7 @@ export const DiagnosticsPage = () => {
     );
 
     const gpsFlags = gps.flags ?? 0;
-    const gpsFixType = useMemo(() => {
-        if (gpsFlags & AbsolutePoseConstants.FLAG_GPS_RTK_FIXED) return "RTK FIX";
-        if (gpsFlags & AbsolutePoseConstants.FLAG_GPS_RTK_FLOAT) return "RTK FLOAT";
-        if (gpsFlags & AbsolutePoseConstants.FLAG_GPS_RTK) return "GPS FIX";
-        return "No Fix";
-    }, [gpsFlags]);
+    const gpsFixType = useMemo(() => deriveGpsStatus(gpsFlags).label, [gpsFlags]);
 
     const orientation = pose.pose?.pose?.orientation;
     const qx = orientation?.x ?? 0;


### PR DESCRIPTION
## Summary

`utils/gpsStatus.ts:deriveGpsStatus` is the helper that consolidates the
GPS `flags → label` mapping (introduced when issue #154 closed). The
dashboard hint on `MowgliNextPage` already routes through it, but two
other surfaces — `DiagnosticsPage` and the system page's `GpsComponent` —
each carried their own inline switch and got out of sync.

Three copies of the same mapping, two of them divergent labels:

| Surface | Label for RTK Fixed | Label for No fix |
|---|---|---|
| Dashboard hint (`MowgliNextPage`) | `RTK fixed` | `No GPS` |
| Diagnostics Health-check badge | `RTK FIX` | `No Fix` |
| System page GPS card "Fix type" | `RTK FIX` | `–` |

## What changed

- `DiagnosticsPage.tsx`: drop the inline `useMemo` switch, replace with `deriveGpsStatus(gpsFlags).label`. Drops the now-unused `AbsolutePoseConstants` import.
- `GpsComponent.tsx`: same migration, plus the "Fix type" Statistic's value-style colour now branches on the `GpsFixType` discriminator returned by `deriveGpsStatus` (was `fixType.includes("FIX") | "FLOAT"` — would silently fall through to `colors.danger` once the label changed case).

11 insertions, 16 deletions across 2 files.

## Behaviour change

The two migrated surfaces now show the dashboard's labels (`RTK fixed` / `RTK float` / `GPS fix` / `No GPS`) instead of the previous uppercase + `No Fix` / `–` strings. That aligns them with `MowgliNextPage`, so the same GPS state reads the same on every surface.

If you'd rather keep the uppercase prominent form on the diagnostics tile, the right move is to change `deriveGpsStatus`'s return labels (and the dashboard inherits the change) — happy to flip the PR that way.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Visual: load DiagnosticsPage during RTK Fixed / Float / No-RTK windows, confirm GPS health badge label matches the dashboard hint
- [ ] Visual: GPS card on the system page renders fix-type label in correct colour (green for Fixed/SPS, amber for Float, red for No GPS)