### PR TITLE
feat(fusion_graph): Pose2 IMU preintegration with joint bias optim (#3 full)

### DIFF
--- a/ros2/src/fusion_graph/config/fusion_graph.yaml
+++ b/ros2/src/fusion_graph/config/fusion_graph.yaml
@@ -81,6 +81,18 @@ fusion_graph_node:
     gyro_bias_ema_tau_s: 30.0
     gyro_bias_max_sample_rad_per_s: 0.10
 
+    # ── Full IMU preintegration (joint bias optim, item #3 final) ────
+    # When true, replaces the EMA bias path with a per-node bias
+    # variable in the graph and a GyroPreintFactor on each pose pair.
+    # iSAM2 jointly optimises trajectory + bias. Higher quality yaw
+    # tracking (especially during long motion windows where the EMA
+    # path can't update) at the cost of more graph state.
+    # Default false until field-validated; flip to true to opt in.
+    use_imu_preint: false
+    gyro_noise_density_rad_per_s: 0.015
+    gyro_bias_rw_rad_per_s: 0.001
+    gyro_bias_prior_sigma_rad_per_s: 0.05
+
     # ── Adaptive process noise on wheel σ_x ────────────────────────────
     # Inflates wheel_sigma_x when the |dtheta_wheel - dtheta_gyro|
     # residual EMA exceeds the floor. Slip on wet grass / slope causes

--- a/ros2/src/fusion_graph/include/fusion_graph/factors.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/factors.hpp
@@ -59,6 +59,66 @@ private:
 };
 
 // ---------------------------------------------------------------------------
+// GyroPreintFactor
+// ---------------------------------------------------------------------------
+//
+// Ternary factor on (Pose2_prev, Pose2_curr, double_bias_curr) that
+// encodes a gyro-preintegrated yaw delta with a jointly-estimated
+// bias state.
+//
+// Background: GTSAM ships PreintegratedImuMeasurements for the full
+// 3D IMU case (accel + gyro, Pose3 + bias-6D). Our robot is planar
+// with a single useful gyro axis (z), so we implement a stripped-down
+// version: integrate (ω_z - b̂) over the inter-node interval and
+// emit a between-factor on yaw with a bias-correction term.
+//
+// Error:
+//   e = wrap( (θ_curr - θ_prev) - (Δθ_preint - bias_curr · dt_total) )
+//
+// where Δθ_preint = Σ_i (ω_z,i - b̂) · dt_i is the bias-corrected
+// integral computed at preintegration time with the bias estimate b̂
+// from the previous node, and the factor expects the optimiser to
+// settle on `bias_curr · dt_total` ≈ (true bias − b̂) · dt_total as
+// the residual correction.
+//
+// Why a single scalar bias per node instead of a continuous random-walk:
+// a random-walk needs additional BetweenFactor<double> chains plus a
+// process noise tuning step. For our drift timescales (minutes vs
+// graph cadence 20 ms) the per-node bias variable is a stable proxy —
+// successive nodes will share nearly the same bias unless an
+// observation perturbs them, naturally smoothing.
+//
+// Noise model on this factor: σ_yaw = √(N · σ_gyro² · dt²) where N is
+// the number of IMU samples integrated. Caller passes the precomputed
+// preint covariance.
+class GyroPreintFactor : public gtsam::NoiseModelFactor3<gtsam::Pose2, gtsam::Pose2, double>
+{
+public:
+  using This = GyroPreintFactor;
+  using Base = gtsam::NoiseModelFactor3<gtsam::Pose2, gtsam::Pose2, double>;
+
+  GyroPreintFactor(gtsam::Key key_prev,
+                   gtsam::Key key_curr,
+                   gtsam::Key key_bias_curr,
+                   double delta_theta_preint,
+                   double dt_total,
+                   const gtsam::SharedNoiseModel& model);
+
+  gtsam::Vector evaluateError(const gtsam::Pose2& X_prev,
+                              const gtsam::Pose2& X_curr,
+                              const double& bias_curr,
+                              OptMat H1 = nullptr,
+                              OptMat H2 = nullptr,
+                              OptMat H3 = nullptr) const override;
+
+  gtsam::NonlinearFactor::shared_ptr clone() const override;
+
+private:
+  double delta_theta_preint_;
+  double dt_total_;
+};
+
+// ---------------------------------------------------------------------------
 // YawUnaryFactor
 // ---------------------------------------------------------------------------
 //

