### PR TITLE
fix(gui): bind LiDAR toggle to lidar_enabled (the actual yaml key)

### DIFF
--- a/gui/web/src/components/settings/SensorsSection.tsx
+++ b/gui/web/src/components/settings/SensorsSection.tsx
@@ -17,7 +17,7 @@ export const SensorsSection: React.FC<Props> = ({ values, onChange }) => {
     // independently from the Localization tab (e.g. to use the graph without
     // scan factors), but the defaults stay sensible.
     const handleLidarToggle = (enabled: boolean) => {
-        onChange("use_lidar", enabled);
+        onChange("lidar_enabled", enabled);
         onChange("use_fusion_graph", enabled);
     };
 
@@ -39,7 +39,7 @@ export const SensorsSection: React.FC<Props> = ({ values, onChange }) => {
                         </Paragraph>
                     </div>
                     <Switch
-                        checked={values.use_lidar ?? false}
+                        checked={values.lidar_enabled ?? false}
                         onChange={handleLidarToggle}
                     />
                 </div>


### PR DESCRIPTION
## Summary

`SensorsSection`'s LiDAR Switch was bound to `values.use_lidar` for the
`checked` prop and the `onChange` write, but the actual yaml key the
GUI loads from / writes to is `lidar_enabled`. The `use_lidar` key is
legacy — nothing on the ROS 2 side consumes it, and the section's own
key whitelist in `useSettingsManager.ts` already lists `lidar_enabled`
(without `use_lidar`), so write-back was already inconsistent.

## Symptoms

On a robot with LiDAR + K-ICP / fusion_graph running normally:

- Switch reads `undefined → false` regardless of actual yaml state — shows "off" while the LD19 driver and scan-matching are active.
- Toggling persists `use_lidar: true` into the yaml; nothing reads that key, so on next load the Switch is back to "off".

## Change

Two-line fix in `gui/web/src/components/settings/SensorsSection.tsx`:

- `handleLidarToggle`: `onChange("use_lidar", …)` → `onChange("lidar_enabled", …)`
- `<Switch checked>`: `values.use_lidar` → `values.lidar_enabled`

`use_fusion_graph` continues to flip alongside (unchanged behaviour).

## Test plan

- [ ] Load a `mowgli_robot.yaml` with `lidar_enabled: true` — Switch shows "on"
- [ ] Toggle off, save, reload — Switch correctly persists across reload, yaml contains `lidar_enabled: false`, no stray `use_lidar` key written
- [ ] Toggle on — `use_fusion_graph: true` written alongside `lidar_enabled: true`