### PR TITLE
fix(scan): account for LIDAR mount yaw in IMU ground filter + feed local costmap

### DIFF
--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -535,31 +535,28 @@ global_costmap:
         enabled: true
         # No persistence: heading drift causes wall duplicates
         observation_persistence: 0.0
-        observation_sources: scan
-        scan:
-          topic: /scan
-          # LaserScan is projected to 3D via laser_geometry then filtered by
-          # map-frame Z. With ground_constraint keeping base_link Z ≈ 0,
-          # lidar is at +0.22 m. Any scan return at Z below 0.08 m is
-          # either ground (on a pitched/rolling robot whose scan plane tilts
-          # downward) or below the mower skirt and irrelevant. Above 1.5 m
-          # is overhead (tree canopy, umbrellas) the mower won't hit.
-          # Previously 200 m which was a workaround for old Z-drift bug;
-          # now fixed by the ground constraint so we can filter properly.
-          # 2D LaserScan rays sit at lidar_link.z (≈0.22 m); after TF to
-          # the costmap frame each point's Z ≈ lidar height on level
-          # ground. min_obstacle_height: 0.12 rejects returns whose Z has
-          # dropped toward ground level — which happens when the mower
-          # pitches/rolls on uneven garden terrain and the forward rays
-          # tilt down into the lawn. At 0.0 those ground hits were marked
-          # as phantom lethal obstacles, blocking the planner mid-swath
-          # and walling off the dock approach (controller_server "Failed
-          # to make progress"). The real 0.22 m scan plane stays well
-          # inside [0.12, 1.5] so genuine obstacles are still marked.
-          # NOTE: this does NOT reduce collision safety — collision_monitor
-          # polls raw /scan in 2D (height-agnostic) and still stops the
-          # robot on any real return; min_obstacle_height only governs what
-          # the PLANNER routes around.
+        observation_sources: scan_filtered
+        scan_filtered:
+          topic: /scan_costmap
+          # Subscribe to the IMU-tilt-filtered /scan_costmap stream from
+          # costmap_scan_filter_node — NOT raw /scan. This is the local
+          # twin of the global costmap's source, and it matters: the
+          # min_obstacle_height band below CANNOT filter tilt-induced
+          # ground hits on its own. robot_localization runs in two_d_mode,
+          # which forces pitch=roll=0 in TF, so a 2D LaserScan always
+          # projects to ~lidar_z (0.22 m) regardless of the real chassis
+          # tilt — every ground return on a slope sails through the
+          # [0.12, 1.5] band and lands as a phantom lethal obstacle (a
+          # tiny pivot on uneven garden terrain was enough to paint
+          # them, driving FTC obstacle-deviation into left-right flap and
+          # controller_server "Failed to make progress"). costmap_scan_filter
+          # does the actual tilt rejection using the IMU gravity vector and
+          # the LIDAR mount yaw, so the planner only sees real obstacles.
+          # The height band is kept as a cheap belt-and-suspenders for the
+          # level case. NOTE: this does NOT reduce collision safety —
+          # collision_monitor reads /scan_costmap in 2D (height-agnostic)
+          # and still stops on any real return; min_obstacle_height only
+          # governs what the PLANNER routes around.
           min_obstacle_height: 0.12
           max_obstacle_height: 1.5
           clearing: true

--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -228,10 +228,21 @@ def generate_launch_description() -> LaunchDescription:
         runtime_config if os.path.isfile(runtime_config) else template_config
     )
     footprint_str = ""
+    # LIDAR mount geometry for the costmap_scan_filter ground filter.
+    # lidar_height = lidar_z (above base_link); lidar_mount_yaw rotates a
+    # beam's index angle into the IMU/base frame before the gravity
+    # projection (the LIDAR is ~π-mounted on this chassis, so omitting it
+    # inverts the front/back ground-filter sign on a slope). imu_yaw is
+    # subtracted because the gravity "up" vector is expressed in the IMU
+    # frame; it is 0 on this stack but kept general.
+    lidar_height_m = 0.22
+    lidar_mount_yaw = 0.0
     if os.path.isfile(robot_config_file):
         with open(robot_config_file, "r") as f:
             rcfg = yaml.safe_load(f) or {}
         rp = rcfg.get("mowgli", {}).get("ros__parameters", {})
+        lidar_height_m = float(rp.get("lidar_z", lidar_height_m))
+        lidar_mount_yaw = float(rp.get("lidar_yaw", 0.0)) - float(rp.get("imu_yaw", 0.0))
         cl = float(rp.get("chassis_length", 0.54))
         cw = float(rp.get("chassis_width", 0.40))
         ccx = float(rp.get("chassis_center_x", 0.18))