--- a/ros2/src/fusion_graph/include/fusion_graph/graph_manager.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/graph_manager.hpp
@@ -148,6 +148,39 @@ struct GraphParams
   // produces residual gyro samples on a truly parked robot.
   double stationary_gyro_thresh_rad_per_s = 0.10;
 
+  // Full IMU preintegration with joint bias optimisation.
+  //
+  // When true, AddGyroDelta accumulates Σω·dt AND Σ(dt²·σ_gyro²) for
+  // the variance, and CreateNodeLocked emits a ternary
+  // GyroPreintFactor(X_prev, X_curr, bias_curr) along with a
+  // random-walk BetweenFactor<double> on bias_{prev}→bias_{curr}.
+  // The optimiser then solves for the trajectory AND the bias
+  // jointly — same machinery GTSAM ships for the full Pose3 case,
+  // tailored here to our planar Pose2 graph.
+  //
+  // When false (default), the existing pragmatic EMA bias estimator
+  // remains active and the per-node BetweenFactor<Pose2> carries
+  // yaw constraints as before.
+  //
+  // Set use_imu_preint=true in mowgli_robot.yaml to opt in. Keep
+  // false until field-tested — the EMA path is well-validated and
+  // the preint factor is new code.
+  bool use_imu_preint = false;
+  // Per-sample gyro_z noise sigma (rad/s). Used to propagate
+  // covariance through the preintegration: σ²_preint = Σ (dt² · σ²).
+  // Datasheet for the IMU on this robot gives ~0.01-0.02 rad/s noise
+  // density; bias drift is handled separately by the bias state.
+  double gyro_noise_density_rad_per_s = 0.015;
+  // Bias random-walk noise (rad/s per √s). The bias state at node k
+  // is constrained by a BetweenFactor<double>(bias_{k-1}, bias_k, 0,
+  // σ = bias_rw · √dt). 0.001 rad/s/√s ≈ 0.06°/s per minute drift
+  // tolerance — consistent with measured thermal drift on the WT901.
+  double gyro_bias_rw_rad_per_s = 0.001;
+  // Initial prior on the bias variable at graph start. Loose enough
+  // that the first few observations dominate, tight enough to keep
+  // iSAM2 well-conditioned. 0.05 rad/s ≈ 3°/s.
+  double gyro_bias_prior_sigma_rad_per_s = 0.05;
+
   // Online gyro bias estimation (item #3, pragmatic variant).
   // hardware_bridge_node calibrates the gyro bias once at boot
   // (20 s window while docked) but the residual drifts with
@@ -474,6 +507,13 @@ private:
     // robot is being externally rotated (hand-pushed / lifted off
     // the ground) so don't snap dθ to 0.
     double max_abs_gyro_rad_per_s = 0.0;
+    // IMU preintegration state (used when params_.use_imu_preint).
+    // gyro_dt_total separately from dt_total because IMU may publish
+    // at a different rate than wheel odom — we want strictly the
+    // integrated gyro time horizon.
+    double gyro_preint_dtheta = 0.0;
+    double gyro_preint_dt = 0.0;
+    double gyro_preint_variance = 0.0;  // Σ(dt_i² · σ_gyro²)
     void Reset()
     {
       *this = Accumulator{};
@@ -569,6 +609,11 @@ private:
   // samples depending on EMA τ and IMU rate).
   double gyro_bias_z_ = 0.0;
   uint64_t gyro_bias_updates_ = 0;
+
+  // When use_imu_preint is true, this holds the latest optimised
+  // bias value from iSAM2 (refreshed at every node creation). Used
+  // as the linearisation point for the next preintegration window.
+  double current_bias_estimate_ = 0.0;
   // Snapshot of "is the wheel-only stationary check currently
   // holding". Updated at each Tick from accum_ before the reset;
   // read by AddGyroDelta to gate EMA updates. Single-writer (Tick)

--- a/ros2/src/fusion_graph/src/factors.cpp
+++ b/ros2/src/fusion_graph/src/factors.cpp
@@ -64,6 +64,70 @@ gtsam::NonlinearFactor::shared_ptr GnssLeverArmFactor::clone() const
 }
 
 // ---------------------------------------------------------------------------
