### PR TITLE
fix(coverage): stop mowing the robot→F2C-start prefix out of the field

### DIFF
--- a/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
@@ -1175,13 +1175,13 @@ BT::NodeStatus PlanCoverageArea::onRunning()
       {
         return BT::NodeStatus::FAILURE;
       }
-      // Transit goal = the real F2C mowing start (AFTER the costmap-blind
-      // straight transit prefix), so an obstacle-aware TransitToStrip (Nav2
-      // Smac + global obstacle_layer) routes the robot AROUND obstacles to
-      // the coverage start and FTC's closest-pose resync skips the prefix —
-      // instead of FTC dragging the robot along the 8 m straight prefix that
-      // ignores the costmap. Fall back to the path front only if we never
-      // captured an F2C start (no piece produced poses).
+      // Transit goal = the real F2C mowing start. The mowed path no longer
+      // carries a robot→F2C-start straight prefix, so an obstacle-aware,
+      // boundary-aware TransitToStrip (Nav2 Smac + global obstacle_layer)
+      // routes the robot AROUND obstacles and inside the polygon to the
+      // coverage start; FollowStrip then begins mowing right at the F2C
+      // start. Fall back to the path front only if we never captured an
+      // F2C start (no piece produced poses).
       if (have_first_coverage_pose_)
       {
         ctx->current_transit_goal = first_coverage_pose_;
@@ -1342,79 +1342,46 @@ BT::NodeStatus PlanCoverageArea::onRunning()
       // F2C v2 (mowgli_coverage server) returns a complete coverage
       // path including headland traversal — no need to prepend the
       // hand-rolled perimeter ring anymore.
-      //
-      // We DO still need a transit segment from the robot's current
-      // pose to the F2C path's first pose, though. F2C plans the
-      // field starting from a sub-cell vertex (typically a corner of
-      // the SW sub-cell) and has no notion of where the robot is.
-      // Without a transit prefix, FTC's setPlan picks the closest
-      // path pose to the robot's current location — which can be a
-      // pose in the LAST sub-cell when the robot starts near the
-      // dock at the opposite corner of the field. The robot then
-      // skips 95 % of the path and only mows the last sub-cell.
-      //
-      // Densify the transit at ~0.10 m so FTC's carrot has poses to
-      // chase along the way; the orientation matches the direction
-      // of travel toward the F2C path's first pose.
       const auto& piece_path = wrapped.result->nav_path;
-      // Densify a transit segment from the previous accumulated end-
-      // pose (or the robot's current TF pose for the very first piece)
-      // to this piece's first pose. Required because each F2C piece
-      // plans independently — the gap between consecutive pieces would
-      // otherwise be picked up by FTC's setPlan as the "closest path
-      // pose to robot", which can land deep in the next piece (skipping
-      // anywhere from 5-95 % of poses depending on geometry). The
-      // transit prefix gives FTC a continuous path from where the robot
-      // actually is to where F2C wants it to start.
       const bool is_first_piece = accumulated_path_.poses.empty();
       if (!piece_path.poses.empty())
       {
-        // Capture the FIRST piece's F2C start (the real mowing start, before
-        // we prepend the straight transit prefix below) as the obstacle-aware
-        // TransitToStrip goal.
+        // Capture the FIRST piece's F2C start as the obstacle-aware
+        // TransitToStrip goal. This is the REAL mowing start: the
+        // robot→F2C-start leg is deliberately NOT prepended to the mowed
+        // path. An obstacle-aware, boundary-aware TransitToStrip (Nav2
+        // Smac + the global obstacle_layer) drives the robot there
+        // blade-off, and FollowStrip then begins mowing exactly at the
+        // F2C start. The old hand-rolled straight prefix ignored the area
+        // polygon entirely and got mowed blade-on straight out of the
+        // field ("un swath qui sort du terrain au point de départ").
         if (is_first_piece && !have_first_coverage_pose_)
         {
           first_coverage_pose_ = piece_path.poses.front();
           first_coverage_pose_.header = piece_path.header;
           have_first_coverage_pose_ = true;
         }
-        double rx = 0.0, ry = 0.0;
-        bool have_origin = false;
-        if (is_first_piece)
-        {
-          try
-          {
-            auto tf = ctx->tf_buffer->lookupTransform(
-                "map", "base_footprint", tf2::TimePointZero);
-            rx = tf.transform.translation.x;
-            ry = tf.transform.translation.y;
-            have_origin = true;
-          }
-          catch (const tf2::TransformException& ex)
-          {
-            RCLCPP_WARN(ctx->node->get_logger(),
-                        "PlanCoverageArea: TF lookup map→base_footprint failed "
-                        "(%s); skipping robot→F2C transit prefix.",
-                        ex.what());
-          }
-        }
-        else
+        // Between consecutive F2C pieces (within the already-planned
+        // field), densify a short transit segment from the previous
+        // accumulated end-pose to this piece's first pose. Required
+        // because each F2C piece plans independently — the gap between
+        // pieces would otherwise be picked up by FTC's setPlan as the
+        // "closest path pose to robot", landing deep in the next piece
+        // (skipping 5-95 % of poses). Only inter-piece gaps, which lie
+        // inside the field, are bridged here; the first piece gets no
+        // prefix (TransitToStrip owns the robot→F2C-start leg).
+        if (!is_first_piece)
         {
           const auto& prev_end = accumulated_path_.poses.back().pose.position;
-          rx = prev_end.x;
-          ry = prev_end.y;
-          have_origin = true;
-        }
-
-        if (have_origin)
-        {
+          const double rx = prev_end.x;
+          const double ry = prev_end.y;
           const auto& first_pose = piece_path.poses.front().pose.position;
           const double tdx = first_pose.x - rx;
           const double tdy = first_pose.y - ry;
           const double tlen = std::hypot(tdx, tdy);
-          // Skip the transit when the origin is already at/near the
-          // F2C start — densifying a 5 cm leg gives one redundant pose
-          // at the same location.
+          // Skip the transit when the previous end is already at/near the
+          // F2C start — densifying a sub-10 cm leg gives one redundant
+          // pose at the same location.
           if (tlen > 0.10)
           {
             const double yaw = std::atan2(tdy, tdx);
@@ -1435,8 +1402,8 @@ BT::NodeStatus PlanCoverageArea::onRunning()
               accumulated_path_.poses.push_back(ps);
             }
             RCLCPP_INFO(ctx->node->get_logger(),
-                        "PlanCoverageArea: piece %zu transit %d poses from "
-                        "(%.2f,%.2f) to F2C start (%.2f,%.2f), %.2fm",
+                        "PlanCoverageArea: piece %zu inter-piece transit %d "
+                        "poses from (%.2f,%.2f) to F2C start (%.2f,%.2f), %.2fm",
                         current_piece_, n_steps, rx, ry,
                         first_pose.x, first_pose.y, tlen);
           }

--- a/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
@@ -1404,8 +1404,13 @@ BT::NodeStatus PlanCoverageArea::onRunning()
             RCLCPP_INFO(ctx->node->get_logger(),
                         "PlanCoverageArea: piece %zu inter-piece transit %d "
                         "poses from (%.2f,%.2f) to F2C start (%.2f,%.2f), %.2fm",
-                        current_piece_, n_steps, rx, ry,
-                        first_pose.x, first_pose.y, tlen);
+                        current_piece_,
+                        n_steps,
+                        rx,
+                        ry,
+                        first_pose.x,
+                        first_pose.y,
+                        tlen);
           }
         }
       }


