### PR TITLE
feat: reliable docking combo (3 fixes)

### DIFF
--- a/gui/web/src/components/RobotComponentEditor.tsx
+++ b/gui/web/src/components/RobotComponentEditor.tsx
@@ -9,6 +9,7 @@ import { useImuYawCalibration } from "../hooks/useImuYawCalibration.ts";
 import { useApi } from "../hooks/useApi.ts";
 import { getQuaternionFromHeading } from "../utils/map.tsx";
 import { usePose } from "../hooks/usePose.ts";
+import { useStatus } from "../hooks/useStatus.ts";
 
 const { Text } = Typography;
 
@@ -124,6 +125,7 @@ export const RobotComponentEditor: React.FC<Props> = ({ values, onChange }) => {
     const { notification, modal } = App.useApp();
     const guiApi = useApi();
     const pose = usePose();
+    const hwStatus = useStatus();
     const [settingDock, setSettingDock] = useState(false);
 
     // Pull the robot's current map-frame pose. Yaw is the EKF-fused
@@ -135,6 +137,16 @@ export const RobotComponentEditor: React.FC<Props> = ({ values, onChange }) => {
     const robotY = pose.pose?.pose?.position?.y;
     const robotYaw = pose.motion_heading;
     const poseAvailable = robotX != null && robotY != null && robotYaw != null;
+    // Require physical charging contact when calibrating the dock pose.
+    // Without this guard, operators sometimes clicked "Set dock pose"
+    // while the robot was close-but-not-charging (visually parked on the
+    // dock, but the contacts hadn't seated). The stored dock_pose then
+    // pointed to that off-contact location, and every subsequent
+    // re-docking aimed there — robot stopping 1-3 cm short of the
+    // charging cradle on every run. By gating the action on
+    // is_charging=true we guarantee the captured pose is the exact
+    // physical contact point, removing one source of dock-approach drift.
+    const isCharging = !!hwStatus.is_charging;
 
     const writeDockPose = useCallback(
         async (px: number, py: number, yaw: number) => {
@@ -895,16 +907,27 @@ export const RobotComponentEditor: React.FC<Props> = ({ values, onChange }) => {
                                     </Typography.Text>
                                 </Col>
                                 <Col flex="none">
-                                    <Button
-                                        type="primary"
-                                        size="small"
-                                        icon={<EnvironmentOutlined />}
-                                        loading={settingDock}
-                                        disabled={!poseAvailable}
-                                        onClick={handleSetDockAtRobot}
+                                    <Tooltip
+                                        title={!isCharging
+                                            ? "Place robot on dock with charging contacts engaged before setting the reference pose"
+                                            : !poseAvailable
+                                                ? "Waiting for robot pose"
+                                                : "Capture the robot's current pose as the canonical dock reference"}
                                     >
-                                        Set dock pose
-                                    </Button>
+                                        {/* span wrapper lets the Tooltip target a disabled Button */}
+                                        <span>
+                                            <Button
+                                                type="primary"
+                                                size="small"
+                                                icon={<EnvironmentOutlined />}
+                                                loading={settingDock}
+                                                disabled={!poseAvailable || !isCharging}
+                                                onClick={handleSetDockAtRobot}
+                                            >
+                                                Set dock pose
+                                            </Button>
+                                        </span>
+                                    </Tooltip>
                                 </Col>
                             </Row>
                         </div>

--- a/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
+++ b/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
@@ -192,6 +192,15 @@ mowgli:
     undock_distance: 1.5           # reverse distance when undocking (m)
     undock_speed: 0.15             # reverse speed (m/s)
     dock_approach_distance: 1.0    # distance to staging pose in front of dock
+    # Overshoot (m) applied to dock_pose in the body forward direction
+    # when configuring opennav_docking's home_dock target. The robot
+    # then aims at (dock_pose + overshoot) instead of dock_pose itself;
+    # combined with docking_threshold (5 cm before the target), it
+    # physically pushes past the calibrated pose so the charging
+    # contacts seat firmly even when fusion's pose has 1-3 cm of
+    # residual RTK / lever-arm noise. 5 cm matches docking_threshold
+    # so a perfect-fusion robot stops exactly at the calibrated pose.
+    dock_approach_overshoot: 0.05
     dock_max_retries: 3
     dock_use_charger_detection: true
     # Charging-current threshold (A) at which SimpleChargingDock considers

--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -706,7 +706,16 @@ docking_server:
     # the cradle. Halving v_linear_max and doubling slowdown_radius gives
     # a calm ~5 cm/s final approach with plenty of braking distance for
     # the 10 Hz controller loop to detect charging and stop cleanly.
-    controller.v_linear_min: 0.05
+    # v_linear_min raised 0.05 → 0.13 to stay above the firmware motor
+    # PWM deadband (~PWM 40 → ~0.13 m/s). Below that the graceful-
+    # controller's smooth slowdown produced cmd_vx values that didn't
+    # actuate the wheels — measured 2026-05-17: robot stuck oscillating
+    # 5-15 cm short of the dock contacts; docking_server timed out
+    # repeatedly. With the floor at 0.13, the closed-loop deadband
+    # compensator in hardware_bridge (PR #228) still kicks in if the
+    # wheels stall, and the controller always asks for at least one
+    # deadband-worth of push.
+    controller.v_linear_min: 0.13
     controller.v_linear_max: 0.12
     controller.v_angular_max: 0.5
     controller.slowdown_radius: 0.5

--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -390,6 +390,8 @@ def generate_launch_description() -> LaunchDescription:
             rt_rp.get("coverage_xy_tolerance", coverage_xy_tolerance))
         dock_approach_distance = float(
             rt_rp.get("dock_approach_distance", dock_approach_distance))
+        dock_approach_overshoot = float(
+            rt_rp.get("dock_approach_overshoot", 0.05))
         dock_charging_threshold = float(
             rt_rp.get("dock_charging_threshold", dock_charging_threshold))
         # Defensive clip: a stale per-site mowgli_robot.yaml can carry
@@ -472,7 +474,22 @@ def generate_launch_description() -> LaunchDescription:
         home_dock = (doc.setdefault("docking_server", {})
                         .setdefault("ros__parameters", {})
                         .setdefault("home_dock", {}))
-        home_dock["pose"] = [dock_pose_x, dock_pose_y, dock_pose_yaw]
+        # Apply dock_approach_overshoot in the body forward direction.
+        # opennav_docking's graceful_controller will drive toward this
+        # shifted target and stop at docking_threshold (5 cm) before it,
+        # putting the robot physically at the calibrated dock_pose with
+        # firm contact on the charging cradle — instead of stopping
+        # 5 cm short like the un-offset configuration did 2026-05-17.
+        # The overshoot is yaml-tunable (dock_approach_overshoot in
+        # mowgli_robot.yaml); 0 disables the shift cleanly.
+        import math as _math
+        _cos_yaw = _math.cos(dock_pose_yaw)
+        _sin_yaw = _math.sin(dock_pose_yaw)
+        home_dock["pose"] = [
+            dock_pose_x + dock_approach_overshoot * _cos_yaw,
+            dock_pose_y + dock_approach_overshoot * _sin_yaw,
+            dock_pose_yaw,
+        ]
         # Staging pose offset along the dock's X axis (negative = behind
         # the dock, the side the robot approaches from). yaml exposes
         # dock_approach_distance as a positive metres knob in the GUI;


### PR DESCRIPTION
Three combined changes to eliminate the most frequent docking failure mode (robot stops 5-15 cm short of charging contacts, opennav_docking retries, eventually aborts).

## Changes
1. **opennav_docking controller.v_linear_min: 0.05 → 0.13 m/s** — keeps cmd_vx above firmware PWM deadband so motors actuate during the slow final approach.
2. **dock_approach_overshoot (new yaml param, default 0.05 m)** — launch wraps opennav_docking's home_dock.pose with a body-forward shift. opennav_docking targets the shifted pose, stops at docking_threshold (5 cm) before it = exactly at the calibrated dock_pose. Robot pushes into charging contacts instead of stopping 5 cm short.
3. **GUI: 'Set dock pose' button gated on is_charging=true** — operator can no longer set dock_pose while the robot is visually-but-not-electrically docked. Tooltip explains why.

## Test plan
- [x] Code edits
- [ ] CI build + Docker push
- [ ] On robot: GUI button shows as disabled when off dock; enabled+set works when charging
- [ ] CMD=2 HOME end-to-end: dock approach reaches contacts without retry loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)