+// GyroPreintFactor
+// ---------------------------------------------------------------------------
+
+GyroPreintFactor::GyroPreintFactor(gtsam::Key key_prev,
+                                   gtsam::Key key_curr,
+                                   gtsam::Key key_bias_curr,
+                                   double delta_theta_preint,
+                                   double dt_total,
+                                   const gtsam::SharedNoiseModel& model)
+    : Base(model, key_prev, key_curr, key_bias_curr),
+      delta_theta_preint_(delta_theta_preint),
+      dt_total_(dt_total)
+{
+}
+
+gtsam::Vector GyroPreintFactor::evaluateError(const gtsam::Pose2& X_prev,
+                                              const gtsam::Pose2& X_curr,
+                                              const double& bias_curr,
+                                              OptMat H1,
+                                              OptMat H2,
+                                              OptMat H3) const
+{
+  // Predicted Δθ using current bias estimate:
+  //   pred = preint − bias_curr · dt
+  // Residual on yaw:
+  //   e = wrap( (θ_curr − θ_prev) − pred )
+  const double pred = delta_theta_preint_ - bias_curr * dt_total_;
+  const double dtheta_actual = X_curr.theta() - X_prev.theta();
+  gtsam::Vector1 e;
+  e << WrapAngle(dtheta_actual - pred);
+
+  // Jacobians. The error depends only on the yaw component of each
+  // pose and linearly on bias_curr. Pose2 tangent ordering is
+  // (dx, dy, dtheta).
+  if (H1)
+  {
+    H1->resize(1, 3);
+    (*H1)(0, 0) = 0.0;
+    (*H1)(0, 1) = 0.0;
+    (*H1)(0, 2) = -1.0;  // ∂e/∂θ_prev = -1
+  }
+  if (H2)
+  {
+    H2->resize(1, 3);
+    (*H2)(0, 0) = 0.0;
+    (*H2)(0, 1) = 0.0;
+    (*H2)(0, 2) = +1.0;  // ∂e/∂θ_curr = +1
+  }
+  if (H3)
+  {
+    H3->resize(1, 1);
+    // ∂e/∂bias_curr = ∂/∂b [ −(preint − b·dt) ] = +dt
+    (*H3)(0, 0) = +dt_total_;
+  }
+
+  return e;
+}
+
+gtsam::NonlinearFactor::shared_ptr GyroPreintFactor::clone() const
+{
+  return gtsam::NonlinearFactor::shared_ptr(new GyroPreintFactor(*this));
+}
+
+// ---------------------------------------------------------------------------
 // YawUnaryFactor
 // ---------------------------------------------------------------------------
 

--- a/ros2/src/fusion_graph/src/fusion_graph_node.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node.cpp
@@ -84,6 +84,18 @@ FusionGraphNode::FusionGraphNode(const rclcpp::NodeOptions& opts)
       declare_parameter<double>("gyro_bias_ema_tau_s", 30.0);
   gp.gyro_bias_max_sample_rad_per_s =
       declare_parameter<double>("gyro_bias_max_sample_rad_per_s", 0.10);
