### PR TITLE
fix(gps): stop /gps/fix publishing stale status/cov pairs

### DIFF
--- a/ros2/scripts/gps_step_verify.py
+++ b/ros2/scripts/gps_step_verify.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Verify whether /gps/fix position steps are caused by stale-status pairing
+in ublox_nav_sat_fix_hp_node, or by genuine receiver behaviour.
+
+Subscribes to:
+  /ubx_nav_hp_pos_llh   -> lat/lon (1e-7 + 1e-9 high-precision), h_acc, iTOW
+  /ubx_nav_status       -> carr_soln.status, gps_fix.fix_type, diff_soln, iTOW
+  /ubx_nav_cov          -> pos_cov_ee/nn, iTOW
+  /gps/fix              -> the published NavSatFix (what consumers actually see)
+
+Stores per-iTOW records. Detects horizontal position steps > step_threshold_m
+(default 0.05 m / 5 cm) between consecutive iTOWs and prints the carr_soln /
+h_acc at that epoch + the surrounding context.
+
+Run inside the mowgli-gps (or ros2) container.
+
+Usage:
+  ros2 run ... OR  python3 gps_step_verify.py --duration 120 --step 0.05
+"""
+import argparse
+import json
+import math
+import sys
+import time
+from collections import defaultdict, deque
+
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import NavSatFix
+from ublox_ubx_msgs.msg import UBXNavHPPosLLH, UBXNavStatus, UBXNavCov
+
+
+def llh_to_enu_meters(lat_deg, lon_deg, lat0_deg, lon0_deg):
+    """Tiny local ENU approximation around (lat0, lon0). Accurate enough for
+    step-detection (<= 1 km baseline)."""
+    R = 6378137.0
+    lat0 = math.radians(lat0_deg)
+    dlat = math.radians(lat_deg - lat0_deg)
+    dlon = math.radians(lon_deg - lon0_deg)
+    east = R * math.cos(lat0) * dlon
+    north = R * dlat
+    return east, north
+
+
+class StepVerifier(Node):
+    def __init__(self, duration, step_threshold):
+        super().__init__("gps_step_verify")
+        self.duration = duration
+        self.step_threshold = step_threshold
+
+        # Per-iTOW state: {itow: {"hp": dict, "status": dict, "cov": dict}}
+        self.epochs = {}
+        # Ordered list of iTOWs we have seen with HPPOSLLH (used to detect steps)
+        self.itow_order = deque()
+        self.last_pos = None        # (itow, east_m, north_m, lat, lon)
+        self.lat0 = None
+        self.lon0 = None
+        self.steps = []
+        self.fix_msgs = 0
+        self.start_t = time.monotonic()
+
+        self.create_subscription(UBXNavHPPosLLH, "/ubx_nav_hp_pos_llh", self.hp_cb, 50)
+        self.create_subscription(UBXNavStatus,   "/ubx_nav_status",     self.status_cb, 50)
+        self.create_subscription(UBXNavCov,      "/ubx_nav_cov",        self.cov_cb, 50)
+        self.create_subscription(NavSatFix,      "/gps/fix",            self.fix_cb, 50)
+
+        self.timer = self.create_timer(0.5, self.tick)
+
+    def _slot(self, itow):
+        if itow not in self.epochs:
+            self.epochs[itow] = {"hp": None, "status": None, "cov": None}
+            self.itow_order.append(itow)
+            # Cap memory: keep the last 200 epochs (~30 s @ 7 Hz)
+            while len(self.itow_order) > 200:
+                old = self.itow_order.popleft()
+                self.epochs.pop(old, None)
+        return self.epochs[itow]
+
+    def hp_cb(self, m):
+        lat = m.lat * 1e-7 + m.lat_hp * 1e-9
+        lon = m.lon * 1e-7 + m.lon_hp * 1e-9
+        height = m.height * 1e-3 + m.height_hp * 1e-4
+        h_acc_mm = m.h_acc * 0.1   # h_acc unit is 0.1 mm
+        slot = self._slot(m.itow)
+        slot["hp"] = {
+            "lat": lat, "lon": lon, "height": height,
+            "h_acc_mm": h_acc_mm,
+            "invalid_lat": m.invalid_lat, "invalid_lon": m.invalid_lon,
+            "invalid_lat_hp": m.invalid_lat_hp, "invalid_lon_hp": m.invalid_lon_hp,
+            "stamp": m.header.stamp.sec + m.header.stamp.nanosec * 1e-9,
+        }
+        if self.lat0 is None:
+            self.lat0 = lat
+            self.lon0 = lon
+
+        # Step detection — compare to last good HP fix
+        e, n = llh_to_enu_meters(lat, lon, self.lat0, self.lon0)
+        if self.last_pos is not None:
+            de = e - self.last_pos[1]
+            dn = n - self.last_pos[2]
+            d = math.hypot(de, dn)
+            if d >= self.step_threshold:
+                # Capture full context (and the status/cov for this AND prior iTOW)
+                prev_itow = self.last_pos[0]
+                self.steps.append({
+                    "from_itow": prev_itow,
+                    "to_itow": m.itow,
+                    "delta_e_m": de,
+                    "delta_n_m": dn,
+                    "delta_horiz_m": d,
+                    "prev_epoch": dict(self.epochs.get(prev_itow, {})),
+                    "this_epoch": dict(self.epochs.get(m.itow, {})),
+                    "h_acc_mm": h_acc_mm,
+                })
+        self.last_pos = (m.itow, e, n, lat, lon)
+
+    def status_cb(self, m):
+        slot = self._slot(m.itow)
+        slot["status"] = {
+            "carr_soln": m.carr_soln.status,    # 0=none, 1=Float, 2=Fixed
+            "fix_type": m.gps_fix.fix_type,
+            "diff_soln": m.diff_soln,
+            "gps_fix_ok": m.gps_fix_ok,
+            "stamp": m.header.stamp.sec + m.header.stamp.nanosec * 1e-9,
+        }
+
+    def cov_cb(self, m):
+        slot = self._slot(m.itow)
+        slot["cov"] = {
+            "pos_cov_ee": m.pos_cov_ee,
+            "pos_cov_nn": m.pos_cov_nn,
+            "stamp": m.header.stamp.sec + m.header.stamp.nanosec * 1e-9,
+        }
+
+    def fix_cb(self, m):
+        self.fix_msgs += 1
+        # We compare the /gps/fix status (cached in HP node) against the truth
+        # in /ubx_nav_status, but we can't do per-iTOW correlation here because
+        # NavSatFix doesn't carry iTOW. We just count messages.
+
+    def tick(self):
+        dt = time.monotonic() - self.start_t
+        if dt >= self.duration:
+            self.print_summary()
+            rclpy.shutdown()
+            sys.exit(0)
+
+    def print_summary(self):
+        n_epochs = len(self.epochs)
+        n_paired = sum(
+            1 for v in self.epochs.values()
+            if v["hp"] and v["status"] and v["cov"]
+        )
+        print("=" * 78)
+        print(f"Duration:       {self.duration:.0f} s")
+        print(f"HP epochs:      {n_epochs}")
+        print(f"Fully paired:   {n_paired}  ({100*n_paired/max(n_epochs,1):.1f}%)")
+        print(f"/gps/fix msgs:  {self.fix_msgs}")
+        print(f"Steps >= {self.step_threshold*100:.0f} cm: {len(self.steps)}")
+        print("=" * 78)
+        for i, s in enumerate(self.steps):
+            print()
+            print(f"--- Step {i+1}: {s['delta_horiz_m']*100:.1f} cm "
+                  f"(dE={s['delta_e_m']*100:+.1f} cm, dN={s['delta_n_m']*100:+.1f} cm) ---")
+            print(f"  from iTOW {s['from_itow']}  ->  to iTOW {s['to_itow']}")
+            print(f"  h_acc at step: {s['h_acc_mm']:.1f} mm")
+            for label, ep in (("prev", s["prev_epoch"]), ("this", s["this_epoch"])):
+                st = ep.get("status") or {}
+                hp = ep.get("hp") or {}
+                cov = ep.get("cov") or {}
+                cs = st.get("carr_soln", "?")
+                cs_label = {0: "None", 1: "Float", 2: "Fixed"}.get(cs, str(cs))
+                ftype = st.get("fix_type", "?")
+                diff = st.get("diff_soln", "?")
+                hacc = hp.get("h_acc_mm", "?")
+                ee = cov.get("pos_cov_ee", "?")
+                nn = cov.get("pos_cov_nn", "?")
+                inv = (
+                    f"inv_lat={hp.get('invalid_lat')}, inv_lon={hp.get('invalid_lon')}, "
+                    f"inv_lat_hp={hp.get('invalid_lat_hp')}, inv_lon_hp={hp.get('invalid_lon_hp')}"
+                )
+                print(f"  [{label}] carr_soln={cs_label}  fix_type={ftype}  "
+                      f"diff_soln={diff}  h_acc={hacc} mm  "
+                      f"cov_ee={ee}  cov_nn={nn}")
+                print(f"         {inv}")
+
+        # Distribution of carr_soln across all paired epochs
+        soln_counts = defaultdict(int)
+        for ep in self.epochs.values():
+            if ep["status"]:
+                soln_counts[ep["status"]["carr_soln"]] += 1
+        print()
+        print("carr_soln distribution across all epochs:")
+        for v in (0, 1, 2):
+            label = {0: "None", 1: "Float", 2: "Fixed"}[v]
+            print(f"  {label}:  {soln_counts.get(v, 0)} "
+                  f"({100*soln_counts.get(v,0)/max(n_epochs,1):.1f}%)")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--duration", type=float, default=120.0,
+                    help="Capture duration in seconds")
+    ap.add_argument("--step", type=float, default=0.05,
+                    help="Horizontal step threshold in metres (default 0.05 = 5 cm)")
+    args = ap.parse_args()
+
+    rclpy.init()
+    node = StepVerifier(args.duration, args.step)
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        node.print_summary()
+    finally:
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/sensors/gps/Dockerfile
+++ b/sensors/gps/Dockerfile
@@ -22,19 +22,21 @@
 FROM ros:kilted-ros-base AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG UBLOX_DGNSS_REF=fix/serial-reconnect-on-eio
+ARG UBLOX_DGNSS_REF=fix/hp-fix-stale-status-cov
 # Bump UBLOX_DGNSS_SHA to the current branch tip to bust the docker
 # layer cache when upstream moves. `git clone --branch` accepts only
 # branch/tag names so we clone shallow then checkout the pinned SHA;
 # the SHA also ensures cache-from doesn't reuse a stale layer when
 # the branch moves under us (which is what we hit on 2026-04-26).
-# Currently riding the fix/serial-reconnect-on-eio branch (PR
-# cedbossneo/ublox_dgnss#1) so the driver reopens the CDC ACM FD
-# when the F9P briefly disconnects from USB and re-enumerates on a
-# different ttyACM minor — without this we ended up stuck spamming
-# "RTCM write failed: serial write errno=5" until docker restart.
-# Switch back to feat/serial-transport once #1 lands.
-ARG UBLOX_DGNSS_SHA=80dd8db96e1e72d083a983305ef39b27fd74dd6f
+# Currently riding fix/hp-fix-stale-status-cov (PR cedbossneo/ublox_dgnss#2),
+# which is fix/serial-reconnect-on-eio (#1, CDC ACM FD reopen on EIO) +
+# a per-epoch h_acc fallback in ublox_nav_sat_fix_hp_node so /gps/fix no
+# longer publishes positions with status/covariance from a different
+# epoch. Measured loss on the prior branch: NAV-STATUS ~57 %, NAV-COV
+# ~80 % at 7 Hz nav rate, which silently published Float positions with
+# stale Fixed status during cycle slips. Switch back to the parent
+# branches once #1 and #2 land.
+ARG UBLOX_DGNSS_SHA=76115f43259d45da19c918f1aad8c5a88186b878
 # cedbossneo fork (itself a fork of privatedocs000/ublox_dgnss). Layered
 # customisations over upstream:
 #   * privatedocs000 base — RTK-Fixed detection via UBX-NAV-STATUS.carr_soln:

--- a/sensors/gps/ublox_dgnss.yaml
+++ b/sensors/gps/ublox_dgnss.yaml
@@ -128,15 +128,36 @@ ublox_dgnss:
 
     # UBX messages on USB. Value = output every N nav epochs (0 = off).
     # At 7 Hz, "1" = ~7 msg/s, "7" = ~1 msg/s.
+    #
+    # F9P USB tx-buffer pressure: at 7 Hz with all per-epoch messages
+    # on AND NAV-SAT/NAV-SIG at 1 Hz, the receiver drops the tail of
+    # its per-epoch output sequence. Measured loss:
+    #   NAV-HPPOSLLH ~0 % | NAV-PVT ~0 %
+    #   NAV-STATUS ~57 % | NAV-COV ~80 %
+    # which made the HP NavSatFix node publish /gps/fix with a status
+    # and covariance from a different epoch than the position — bad in
+    # general, and during a brief Fixed→Float→Fixed cycle slip it
+    # silently labels Float positions as Fixed.
+    #
+    # Two-sided fix applied:
+    #   1. cedbossneo/ublox_dgnss#2 makes the HP node derive status
+    #      and a diagonal covariance from per-epoch h_acc/v_acc when
+    #      the cached NAV-STATUS / NAV-COV iTOW does not match.
+    #   2. Bandwidth budget below: drop NAV-PVT (not consumed in this
+    #      project; the same data lives in HPPOSLLH+VELNED), disable
+    #      NAV-SIG (not consumed), and slow NAV-SAT from 1 Hz to
+    #      ~0.5 Hz (2 s — gps_health_aggregator has a 5 s freshness
+    #      timeout on /ubx_nav_sat, so we keep generous headroom).
+    #      Together this gets STATUS and COV back to 7 Hz at source.
     CFG_MSGOUT_UBX_NAV_HPPOSLLH_USB: 1   # high-precision LLH — needed by HP NavSatFix node
     CFG_MSGOUT_UBX_NAV_STATUS_USB: 1     # fix type + carrSoln/diffSoln diagnostics
     CFG_MSGOUT_UBX_NAV_COV_USB: 1        # covariance → NavSatFix.position_covariance
-    CFG_MSGOUT_UBX_NAV_PVT_USB: 1
-    CFG_MSGOUT_UBX_NAV_VELNED_USB: 1
+    CFG_MSGOUT_UBX_NAV_PVT_USB: 0        # nothing consumes /ubx_nav_pvt in mowglinext
+    CFG_MSGOUT_UBX_NAV_VELNED_USB: 1     # → cog_to_imu_node /imu/cog_heading (CRITICAL)
     CFG_MSGOUT_UBX_NAV_RELPOSNED_USB: 0  # 0 unless moving-base / dual-antenna
     CFG_MSGOUT_UBX_RXM_RTCM_USB: 1       # correction ingestion counter — NTRIP debug
-    CFG_MSGOUT_UBX_NAV_SIG_USB: 7        # per-signal CN0/quality, ~1 Hz — multipath diagnostics
-    CFG_MSGOUT_UBX_NAV_SAT_USB: 7        # per-satellite info, ~1 Hz — sky-view diagnostics
+    CFG_MSGOUT_UBX_NAV_SIG_USB: 0        # not consumed; freed for NAV-STATUS/COV
+    CFG_MSGOUT_UBX_NAV_SAT_USB: 14       # ~0.5 Hz, kept for /gps/health sky-view diag
 
     # Silence UBX-MON messages on USB — the driver doesn't have parsers
     # for them and logs "ubx class: 0x0a id: 0xNN unknown ... doing


### PR DESCRIPTION
## Summary

- Bump `ublox_dgnss` to [`fix/hp-fix-stale-status-cov`](https://github.com/cedbossneo/ublox_dgnss/pull/2) (PR cedbossneo/ublox_dgnss#2): the HP NavSatFix node now derives `/gps/fix.status` and `position_covariance` from the per-epoch `h_acc` / `v_acc` in `UBX-NAV-HPPOSLLH` whenever the cached `NAV-STATUS` / `NAV-COV` iTOW does not match the current epoch.
- Trim F9P USB output rates: disable `NAV-PVT` and `NAV-SIG` (no consumers in this project), slow `NAV-SAT` from 1 Hz to 0.5 Hz (kept for `gps_health_aggregator` sky-view diagnostics, which has a 5 s freshness timeout — comfortably above 2 s).

## Why

60 s iTOW-tagged capture on a stationary rover at 7 Hz showed:

| Topic | Configured | Actual | Loss |
|---|---|---|---|
| `/ubx_nav_hp_pos_llh` | 7 Hz | 7.0 Hz | 0 % |
| `/ubx_nav_pvt` | 7 Hz | 7.0 Hz | 0 % |
| `/ubx_nav_status` | 7 Hz | ~3.0 Hz | ~57 % |
| `/ubx_nav_cov` | 7 Hz | ~1.0 Hz | ~80 % |

Only **22 % of `/gps/fix` publications had a same-epoch `NAV-STATUS` and `NAV-COV` available** — the receiver was silently dropping the tail of its per-epoch UBX output sequence under USB tx-buffer pressure from `NAV-SAT` / `NAV-SIG`. The HP node cached the most recent status / covariance and re-attached them to every position, so during brief `Fixed→Float→Fixed` cycle slips the new Float-quality position got published with the prior epoch's Fixed status (and vice-versa on recovery). Downstream consumers gating on `NavSatStatus::STATUS_GBAS_FIX` therefore admitted Float-quality positions as Fixed with a corresponding 5-20 cm step.

## Test plan

- [ ] Rebuild `mowgli-gps` Docker image from this branch and confirm:
  - `ros2 topic hz /ubx_nav_status` → ~7 Hz (was ~3 Hz)
  - `ros2 topic hz /ubx_nav_cov` → ~7 Hz (was ~1 Hz)
  - `ros2 topic hz /ubx_nav_sat` → ~0.5 Hz (was ~1 Hz)
  - `ros2 topic echo /gps/fix.status.status` flips with `/ubx_nav_status.carr_soln` in real time (no longer lagging)
- [ ] Run `ros2/scripts/gps_step_verify.py --duration 300 --step 0.05` during a mowing session and confirm no >5 cm steps that don't correlate with a real `carr_soln` transition.
- [ ] `gps_health_aggregator` sat-status diagnostic stays green (no 5 s timeout on `/ubx_nav_sat`).