### PR TITLE
fix(scan_deskew): per-ray ω from IMU buffer interpolation

### DIFF
--- a/ros2/src/mowgli_localization/src/scan_deskew_node.cpp
+++ b/ros2/src/mowgli_localization/src/scan_deskew_node.cpp
@@ -18,6 +18,19 @@
 // re-binned into the original LaserScan grid; each output bin keeps
 // the nearest range when multiple input rays remap to it.
 //
+// **Per-ray ω from an IMU history buffer.** Older versions used the
+// single most recent gyro_z sample for every ray of every scan. That
+// over-corrected during transitions (e.g. when cmd_vel went 0.8 → 0
+// and the robot decelerated 0.6 → 0 rad/s within a scan window):
+// `latest_omega_z_` was still 0.8 rad/s but the scan's average ω was
+// much lower, so the deskew rotated all rays by ~5° too much, making
+// the scan appear to "follow then snap back" in the costmap. The
+// operator observed this as phantom rotations during pivots.
+//
+// Fix: keep a sliding-window buffer of (stamp, ω_z) IMU samples and
+// linearly interpolate to the actual time of each ray. Buffer depth
+// covers ~150 ms — one scan period plus margin for IMU latency.
+//
 // Linear motion compensation is currently skipped — at typical
 // mowing speeds (≤ 0.3 m/s × ≤ 0.1 s scan) the resulting < 30 mm
 // displacement is negligible compared to the rotational smear, and
@@ -29,6 +42,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <deque>
 #include <limits>
 
 #include "rclcpp/qos.hpp"
@@ -62,6 +76,12 @@ public:
     // fall back to passthrough rather than apply a wildly wrong ω.
     imu_max_age_s_ = declare_parameter<double>("imu_max_age_s", 0.5);
 
+    // IMU buffer depth in seconds. Should cover one scan window plus
+    // some margin (LiDAR end-stamp is the last ray; the first ray is
+    // scan_duration before that, plus any IMU-to-scan publish lag).
+    imu_buffer_horizon_s_ =
+        declare_parameter<double>("imu_buffer_horizon_s", 0.5);
+
     rclcpp::QoS qos_sensor = rclcpp::SensorDataQoS();
     pub_ = create_publisher<sensor_msgs::msg::LaserScan>(output_topic, qos_sensor);
 
@@ -73,33 +93,112 @@ public:
     sub_imu_ = create_subscription<sensor_msgs::msg::Imu>(
         imu_topic,
         qos_sensor,
-        [this](sensor_msgs::msg::Imu::ConstSharedPtr msg)
-        {
-          latest_omega_z_ = msg->angular_velocity.z;
-          latest_imu_t_ = msg->header.stamp;
-          have_imu_ = true;
-        });
+        [this](sensor_msgs::msg::Imu::ConstSharedPtr msg) { on_imu(*msg); });
 
     pub_count_ = 0;
     skipped_count_ = 0;
+    interp_misses_ = 0;
     create_wall_timer(std::chrono::seconds(15),
                       [this]() {
                         RCLCPP_INFO(get_logger(),
                                     "scan_deskew stats: published=%zu, "
-                                    "passthrough(stale-IMU)=%zu, last_ω_z=%.3f rad/s",
-                                    pub_count_, skipped_count_, latest_omega_z_);
+                                    "passthrough(stale-IMU)=%zu, "
+                                    "interp_misses=%zu, last_ω_z=%.3f rad/s, "
+                                    "buf_size=%zu",
+                                    pub_count_, skipped_count_, interp_misses_,
+                                    latest_omega_z_, imu_buffer_.size());
                       });
 
     RCLCPP_INFO(get_logger(),
-                "scan_deskew started — %s -> %s (reference=%s, imu=%s, max_age=%.2fs)",
+                "scan_deskew started — %s -> %s (reference=%s, imu=%s, "
+                "max_age=%.2fs, buffer_horizon=%.2fs)",
                 input_topic.c_str(),
                 output_topic.c_str(),
                 reference_.c_str(),
                 imu_topic.c_str(),
-                imu_max_age_s_);
+                imu_max_age_s_,
+                imu_buffer_horizon_s_);
   }
 
 private:
+  struct ImuSample
+  {
+    double t_s;     // ROS seconds
+    double omega_z; // rad/s
+  };
+
+  void on_imu(const sensor_msgs::msg::Imu& msg)
+  {
+    const rclcpp::Time stamp(msg.header.stamp);
+    const double t = stamp.seconds();
+    if (t <= 0.0)
+    {
+      // Bad stamp — skip rather than corrupt the buffer order.
+      return;
+    }
+    const double wz = msg.angular_velocity.z;
+    imu_buffer_.push_back({t, wz});
+    latest_omega_z_ = wz;
+    latest_imu_t_ = stamp;
+    have_imu_ = true;
+
+    // Trim entries older than imu_buffer_horizon_s_ before the newest.
+    while (!imu_buffer_.empty() &&
+           (t - imu_buffer_.front().t_s) > imu_buffer_horizon_s_)
+    {
+      imu_buffer_.pop_front();
+    }
+  }
+
+  // Linear interpolation of ω_z at query time `t_s`. Returns the
+  // interpolated value via `omega_out` and `true` on success. If `t_s`
+  // falls outside the buffer (e.g. before the oldest sample or after
+  // the newest), the caller decides what to do; `omega_out` is then
+  // set to the nearest endpoint value.
+  bool interp_omega(double t_s, double& omega_out) const
+  {
+    if (imu_buffer_.empty())
+    {
+      omega_out = 0.0;
+      return false;
+    }
+    if (t_s <= imu_buffer_.front().t_s)
+    {
+      // Query predates buffer — use oldest sample as best guess.
+      omega_out = imu_buffer_.front().omega_z;
+      return false;
+    }
+    if (t_s >= imu_buffer_.back().t_s)
+    {
+      // Query past newest — use newest sample. The caller can decide
+      // to gate on the gap if it matters.
+      omega_out = imu_buffer_.back().omega_z;
+      return false;
+    }
+    // Buffer is small (≤ ~50 samples for 0.5 s @ 100 Hz IMU) → linear
+    // scan is cheaper than binary search and avoids the iterator
+    // arithmetic that std::lower_bound on a deque incurs.
+    for (size_t i = 1; i < imu_buffer_.size(); ++i)
+    {
+      const auto& b = imu_buffer_[i];
+      if (b.t_s >= t_s)
+      {
+        const auto& a = imu_buffer_[i - 1];
+        const double dt = b.t_s - a.t_s;
+        if (dt <= 0.0)
+        {
+          omega_out = b.omega_z;
+          return true;
+        }
+        const double f = (t_s - a.t_s) / dt;
+        omega_out = a.omega_z + f * (b.omega_z - a.omega_z);
+        return true;
+      }
+    }
+    omega_out = imu_buffer_.back().omega_z;
+    return false;
+  }
+
   void on_scan(const sensor_msgs::msg::LaserScan& in)
   {
     sensor_msgs::msg::LaserScan out = in;
@@ -135,9 +234,11 @@ private:
       std::fill(out.intensities.begin(), out.intensities.end(), 0.0f);
     }
 
-    const double omega = latest_omega_z_;
-    // Reference offset: for "end" the last ray (i = n-1) has dt = 0;
-    // for "start" the first ray (i = 0) has dt = 0.
+    // Scan reference time. The published header.stamp is the timestamp
+    // of the reference ray (last for "end", first for "start"). Build
+    // an absolute time per ray for the IMU buffer query.
+    const rclcpp::Time scan_stamp(in.header.stamp);
+    const double scan_stamp_s = scan_stamp.seconds();
     const double ref_offset_s =
         (reference_ == "start") ? 0.0 : static_cast<double>(in.time_increment) * (n - 1);
 
@@ -154,14 +255,40 @@ private:
         continue;
       }
 
+      // dt is the ray's time offset relative to the reference. For
+      // "end", dt is negative for early rays (they were sampled
+      // before the stamp). We want ω at the ray's time, not at the
+      // reference, so the absolute ray time is:
+      //     t_ray = scan_stamp_s + dt
       const double dt = static_cast<double>(in.time_increment) * i - ref_offset_s;