+  // Full IMU preintegration with joint bias optimisation (opt-in).
+  // When true, the EMA bias path is skipped and the graph carries a
+  // per-node `bias` variable plus a GyroPreintFactor on each pair of
+  // consecutive poses. See GraphParams docs in graph_manager.hpp.
+  gp.use_imu_preint =
+      declare_parameter<bool>("use_imu_preint", false);
+  gp.gyro_noise_density_rad_per_s =
+      declare_parameter<double>("gyro_noise_density_rad_per_s", 0.015);
+  gp.gyro_bias_rw_rad_per_s =
+      declare_parameter<double>("gyro_bias_rw_rad_per_s", 0.001);
+  gp.gyro_bias_prior_sigma_rad_per_s =
+      declare_parameter<double>("gyro_bias_prior_sigma_rad_per_s", 0.05);
   gp.adaptive_noise_enabled_gain =
       declare_parameter<double>("adaptive_noise_enabled_gain", 10.0);
   gp.adaptive_noise_ema_tau_s =

--- a/ros2/src/fusion_graph/src/graph_manager.cpp
+++ b/ros2/src/fusion_graph/src/graph_manager.cpp
@@ -145,9 +145,28 @@ void GraphManager::AddGyroDelta(double wz, double dt)
   // Subtract the current bias estimate before integration. First few
   // seconds use bias=0 (offline cal from hardware_bridge has removed
   // the cold bias); EMA refines as temperature drifts.
-  const double wz_corrected =
-      params_.gyro_bias_estimation_enabled ? wz - gyro_bias_z_ : wz;
+  //
+  // When use_imu_preint is true, we DON'T pre-subtract the EMA bias —
+  // the graph's bias variable absorbs the residual via the
+  // GyroPreintFactor. We still apply the latest bias_estimate_at_node
+  // (stored in current_bias_estimate_) so the integrated ω is in the
+  // right ballpark for iSAM2's linearisation point.
+  const double bias_correction =
+      params_.use_imu_preint ? current_bias_estimate_
+      : (params_.gyro_bias_estimation_enabled ? gyro_bias_z_ : 0.0);
+  const double wz_corrected = wz - bias_correction;
   accum_.dtheta_gyro += wz_corrected * dt;
+
+  // Preintegration accumulation. Variance propagates as
+  // Σ(dt² · σ_gyro²) — this is the noise on the integrated ω, not on
+  // ω itself. Independent of which bias correction is applied above.
+  if (params_.use_imu_preint)
+  {
+    accum_.gyro_preint_dtheta += wz_corrected * dt;
+    accum_.gyro_preint_dt += dt;
+    const double sigma = params_.gyro_noise_density_rad_per_s;
+    accum_.gyro_preint_variance += dt * dt * sigma * sigma;
+  }
 }
 
 void GraphManager::QueueGnss(double x, double y, double sigma_xy, bool robust)
@@ -195,6 +214,19 @@ void GraphManager::Initialize(const gtsam::Pose2& X0,
   auto k0 = PoseKey(0);
   new_values_.insert(k0, X0);
   new_factors_.add(gtsam::PriorFactor<gtsam::Pose2>(k0, X0, prior_noise));
+
+  // When IMU preintegration is on, seed the bias state at 0 with a
+  // loose prior. iSAM2 refines it from the very first preint factor.
+  if (params_.use_imu_preint)
+  {
+    using gtsam::Symbol;
+    auto k_bias0 = Symbol('b', 0);
+    new_values_.insert(k_bias0, 0.0);
+    auto bias_prior_noise = gtsam::noiseModel::Diagonal::Sigmas(
+        gtsam::Vector1(params_.gyro_bias_prior_sigma_rad_per_s));
+    new_factors_.add(
+        gtsam::PriorFactor<double>(k_bias0, 0.0, bias_prior_noise));
+  }
 
   isam_.update(new_factors_, new_values_);
   estimate_dirty_ = true;
@@ -388,12 +420,60 @@ TickOutput GraphManager::CreateNodeLocked(double now_s)
   }
   last_wheel_sigma_x_eff_ = wheel_sigma_x_eff;
 