@@ -778,7 +789,13 @@ def generate_launch_description() -> LaunchDescription:
              # tighten if real-obstacle sensitivity is critical.
              "chassis_blank_range": 0.55,
              "dock_blank_range": 0.70,
-             "post_undock_blank_sec": 5.0},
+             "post_undock_blank_sec": 5.0,
+             # Ground-filter geometry from mowgli_robot.yaml. lidar_mount_yaw
+             # (~π on the 180°-rotated mount) is essential — without it the
+             # gravity projection's front/back sign inverts on a slope and
+             # forward ground returns survive as phantom obstacles.
+             "lidar_height_m": lidar_height_m,
+             "lidar_mount_yaw": lidar_mount_yaw},
         ],
     )
 

--- a/ros2/src/mowgli_localization/src/costmap_scan_filter_node.cpp
+++ b/ros2/src/mowgli_localization/src/costmap_scan_filter_node.cpp
@@ -28,10 +28,20 @@
 //      by /imu/data linear_acceleration (which carries actual robot
 //      pitch/roll). The IMU orientation field on this stack is currently
 //      hardcoded identity by hardware_bridge — accel is the only signal
-//      that knows we're tilted. For each beam at angle α (LIDAR frame
-//      assumed flat-mounted relative to base_link), the Z component of
-//      the beam direction in the gravity-aligned frame is:
-//        z_dir    = (ax·cos α + ay·sin α) / |accel|
+//      that knows we're tilted. The gravity ("up") vector lives in the
+//      IMU/base_link frame, but a beam's index angle α is in the LIDAR
+//      frame, which on this robot is yaw-mounted ~π (180°-rotated) from
+//      base_link (mowgli_robot.yaml lidar_yaw). So α must be rotated into
+//      the base/IMU frame before projecting onto gravity, via the
+//      lidar_mount_yaw param (= lidar_yaw − imu_yaw): a beam at LIDAR
+//      angle α points along base bearing ψ = α + lidar_mount_yaw. Skipping
+//      this rotation flips the front/back sign on a pitched robot — the
+//      forward ground returns (LIDAR α≈π on this mount) get a POSITIVE
+//      z_dir and survive as phantom obstacles, while the empty sky-side
+//      beams get "filtered". On flat ground (ux,uy≈0) the error is
+//      invisible, which is why it only bites on a sloped garden.
+//        ψ        = α + lidar_mount_yaw
+//        z_dir    = (ax·cos ψ + ay·sin ψ) / |accel|
 //        return_Z = lidar_height + range · z_dir
 //      where (ax, ay, az) is the latest IMU linear_acceleration. A 10°
 //      nose-down pitch gives ax ≈ −1.7 m/s² → forward beam z_dir ≈ −0.17
@@ -83,6 +93,12 @@ public:
     min_obstacle_z_m_ = declare_parameter<double>("min_obstacle_z_m", 0.08);
     max_obstacle_z_m_ = declare_parameter<double>("max_obstacle_z_m", 1.5);
     lidar_height_m_ = declare_parameter<double>("lidar_height_m", 0.22);
+    // Yaw of the LIDAR frame relative to the IMU/base_link frame
+    // (= lidar_yaw − imu_yaw from mowgli_robot.yaml). Needed to rotate a
+    // beam's index angle into the gravity frame before the ground
+    // projection. Default 0 keeps the old (flat-mount) behaviour; the
+    // launch passes the real ~π value for the 180°-rotated mount.
+    lidar_mount_yaw_ = declare_parameter<double>("lidar_mount_yaw", 0.0);
     imu_max_age_s_ = declare_parameter<double>("imu_max_age_s", 0.5);
     accel_g_tolerance_ms2_ = declare_parameter<double>("accel_g_tolerance_ms2", 3.0);
     const std::string input_topic = declare_parameter<std::string>("input_topic", "/scan");
@@ -118,7 +134,8 @@ public:
                 "costmap_scan_filter started — %s -> %s, chassis_blank_range=%.2f m, "
                 "dock_blank_range=%.2f m, post_undock_blank_sec=%.1f s, "
                 "ground_filter=%s [Z range %.2f..%.2f m, lidar_height=%.2f m, "
-                "imu_max_age=%.2f s, accel_g_tol=±%.2f m/s², source %s].",
+                "lidar_mount_yaw=%.3f rad, imu_max_age=%.2f s, "
+                "accel_g_tol=±%.2f m/s², source %s].",
                 input_topic.c_str(),
                 output_topic.c_str(),
                 chassis_blank_range_,