### PR DESCRIPTION
## Problem

A coverage swath exits the field at the **start point** ("un swath qui sort du terrain au point de départ"). `PlanCoverageArea` prepended a hand-rolled straight transit segment — from the robot's current TF pose to the first F2C pose — directly into the **blade-on** `accumulated_path_`. That prefix is polygon-blind, so on the first piece `FollowStrip` mowed a straight line from wherever the robot started (near the dock, frequently outside the field boundary) into the coverage start.

## Fix

Drop the **first-piece** prefix. `TransitToStrip` already owns the robot→F2C-start leg: it drives there blade-off via Nav2 Smac + the global `obstacle_layer` (obstacle- and boundary-aware), with `first_coverage_pose_` as its goal (commit 84232362 already established this). The straight prefix was therefore both redundant and unsafe.

After this change:
- `accumulated_path_` starts exactly at the F2C start — no out-of-field straight segment to mow.
- Even if `TransitToStrip` soft-fails (the `AlwaysSuccess` fallthrough), FTC's closest-pose resync now lands on an **in-field** coverage pose instead of being dragged along an out-of-field straight line.

**Inter-piece** transit segments are kept: the gaps between consecutive F2C pieces lie inside the already-planned field and are needed so FTC's `setPlan` doesn't snap deep into the next piece.

## Safety

No change to blade-safety path — blade enable/disable ordering is unchanged. This only removes poses from the planned path; firmware remains sole blade authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)