+      const double t_ray = scan_stamp_s + dt;
+
+      double omega_at_ray = 0.0;
+      const bool ok = interp_omega(t_ray, omega_at_ray);
+      if (!ok)
+      {
+        // t_ray fell outside the IMU buffer — interp_omega already
+        // populated omega_at_ray with the nearest endpoint, but
+        // bump the counter so the rate is visible in stats.
+        interp_misses_++;
+      }
+
       // Geometric: at ray-time the lidar had orientation θ_i, at scan-
-      // stamp time it has θ_ref = θ_i + ω·(t_ref - t_i). The ray's
-      // endpoint angle expressed in the scan-stamp lidar frame is
-      // shifted by -(θ_ref - θ_i) = -ω·(t_ref - t_i) = +ω·dt.
+      // stamp time it has θ_ref = θ_i + ∫ω dt over (t_ray, t_ref).
+      // The exact integral would be ∫ω(t)dt; for short dt (≤ 100 ms)
+      // and smoothly-varying ω, the trapezoidal approximation
+      // 0.5 · (ω_at_ray + ω_at_ref) · dt is more accurate than
+      // either endpoint alone — but the cost is one extra interp.
+      // We use ω_at_ray · dt which is a first-order approximation
+      // and matches the previous algebra; the buffer-driven ω is the
+      // dominant accuracy gain. Switch to trapezoidal in a follow-up
+      // if residual smear during fast ω transients is still visible.
       const double alpha = static_cast<double>(ang_min) +
                            static_cast<double>(ang_inc) * static_cast<double>(i);
-      const double alpha_corr = alpha + omega * dt;
+      // dt is t_ray - t_ref (negative for "end" mode early rays). The
+      // ray's endpoint angle expressed in the scan-stamp lidar frame
+      // is shifted by -(θ_ref - θ_i) = -ω·(t_ref - t_ray) = +ω·dt.
+      const double alpha_corr = alpha + omega_at_ray * dt;
 
       // Re-bin into the output grid (nearest bin).
       const int bin = static_cast<int>(
@@ -193,13 +320,20 @@ private:
   rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
   rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr pub_;
 
+  // IMU history. Deque so the trim path is O(1) on the oldest end.
+  // Bounded by imu_buffer_horizon_s_ — at 100 Hz IMU × 0.5 s = 50
+  // samples max, fits comfortably in CPU cache.
+  std::deque<ImuSample> imu_buffer_;
+
   double latest_omega_z_{0.0};
   rclcpp::Time latest_imu_t_{0, 0, RCL_ROS_TIME};
   bool have_imu_{false};
   std::string reference_{"end"};
   double imu_max_age_s_{0.5};
+  double imu_buffer_horizon_s_{0.5};
   size_t pub_count_{0};
   size_t skipped_count_{0};
+  size_t interp_misses_{0};
 };
 
 }  // namespace mowgli_localization


### PR DESCRIPTION
## Why
Operator observed 'phantom rotations in the costmap during pivots' — scan appears to follow the rotation then snap back. Root cause: `scan_deskew_node` was using `latest_omega_z_` (single most recent IMU sample) for every ray of every scan. During fast ω transients (deceleration after cmd=0, motor stall on impulse), that snapshot is stale relative to the average ω over the scan window, so every ray gets the wrong correction.

## How
Keep a sliding-window buffer of (stamp, ω_z) IMU samples for `imu_buffer_horizon_s` (default 0.5 s) and linearly interpolate to each ray's absolute time. At 100 Hz IMU × 0.5 s = 50 samples max; trivial CPU.

```
t_ray = scan_stamp_s + (i * time_increment - ref_offset_s)
ω(t_ray) = interp(buffer, t_ray)
α_corr = α + ω(t_ray) · dt
```

## Tests
Manually validated: when ω is constant, output matches the previous algorithm. When ω is transitioning, the new path picks the actual per-ray value instead of the stale 'latest'.

## Params
- `imu_buffer_horizon_s`: new, default 0.5 (one scan period + margin)

## Diagnostics
- `interp_misses`: new stat counter, incremented when a ray's absolute time falls outside the buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)