### PR TITLE
fix(fusion_graph): explicit /set_pose suppresses cold-boot scan-match relocalize

### DIFF
--- a/ros2/src/fusion_graph/src/fusion_graph_node.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node.cpp
@@ -980,9 +980,25 @@ void FusionGraphNode::OnSetPose(geometry_msgs::msg::PoseWithCovarianceStamped::C
   if (!snap)
     return;
   graph_->ForceAnchor(snap->node_index, pose, sigma_xy, sigma_theta);
+
+  // Suppress the cold-boot scan-match relocalize heuristic. The
+  // explicit seed (typically dock_yaw_to_set_pose firing on a
+  // charging rising edge with the calibrated dock_pose from
+  // mowgli_robot.yaml) is more authoritative than ICP against the
+  // persisted graph's old scans — especially when the operator
+  // has re-calibrated dock_pose since the persisted session, in
+  // which case the scan-match relocalize would pull the trajectory
+  // back to the OLD dock anchor. Mark relocalize_done_ so OnScan
+  // skips the heuristic on the very first incoming scan.
+  relocalize_done_ = true;
+  // Same reasoning for the RTK-autoload override path: the seed
+  // we just applied is the operator's intent, GPS shouldn't fight
+  // it within the threshold window.
+  rtk_autoload_override_done_ = true;
+
   RCLCPP_INFO(get_logger(),
               "fusion_graph: re-anchored node %lu via /set_pose to "
-              "(%.2f, %.2f, %.2f rad)",
+              "(%.2f, %.2f, %.2f rad) — relocalize suppressed",
               static_cast<unsigned long>(snap->node_index),
               pose.x(),
               pose.y(),


### PR DESCRIPTION
Field-observed sequence after PR #242:
```
re-anchored node 90144 via /set_pose to (0.11, -0.16, -2.51)
relocalized via scan match node=73832 → (-0.02, -0.04, -0.07)  ← overrides
```

OnSetPose already ForceAnchors at the operator-calibrated dock_pose, but the cold-boot scan-match relocalize runs unconditionally on the first valid scan AND ForceAnchors AGAIN at the persisted graph's old anchor. Order matters: when the operator has explicitly seeded the pose, the heuristic should defer.

Fix: set `relocalize_done_ = true` and `rtk_autoload_override_done_ = true` in OnSetPose. Authority order:
1. Explicit /set_pose (dock_yaw_to_set_pose on charging, or manual)
2. Cold-boot scan-match heuristic
3. Live observations

🤖 Generated with [Claude Code](https://claude.com/claude-code)