+  // When IMU preintegration is active, the GyroPreintFactor below
+  // owns the yaw constraint with a tight statistically-grounded
+  // sigma. The wheel between-factor still carries xy translation but
+  // we inflate its sigma_theta so it doesn't fight the preint factor.
+  if (params_.use_imu_preint)
+  {
+    sigma_theta = 0.5;  // very loose — preint dominates yaw
+  }
+
   auto between_noise = MakeDiagonal({
       wheel_sigma_x_eff,
       params_.wheel_sigma_y,
       sigma_theta,
   });
   new_factors_.add(gtsam::BetweenFactor<gtsam::Pose2>(k_prev, k_curr, between, between_noise));
+
+  // ── IMU preintegration: ternary GyroPreintFactor + bias RW ──────
+  // The preint factor adds a yaw constraint that depends on the
+  // jointly-optimised bias variable, and the random-walk between-
+  // factor links consecutive bias variables so iSAM2 can propagate
+  // bias estimates through the trajectory.
+  if (params_.use_imu_preint && accum_.gyro_preint_dt > 0.0)
+  {
+    using gtsam::Symbol;
+    const auto k_bias_prev = Symbol('b', next_index_ - 1);
+    const auto k_bias_curr = Symbol('b', next_index_);
+
+    // Insert the new bias variable initialised at the current best
+    // estimate. iSAM2 will refine it on the next update.
+    new_values_.insert(k_bias_curr, current_bias_estimate_);
+
+    // Preint factor noise: sigma = √variance. Floor at a small value
+    // to avoid a singular constraint when dt is tiny.
+    const double sigma_preint =
+        std::max(std::sqrt(accum_.gyro_preint_variance), 1e-4);
+    auto preint_noise = gtsam::noiseModel::Diagonal::Sigmas(
+        gtsam::Vector1(sigma_preint));
+    new_factors_.add(
+        boost::make_shared<GyroPreintFactor>(k_prev,
+                                              k_curr,
+                                              k_bias_curr,
+                                              accum_.gyro_preint_dtheta,
+                                              accum_.gyro_preint_dt,
+                                              preint_noise));
+
+    // Bias random-walk between: bias_{k} = bias_{k-1} + N(0, σ_rw·√dt)
+    const double sigma_bias_rw =
+        params_.gyro_bias_rw_rad_per_s * std::sqrt(accum_.gyro_preint_dt);
+    auto bias_rw_noise = gtsam::noiseModel::Diagonal::Sigmas(
+        gtsam::Vector1(std::max(sigma_bias_rw, 1e-6)));
+    new_factors_.add(
+        gtsam::BetweenFactor<double>(k_bias_prev, k_bias_curr, 0.0,
+                                     bias_rw_noise));
+  }
 
   // 3. Queued unary factors. Wrap in Huber when caller flagged the
   // measurement as outlier-prone (RTK-Float / single fix on GPS;
@@ -443,6 +523,23 @@ TickOutput GraphManager::CreateNodeLocked(double now_s)
   estimate_dirty_ = true;
   new_factors_.resize(0);
   new_values_.clear();
+
+  // 4b. Refresh the bias linearisation point from the new estimate
+  //     when IMU preint is active. AddGyroDelta will subtract this
+  //     from incoming samples until the next node creation.
+  if (params_.use_imu_preint)
+  {
+    try
+    {
+      const auto k_bias = gtsam::Symbol('b', next_index_);
+      current_bias_estimate_ = isam_.calculateEstimate<double>(k_bias);
+    }
+    catch (const std::exception&)
+    {
+      // Keep the previous estimate if iSAM2 hasn't materialised this
+      // variable yet (shouldn't happen — we just inserted it).
+    }
+  }
 
   // 5. Marginal covariance — throttled. marginalCovariance is O(node
   //    count) on the Bayes tree path and dominates CPU once the graph

--- a/ros2/src/fusion_graph/src/graph_manager.cpp
+++ b/ros2/src/fusion_graph/src/graph_manager.cpp
@@ -457,13 +457,12 @@ TickOutput GraphManager::CreateNodeLocked(double now_s)
         std::max(std::sqrt(accum_.gyro_preint_variance), 1e-4);
     auto preint_noise = gtsam::noiseModel::Diagonal::Sigmas(
         gtsam::Vector1(sigma_preint));