@@ -128,6 +145,7 @@ public:
                 min_obstacle_z_m_,
                 max_obstacle_z_m_,
                 lidar_height_m_,
+                lidar_mount_yaw_,
                 imu_max_age_s_,
                 accel_g_tolerance_ms2_,
                 imu_topic.c_str());
@@ -154,6 +172,9 @@ public:
     double min_obstacle_z_m{0.08};
     double max_obstacle_z_m{1.5};
     double lidar_height_m{0.22};
+    /// Yaw of the LIDAR frame relative to base_link/IMU (rad). A beam at
+    /// LIDAR index angle α points along base bearing α + lidar_mount_yaw.
+    double lidar_mount_yaw{0.0};
   };
 
   /// Apply the radial blank to a copy of @p in. Returns the result.
@@ -177,11 +198,12 @@ public:
   }
 
   /// Apply the gravity-aware ground filter to @p io in place. For each
-  /// beam at angle α (LIDAR frame, assumed flat-mounted relative to
-  /// base_link), the Z component of the beam direction in the gravity-
-  /// aligned frame is computed from the IMU's measured "up" unit vector:
+  /// beam at LIDAR index angle α, rotate into the base/IMU frame by the
+  /// LIDAR mount yaw (ψ = α + lidar_mount_yaw) before projecting onto the
+  /// IMU's measured "up" unit vector:
   ///
-  ///     z_dir    = up_in_imu.x · cos α + up_in_imu.y · sin α
+  ///     ψ        = α + cfg.lidar_mount_yaw
+  ///     z_dir    = up_in_imu.x · cos ψ + up_in_imu.y · sin ψ
   ///     return_Z = lidar_height + range · z_dir
   ///
   /// where up_in_imu = accel / |accel| (the gravity reaction direction).
@@ -208,8 +230,8 @@ public:
       float& r = io.ranges[i];
       if (!std::isfinite(r))
         continue;
-      const double a = a0 + da * static_cast<double>(i);
-      const double z_dir = u.x * std::cos(a) + u.y * std::sin(a);
+      const double psi = a0 + da * static_cast<double>(i) + cfg.lidar_mount_yaw;
+      const double z_dir = u.x * std::cos(psi) + u.y * std::sin(psi);
       const float return_z = static_cast<float>(cfg.lidar_height_m + r * z_dir);
       if (return_z < min_z || return_z > max_z)
         r = inf;
@@ -322,7 +344,8 @@ private:
     GroundFilterConfig cfg{enable_ground_filter_,
                            min_obstacle_z_m_,
                            max_obstacle_z_m_,
-                           lidar_height_m_};
+                           lidar_height_m_,
+                           lidar_mount_yaw_};
     apply_ground_filter(out, cfg, up);
 
     pub_scan_->publish(out);
@@ -360,6 +383,7 @@ private:
   double min_obstacle_z_m_{0.08};
   double max_obstacle_z_m_{1.5};
   double lidar_height_m_{0.22};
+  double lidar_mount_yaw_{0.0};
   double imu_max_age_s_{0.5};
   double accel_g_tolerance_ms2_{3.0};
 

--- a/ros2/src/mowgli_localization/test/test_costmap_scan_filter.cpp
+++ b/ros2/src/mowgli_localization/test/test_costmap_scan_filter.cpp
@@ -273,8 +273,7 @@ TEST(CostmapScanFilterGround, MountYawPiFiltersForwardGroundReturn)
   // ψ = π + π ≡ 0 → z_dir = u.x = -sin(10°) → Z = 0.22 - 0.35 < 0.08.
   const double pitch_rad = 10.0 * M_PI / 180.0;
   auto in = make_single_beam_at(static_cast<float>(M_PI), 2.0f);
-  mowgli_localization::GroundFilterConfigForTest cfg{
-      true, 0.08, 1.5, 0.22, M_PI};
+  mowgli_localization::GroundFilterConfigForTest cfg{true, 0.08, 1.5, 0.22, M_PI};
   auto u = mowgli_localization::up_from_pitch_rad(pitch_rad);
   mowgli_localization::apply_ground_filter_for_test(in, cfg, u);
   EXPECT_FALSE(std::isfinite(in.ranges[0]));
@@ -288,8 +287,7 @@ TEST(CostmapScanFilterGround, MountYawPiKeepsRearBeam)
   // stays in band → kept.
   const double pitch_rad = 10.0 * M_PI / 180.0;
   auto in = make_single_beam_at(0.0f, 2.0f);
