### PR TITLE
fix(coverage): stop the resume re-plan blow-up that freezes the robot

### DIFF
--- a/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
@@ -1294,11 +1294,16 @@ BT::NodeStatus PlanCoverageArea::onRunning()
   {
     if (result_future_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready)
     {
-      // F2C planning can take seconds on large fields; allow 30 s.
-      if (std::chrono::steady_clock::now() - phase_start_ > std::chrono::seconds(30))
+      // Backstop only. With the mowed-hole simplification (remaining_polygon)
+      // and the sub-cell area floor (coverage_server), a piece now plans in a
+      // few seconds even on a heavily mowed-out resume field. The old 30 s,
+      // multiplied by ~17 resume pieces × 5 retries, froze the robot for
+      // minutes when F2C choked on a staircased hole (field 2026-06-01). 12 s
+      // still clears any legitimately large single piece.
+      if (std::chrono::steady_clock::now() - phase_start_ > std::chrono::seconds(12))
       {
         RCLCPP_WARN(ctx->node->get_logger(),
-                    "PlanCoverageArea: piece %zu result timeout (30s) — skipping",
+                    "PlanCoverageArea: piece %zu result timeout (12s) — skipping",
                     current_piece_);
         pieces_failed_++;
         current_piece_++;

--- a/ros2/src/mowgli_coverage/include/mowgli_coverage/coverage_server.hpp
+++ b/ros2/src/mowgli_coverage/include/mowgli_coverage/coverage_server.hpp
@@ -92,11 +92,12 @@ private:
   // 2-3 rings, or conversely to add an extra ring on a sloppy edge.
   int num_headland_passes_{0};
   // Drop sub-cells from TrapezoidalDecomp whose area is smaller
-  // than this threshold (m²). With tool_width = 0.18 a sub-cell
-  // under ~ 2 × tool_width² = 0.065 m² can't fit a single swath
-  // anyway, and the F2C path planning adds a Dubins connector for
-  // each one — capping the cost of degenerate splits.
-  double min_subcell_area_m2_{0.065};
+  // than this threshold (m²). A sub-cell under ~0.25 m² (≈ a 0.18 m
+  // swath × 1.4 m) can't tile a useful swath, and screening it here
+  // skips the costly per-sub-cell BruteForce on the staircase slivers
+  // a resume plan leaves behind — see the rationale in coverage_server's
+  // sub-cell loop (94 s/piece regression fixed 2026-06-01).
+  double min_subcell_area_m2_{0.25};
 };
 
 }  // namespace mowgli_coverage

--- a/ros2/src/mowgli_coverage/src/coverage_server.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_server.cpp
@@ -47,8 +47,7 @@ nav2_util::CallbackReturn CoverageServer::on_configure(
       declare_parameter<double>("chassis_safety_inset", 0.0);
   num_headland_passes_ =
       declare_parameter<int>("num_headland_passes", 0);
-  min_subcell_area_m2_ =
-      declare_parameter<double>("min_subcell_area_m2", 0.065);
+  min_subcell_area_m2_ = declare_parameter<double>("min_subcell_area_m2", 0.25);
 
   // The legacy server exposed a handful of mode strings (DUBIN /
   // DUBIN_CC / REEDS_SHEPP, BOUSTROPHEDON / SNAKE, BRUTE_FORCE,
@@ -473,13 +472,19 @@ void CoverageServer::computeCoveragePath()
       if (check_cancel()) return;
 
       const auto sub_cell = planning_cells.getGeometry(i);
-      // Drop sub-cells that can't fit a single swath. F2C v2's
-      // TrapezoidalDecomp can split a hole-bearing polygon into
-      // dozens of slivers along the densified ConstHL output (we
-      // saw 98 sub-cells from one 0.8x0.8 m hole in a 9x6 m field).
-      // Each tiny sliver adds a Dubins connector but no usable
-      // coverage. Threshold = 2 × cov_width² = 0.065 m² with
-      // tool_width = 0.18.
+      // Drop sub-cells that can't fit a single useful swath BEFORE the
+      // costly BruteForce below (generateBestSwaths is ~0.3-0.6 s on each
+      // sub-cell even when it ultimately yields zero swaths). F2C v2's
+      // TrapezoidalDecomp splits a hole-bearing polygon into dozens of
+      // slivers along the densified ConstHL output — a resume plan on a
+      // mowed-out field produced 224 sub-cells, ~170 of them 0.07-0.28 m²,
+      // each burning a full BruteForce for no coverage → 94 s per piece
+      // (field 2026-06-01). These slivers never produce a swath, so screen
+      // them on area here. The simplify-the-mowed-hole fix in
+      // remaining_polygon keeps the sub-cell COUNT sane; this floor keeps
+      // the per-sub-cell COST off the staircase remnants. 0.25 m² ≈ a
+      // 0.18 m swath × 1.4 m — anything smaller can't tile. Tunable via the
+      // min_subcell_area_m2 param.
       if (sub_cell.area() < min_subcell_area_m2_)
       {
         ++skipped_tiny;

--- a/ros2/src/mowgli_map/src/remaining_polygon.cpp
+++ b/ros2/src/mowgli_map/src/remaining_polygon.cpp
@@ -308,7 +308,7 @@ void MapServerNode::on_get_remaining_area_polygon(
         continue;
       }
       BgPolygon simple_orig;
-      bg::simplify(sub, simple_orig, 0.02);
+      bg::simplify(sub, simple_orig, 0.08);
       if (simple_orig.outer().size() < 4)
       {
         simple_orig = sub;
@@ -416,12 +416,17 @@ void MapServerNode::on_get_remaining_area_polygon(
     }
 
     // Collapse the 0.05 m staircase the mow_progress difference leaves on
-    // the boundary (400-600 near-collinear vertices) into a clean ring.
-    // 0.02 m tolerance is well under one cell so the real shape is kept;
-    // a denser ring inflates F2C planning cost and risks GEOS degeneracies.
-    // Fall back to the raw piece if simplification collapses it.
+    // the outer ring AND the mowed-region holes (each a 100-800 vertex
+    // raster boundary). The tolerance MUST exceed one cell (0.05 m) to
+    // actually remove the staircase: at the old 0.02 m it sat *under* the
+    // cell pitch and kept ~all the steps, so a resume piece arrived at F2C
+    // with a 682-pt outer + 114-pt hole, which TrapezoidalDecomp exploded
+    // into 224 sub-cells → 94 s to plan one piece (field 2026-06-01).
+    // 0.08 m clears the steps while staying well inside the chassis/headland
+    // inset, so the real mowable shape is unchanged. Fall back to the raw
+    // piece if simplification collapses it.
     BgPolygon simple_piece;
-    bg::simplify(bg_piece, simple_piece, 0.02);
+    bg::simplify(bg_piece, simple_piece, 0.08);
     if (simple_piece.outer().size() < 4)
     {
       simple_piece = bg_piece;


### PR DESCRIPTION
## Symptom (field report, dev user, 2026-06-01)

> Le robot s'arrête, ne reprend pas la tonte, la phase de planning est très longue, repasse en Idle, « il n'y arrive même plus ».

The robot mowed to **26%**, stopped, then froze in `PLANNING` for minutes and went Idle.

## Root cause (from the user's logs)

On resume, `GetNextUnmowedArea` re-plans the un-mowed remainder. `get_remaining_area_polygon` subtracts the **rasterised** `mow_progress` region, producing an outer ring + a **mowed-region hole that is a 0.05 m raster staircase** (114–806 vertices). F2C `TrapezoidalDecomp` exploded that into **224 sub-cells**, ~170 of them 0.07–0.28 m². Each one still ran a full `BruteForce` that yields **no swath**:

```
Coverage path planned: ... 224 sub-cell(s) ... planning 93917ms   ← 94 s for ONE piece
PlanCoverageArea: piece 15 result timeout (30s) — skipping
PlanCoverageArea: combined path has 0 poses (0 ok, 17 failed)
GetNextUnmowedArea: area 0 has 72 strips remaining (26.2% done) — dispatch attempt 2/5
```

17 resume pieces × several 30 s timeouts × 5 retries ⇒ the robot sat motionless (`acc_dL=0 acc_dR=0`, odom flat) for minutes.

**Why "depuis quelques jours":** amplified by the 2026-05-30 coverage changes (split-lobes returns every piece + stricter area-completion ⇒ the area no longer finishes so it keeps re-entering planning). This is a re-plan blow-up — **not** #259/#260.

## Fix (robust, at the source)

| Volet | File | Change |
|------|------|--------|
| 1 | `remaining_polygon.cpp` | Simplify resume pieces (outer **and** mowed-region holes) at **0.08 m** instead of 0.02 m. The tolerance must exceed the 0.05 m cell pitch to collapse the staircase; 0.02 sat under it and kept every step. Cuts a 682-pt outer + 114-pt hole to a few dozen vertices ⇒ far fewer trapezoids. |
| 2 | `coverage_server.cpp` (+ hpp) | Raise `min_subcell_area_m2` **0.065 → 0.25** so the leftover staircase trapezoids are screened on area **before** the costly per-sub-cell `BruteForce`. Only bites holey/resume decompositions; normal first-plan sub-cells are far larger. Tunable via the param. |
| 3 | `coverage_nodes.cpp` | Lower the per-piece F2C backstop timeout **30 s → 12 s**. With Volets 1+2 each piece plans in seconds; 30 s × 17 × 5 was the freeze multiplier. 12 s still clears any legitimately large single piece. |

## Safety

Holes are **only simplified, never dropped** — operator obstacles and the dock exclusion keep their geometry, so the robot never plans a swath through a real obstacle. No change to the blade path; firmware remains sole authority.

## Note for the field user

This is separate from #259 (phantom obstacles on uneven ground → FTC flap → FollowStrip abort at ~26% → which *triggers* the re-plan). #259 landed on dev today; the user should pull latest dev to get both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)