-    new_factors_.add(
-        boost::make_shared<GyroPreintFactor>(k_prev,
-                                              k_curr,
-                                              k_bias_curr,
-                                              accum_.gyro_preint_dtheta,
-                                              accum_.gyro_preint_dt,
-                                              preint_noise));
+    new_factors_.add(GyroPreintFactor(k_prev,
+                                       k_curr,
+                                       k_bias_curr,
+                                       accum_.gyro_preint_dtheta,
+                                       accum_.gyro_preint_dt,
+                                       preint_noise));
 
     // Bias random-walk between: bias_{k} = bias_{k-1} + N(0, σ_rw·√dt)
     const double sigma_bias_rw =

--- a/ros2/src/fusion_graph/test/test_factors.cpp
+++ b/ros2/src/fusion_graph/test/test_factors.cpp
@@ -12,6 +12,7 @@
 #include <gtsam/linear/NoiseModel.h>
 
 using fusion_graph::GnssLeverArmFactor;
+using fusion_graph::GyroPreintFactor;
 using fusion_graph::WrapAngle;
 using fusion_graph::YawUnaryFactor;
 
@@ -172,4 +173,106 @@ TEST(WrapAngle, BoundsRespected)
   EXPECT_NEAR(WrapAngle(-M_PI), M_PI, 1e-12);  // -π wraps to +π
   EXPECT_NEAR(WrapAngle(2.0 * M_PI), 0.0, 1e-12);
   EXPECT_NEAR(WrapAngle(-1.5 * M_PI), 0.5 * M_PI, 1e-12);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// GyroPreintFactor