-  mowgli_localization::GroundFilterConfigForTest cfg{
-      true, 0.08, 1.5, 0.22, M_PI};
+  mowgli_localization::GroundFilterConfigForTest cfg{true, 0.08, 1.5, 0.22, M_PI};
   auto u = mowgli_localization::up_from_pitch_rad(pitch_rad);
   mowgli_localization::apply_ground_filter_for_test(in, cfg, u);
   EXPECT_FLOAT_EQ(in.ranges[0], 2.0f);
@@ -305,8 +303,8 @@ TEST(CostmapScanFilterGround, UnaccountedMountYawInvertsFilter)
   // wrong behaviour so a future refactor can't silently reintroduce it.
   const double pitch_rad = 10.0 * M_PI / 180.0;
   auto in = make_single_beam_at(static_cast<float>(M_PI), 2.0f);
-  mowgli_localization::GroundFilterConfigForTest cfg{
-      true, 0.08, 1.5, 0.22, 0.0};  // mount yaw NOT applied
+  // mount yaw NOT applied (the old bug)
+  mowgli_localization::GroundFilterConfigForTest cfg{true, 0.08, 1.5, 0.22, 0.0};
   auto u = mowgli_localization::up_from_pitch_rad(pitch_rad);
   mowgli_localization::apply_ground_filter_for_test(in, cfg, u);
   EXPECT_FLOAT_EQ(in.ranges[0], 2.0f);  // bug: ground return survives

--- a/ros2/src/mowgli_localization/test/test_costmap_scan_filter.cpp
+++ b/ros2/src/mowgli_localization/test/test_costmap_scan_filter.cpp
@@ -50,6 +50,7 @@ struct GroundFilterConfigForTest
   double min_obstacle_z_m{0.08};
   double max_obstacle_z_m{1.5};
   double lidar_height_m{0.22};
