### PR TITLE
fix(battery): default battery_full_voltage 28.5 → 28.0 (YardForce500 SLA)

### DIFF
--- a/gui/asserts/mower_config.schema.json
+++ b/gui/asserts/mower_config.schema.json
@@ -408,8 +408,8 @@
         "battery_full_voltage": {
           "type": "number",
           "title": "Full Voltage",
-          "default": 28.5,
-          "description": "Voltage at which battery is considered full."
+          "default": 28.0,
+          "description": "Voltage at which battery is considered full. Default 28.0 matches YardForce500 SLA packs on the dock; raise if your pack genuinely reaches a higher resting voltage."
         },
         "battery_empty_voltage": {
           "type": "number",

--- a/gui/web/src/utils/battery.ts
+++ b/gui/web/src/utils/battery.ts
@@ -1,6 +1,8 @@
 /** Default battery voltage thresholds — must match mower_config.schema.json */
 export const BATTERY_DEFAULTS = {
-    fullVoltage: 28.5,
+    // YardForce500 SLA packs top out around 28.0 V at the dock; the old
+    // 28.5 V default capped the displayed percent at 88.9 % even when full.
+    fullVoltage: 28.0,
     emptyVoltage: 24.0,
     criticalVoltage: 23.0,
 } as const;

--- a/install/config/mowgli/mowgli_robot.yaml
+++ b/install/config/mowgli/mowgli_robot.yaml
@@ -29,7 +29,11 @@ mowgli:
         battery_critical_voltage: 23
         battery_empty_voltage: 24
         battery_full_percent: 95
-        battery_full_voltage: 28.5
+        # YardForce500 SLA packs top out at ~28.0 V on the dock. Earlier
+        # default of 28.5 V capped the displayed percent at 88.9 % even when
+        # fully charged. Operators with a pack that truly reaches 28.5 V can
+        # override this here.
+        battery_full_voltage: 28.0
         battery_low_percent: 20
 
         # ── Chassis (YardForce500 measured) ─────────────────────────

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -422,9 +422,11 @@ private:
     declare_parameter<double>("chassis_width", 0.40);
     declare_parameter<double>("chassis_length", 0.60);
 
-    // Battery voltage curve — configurable via mowgli_robot.yaml
+    // Battery voltage curve — configurable via mowgli_robot.yaml.
+    // YardForce500 SLA packs top out around 28.0 V on the dock; the previous
+    // default of 28.5 V capped the displayed percent at 88.9 % when full.
     battery_full_voltage_ =
-        static_cast<float>(declare_parameter<double>("battery_full_voltage", 28.5));
+        static_cast<float>(declare_parameter<double>("battery_full_voltage", 28.0));
     battery_empty_voltage_ =
         static_cast<float>(declare_parameter<double>("battery_empty_voltage", 24.0));
 
@@ -527,7 +529,7 @@ private:
   bool undock_ready_{false};
 
   // Battery voltage curve parameters
-  float battery_full_voltage_{28.5f};
+  float battery_full_voltage_{28.0f};
   float battery_empty_voltage_{24.0f};
 };
 


### PR DESCRIPTION
## Problem

Deployed YardForce500 SLA packs top out at ~28.0 V on the dock, not 28.5 V. With the previous default the linear voltage→percent interpolation
```
pct = 100 * (v - empty) / (full - empty)
    = 100 * (28.0 - 24.0) / (28.5 - 24.0)
    = 88.9 %
```
caps the displayed level at 88.9 % even when the pack is fully charged. Operators see "89 %" after 12 h on the dock and report "the GUI never shows 100 %".

## Fix

Lower the default to 28.0 V in all four canonical places that ship the YardForce500 baseline configuration:

| File | Change |
|---|---|
| `install/config/mowgli/mowgli_robot.yaml` | `battery_full_voltage: 28.5` → `28.0` (+ comment) |
| `ros2/src/mowgli_behavior/src/behavior_tree_node.cpp` | `declare_parameter("battery_full_voltage", 28.5)` → `28.0`, member init `28.5f` → `28.0f` |
| `gui/web/src/utils/battery.ts` | `BATTERY_DEFAULTS.fullVoltage: 28.5` → `28.0` |
| `gui/asserts/mower_config.schema.json` | `default: 28.5` → `28.0`, description tightened |

## Effect

- A fully charged 28.0 V pack now reads 100 % in the GUI.
- The 20 %-percent docking trigger lands at `0.20 * (28.0 - 24.0) + 24 = 24.8 V` (was 24.9 V) — operationally identical.
- Operators with a pack that genuinely tops at 28.5 V (or any other voltage) override via `battery_full_voltage` in their `mowgli_robot.yaml`; the GUI Battery section also exposes the field.

## Not touched

`gui/web/src/constants/mowerModels.ts` lists `battery_full_voltage: 28.5` for each YardForce variant (500 / 500B / SA650 / 900 ECO / LUV1000RI). Those are per-model GUI defaults that override the global on model-select. I left them as-is in this PR because the SA650 / 900 ECO / LUV1000RI pack specs haven't been re-measured by me — happy to extend to all five if you'd like, but didn't want to drag in changes I can't field-verify.

## Test plan

- [ ] Fresh checkout → mow until docked → GUI shows 100 % battery (not 89 %).
- [ ] Override `battery_full_voltage: 28.5` in a local yaml → GUI honours the override → "89 %" behaviour returns (regression-test the override path).
- [ ] LOW_BATTERY_DOCKING trigger continues to fire at the operator-set `battery_low_percent` threshold (default 20 %) — same as before, just at 24.8 V instead of 24.9 V.

## Related

Independent of #247 (low-pass filter on `v_battery` to suppress load-spike LOW_BATTERY trips). Either PR works without the other; together they make displayed percent both *accurate* and *stable*.