+// ─────────────────────────────────────────────────────────────────────
+
+TEST(GyroPreintFactor, ZeroErrorAtTrueValue)
+{
+  // Robot rotated by +0.1 rad over 1 s. Preint with zero bias should
+  // expect Δθ_curr − Δθ_prev = 0.1, residual = 0 when bias_curr = 0.
+  GyroPreintFactor f(gtsam::Symbol('x', 0),
+                     gtsam::Symbol('x', 1),
+                     gtsam::Symbol('b', 1),
+                     /* delta_theta_preint */ 0.10,
+                     /* dt_total */ 1.0,
+                     UnitDiag1());
+  const gtsam::Pose2 X_prev(0.0, 0.0, 0.0);
+  const gtsam::Pose2 X_curr(0.0, 0.0, 0.10);
+  const double bias = 0.0;
+  auto e = f.evaluateError(X_prev, X_curr, bias);
+  EXPECT_NEAR(e[0], 0.0, 1e-12);
+}
+
+TEST(GyroPreintFactor, BiasCancelsCorrectly)
+{
+  // Preint says Δθ_preint = 0.20 over 1 s, but true motion was 0.10.
+  // → factor expects bias_curr · 1.0 = 0.10 (i.e. bias = 0.10 rad/s)
+  // for zero residual.
+  GyroPreintFactor f(gtsam::Symbol('x', 0),
+                     gtsam::Symbol('x', 1),
+                     gtsam::Symbol('b', 1),
+                     /* delta_theta_preint */ 0.20,
+                     /* dt_total */ 1.0,
+                     UnitDiag1());
+  const gtsam::Pose2 X_prev(0.0, 0.0, 0.0);
+  const gtsam::Pose2 X_curr(0.0, 0.0, 0.10);
+
+  // bias = 0 → residual = (0.10 - (0.20 - 0)) = -0.10
+  EXPECT_NEAR(f.evaluateError(X_prev, X_curr, 0.0)[0], -0.10, 1e-12);
+  // bias = 0.10 → residual = (0.10 - (0.20 - 0.10*1.0)) = 0
+  EXPECT_NEAR(f.evaluateError(X_prev, X_curr, 0.10)[0], 0.0, 1e-12);
+}
+
+TEST(GyroPreintFactor, JacobianMatchesNumeric)
+{
+  GyroPreintFactor f(gtsam::Symbol('x', 0),
+                     gtsam::Symbol('x', 1),
+                     gtsam::Symbol('b', 1),
+                     0.15,
+                     0.5,
+                     UnitDiag1());
+  const gtsam::Pose2 X_prev(0.5, 0.2, 0.3);
+  const gtsam::Pose2 X_curr(0.7, 0.1, 0.45);
+  const double bias = 0.02;
+
+  gtsam::Matrix H1_an, H2_an, H3_an;
+  f.evaluateError(X_prev, X_curr, bias, &H1_an, &H2_an, &H3_an);
+
+  const double eps = 1e-6;
+  gtsam::Matrix H1_num(1, 3), H2_num(1, 3), H3_num(1, 1);
+
+  for (int i = 0; i < 3; ++i)
+  {
+    gtsam::Vector3 d_prev = gtsam::Vector3::Zero();
+    d_prev(i) = eps;
+    auto e_plus = f.evaluateError(X_prev.retract(d_prev), X_curr, bias);
+    auto e_minus = f.evaluateError(X_prev.retract(-d_prev), X_curr, bias);
+    H1_num(0, i) = (e_plus[0] - e_minus[0]) / (2.0 * eps);
+
+    gtsam::Vector3 d_curr = gtsam::Vector3::Zero();
+    d_curr(i) = eps;
+    auto e_plus2 = f.evaluateError(X_prev, X_curr.retract(d_curr), bias);
+    auto e_minus2 = f.evaluateError(X_prev, X_curr.retract(-d_curr), bias);
+    H2_num(0, i) = (e_plus2[0] - e_minus2[0]) / (2.0 * eps);
+  }
+  H3_num(0, 0) =
+      (f.evaluateError(X_prev, X_curr, bias + eps)[0] -
+       f.evaluateError(X_prev, X_curr, bias - eps)[0]) /
+      (2.0 * eps);
+
+  for (int j = 0; j < 3; ++j)
+  {
+    EXPECT_NEAR(H1_an(0, j), H1_num(0, j), 1e-4) << "H1[0," << j << "]";
+    EXPECT_NEAR(H2_an(0, j), H2_num(0, j), 1e-4) << "H2[0," << j << "]";
+  }
+  EXPECT_NEAR(H3_an(0, 0), H3_num(0, 0), 1e-4);
+}
+
+TEST(GyroPreintFactor, WrapsAroundPi)
+{
+  // X_prev.theta = π−0.05, X_curr.theta = -π+0.05 → actual Δθ = 0.10
+  // (crosses ±π). Preint = 0.10, bias = 0 → residual must be 0
+  // (NOT 2π − 0.10).
+  GyroPreintFactor f(gtsam::Symbol('x', 0),
+                     gtsam::Symbol('x', 1),
+                     gtsam::Symbol('b', 1),
+                     0.10,
+                     0.1,
+                     UnitDiag1());
+  const gtsam::Pose2 X_prev(0.0, 0.0, M_PI - 0.05);
+  const gtsam::Pose2 X_curr(0.0, 0.0, -M_PI + 0.05);
+  EXPECT_NEAR(f.evaluateError(X_prev, X_curr, 0.0)[0], 0.0, 1e-9);
 }


### PR DESCRIPTION
Promotes item #3 from the pragmatic EMA variant (PR #237) to full preintegration with joint bias optimisation. iSAM2 solves trajectory + bias together. Opt-in via `use_imu_preint: true` in mowgli_robot.yaml; default false until field-validated.

## Factor
`GyroPreintFactor` is a custom ternary on (Pose2_prev, Pose2_curr, double_bias_curr). Pose2 (not Pose3) because the robot is planar — keeps iSAM2 lightweight.

## Tests
- ZeroErrorAtTrueValue
- BiasCancelsCorrectly
- JacobianMatchesNumeric
- WrapsAroundPi

## Limitations (documented in commit)
- Save/Load doesn't persist bias values (re-converges in seconds on restart)
- RebaseISAM2 drops bias variables; re-converges in next preint window

🤖 Generated with [Claude Code](https://claude.com/claude-code)