+  double lidar_mount_yaw{0.0};
 };
 
 void apply_ground_filter_for_test(sensor_msgs::msg::LaserScan& io,
@@ -69,8 +70,8 @@ void apply_ground_filter_for_test(sensor_msgs::msg::LaserScan& io,
     float& r = io.ranges[i];
     if (!std::isfinite(r))
       continue;
-    const double a = a0 + da * static_cast<double>(i);
-    const double z_dir = u.x * std::cos(a) + u.y * std::sin(a);
+    const double psi = a0 + da * static_cast<double>(i) + cfg.lidar_mount_yaw;
+    const double z_dir = u.x * std::cos(psi) + u.y * std::sin(psi);
     const float return_z = static_cast<float>(cfg.lidar_height_m + r * z_dir);
     if (return_z < min_z || return_z > max_z)
       r = inf;
@@ -245,6 +246,70 @@ TEST(CostmapScanFilterGround, OverheadReturnFilteredOnLevelRobot)
       mowgli_localization::Vec3ForTest{0.0, 0.0, 1.0};  // level
   mowgli_localization::apply_ground_filter_for_test(in, cfg, u);
   EXPECT_FALSE(std::isfinite(in.ranges[0]));
+}
+
+namespace
+{
+// Single beam at an explicit LIDAR-frame angle α. Lets the mount-yaw
+// tests place a return on the forward/rear half of the LIDAR ring.
+sensor_msgs::msg::LaserScan make_single_beam_at(float alpha_rad, float range_m)
+{
+  sensor_msgs::msg::LaserScan s;
+  s.angle_min = alpha_rad;
+  s.angle_max = alpha_rad;
+  s.angle_increment = 0.0f;
+  s.range_min = 0.05f;
+  s.range_max = 12.0f;
+  s.ranges = {range_m};
+  return s;
+}
+}  // namespace
+
+TEST(CostmapScanFilterGround, MountYawPiFiltersForwardGroundReturn)
+{
+  // 180°-rotated LIDAR mount (lidar_mount_yaw = π): the beam pointing
+  // FORWARD in the robot/base frame sits at LIDAR angle α = π. On a 10°
+  // nose-down slope that forward ground return at 2 m must be filtered.
+  // ψ = π + π ≡ 0 → z_dir = u.x = -sin(10°) → Z = 0.22 - 0.35 < 0.08.
+  const double pitch_rad = 10.0 * M_PI / 180.0;
+  auto in = make_single_beam_at(static_cast<float>(M_PI), 2.0f);
+  mowgli_localization::GroundFilterConfigForTest cfg{
+      true, 0.08, 1.5, 0.22, M_PI};
+  auto u = mowgli_localization::up_from_pitch_rad(pitch_rad);
+  mowgli_localization::apply_ground_filter_for_test(in, cfg, u);
+  EXPECT_FALSE(std::isfinite(in.ranges[0]));
+}
+
+TEST(CostmapScanFilterGround, MountYawPiKeepsRearBeam)
+{
+  // Same π mount + nose-down: the beam at LIDAR α = 0 points to the REAR
+  // in base, which tilts UP on a nose-down robot, so a 2 m return there
+  // is not ground. ψ = 0 + π = π → z_dir = -u.x = +sin(10°) → Z rises,
+  // stays in band → kept.
+  const double pitch_rad = 10.0 * M_PI / 180.0;
+  auto in = make_single_beam_at(0.0f, 2.0f);
+  mowgli_localization::GroundFilterConfigForTest cfg{
+      true, 0.08, 1.5, 0.22, M_PI};
+  auto u = mowgli_localization::up_from_pitch_rad(pitch_rad);
+  mowgli_localization::apply_ground_filter_for_test(in, cfg, u);
+  EXPECT_FLOAT_EQ(in.ranges[0], 2.0f);
+}
+
+TEST(CostmapScanFilterGround, UnaccountedMountYawInvertsFilter)
+{
+  // Regression guard: with the mount yaw left at 0 (the old bug) on a
+  // π-mounted robot, the forward ground return at LIDAR α = π is NOT
+  // filtered — ψ = π → z_dir = -u.x = +sin(10°) → Z rises above the
+  // floor → phantom obstacle survives. This is exactly the slope failure
+  // the lidar_mount_yaw plumbing fixes; the assertion documents the
+  // wrong behaviour so a future refactor can't silently reintroduce it.
+  const double pitch_rad = 10.0 * M_PI / 180.0;
+  auto in = make_single_beam_at(static_cast<float>(M_PI), 2.0f);
+  mowgli_localization::GroundFilterConfigForTest cfg{
+      true, 0.08, 1.5, 0.22, 0.0};  // mount yaw NOT applied
+  auto u = mowgli_localization::up_from_pitch_rad(pitch_rad);
+  mowgli_localization::apply_ground_filter_for_test(in, cfg, u);
+  EXPECT_FLOAT_EQ(in.ranges[0], 2.0f);  // bug: ground return survives
 }
 
 TEST(CostmapScanFilterGround, NonFiniteRangesUntouched)


### PR DESCRIPTION
## Why

Last run (`obstacle-circumnavigation-test1`, first obstacle test on **uneven ground**) was erratic: big left-right swerving and **phantom obstacles painted on the map by even a small pivot**. Not a regression — nothing touching the scan→costmap→deviation path landed after the last clean run (May 29). It exposed a **latent bug** + a **missing reroute**.

## Root cause

`costmap_scan_filter_node`'s gravity-aware ground filter projected each beam's tilt using the **raw LIDAR index angle**, assuming a flat (zero-yaw) mount. The LIDAR is yaw-mounted **~π** (180°-rotated, `mowgli_robot.yaml` `lidar_yaw=3.1408`). With the mount yaw unaccounted, the front/back sign **inverts on a slope**: forward ground returns get a *positive* z-projection and **survive as phantom obstacles**, while the empty sky-side beams get 'filtered'. On flat ground `ux,uy≈0` so it's invisible — which is why every prior (flat) run looked perfect.

Separately, `local_costmap` still consumed **raw `/scan`**; its `min_obstacle_height` band can't catch tilt because `two_d_mode` forces pitch=roll=0 in TF, so a 2D scan always projects to ~lidar_z regardless of real tilt.

## Changes

- **`lidar_mount_yaw` param** (= `lidar_yaw − imu_yaw`): rotate the beam angle into the IMU/base frame (`ψ = α + lidar_mount_yaw`) before the gravity projection. Plumbed from `mowgli_robot.yaml` via `navigation.launch.py`. Fixes the filter for **all** consumers of `/scan_costmap` (global costmap + collision_monitor).
- **Reroute `local_costmap` obstacle_layer** `/scan` → `/scan_costmap` so it inherits the now-correct tilt filter (last raw-scan consumer).
- **Tests**: π-mount filter/keep cases + a regression guard pinning the old inverted behaviour.

## Safety

No change to blade/firmware. collision_monitor still reads `/scan_costmap` in 2D (height-agnostic) and stops on any real return; `min_obstacle_height` only governs planner routing. Geometry validated numerically; both modified C++ files `-fsyntax-only` clean against the image's ROS headers. CI builds the ARM/amd64 image.

## Deploy / verify

Once CI builds, point `MOWGLI_ROS2_IMAGE` at the `fix-scan-ground-filter-lidar-yaw` tag (or merge to dev) and re-run the obstacle test on the same uneven patch — watch for phantom obstacles on pivots in the local costmap and the left-right flap.