### PR TITLE
fix(gui): show coverage plan on map + pause (not abort) sessions on recharge

### DIFF
--- a/gui/pkg/api/diagnostics.go
+++ b/gui/pkg/api/diagnostics.go
@@ -85,8 +85,9 @@ type MowingSession struct {
 	CoveragePercent float32 `json:"coverage_percent"`
 	StripsCompleted uint32  `json:"strips_completed"`
 	StripsSkipped   uint32  `json:"strips_skipped"`
-	DistanceMeters  float64 `json:"distance_meters"`
-	Status          string  `json:"status"` // "completed", "aborted", "error"
+	DistanceMeters  float64  `json:"distance_meters"`
+	Status          string   `json:"status"` // "completed", "aborted", "error"
+	RechargePauses  int      `json:"recharge_pauses"` // recharge pauses during the session
 	Errors          []string `json:"errors"`
 }
 

--- a/gui/pkg/providers/ros.go
+++ b/gui/pkg/providers/ros.go
@@ -42,7 +42,7 @@ var topicMap = map[string]topicDef{
 	"ticks":               {"/wheel_ticks", "mowgli_interfaces/msg/WheelTick"},
 	"wheelOdom":           {"/wheel_odom", "nav_msgs/msg/Odometry"},
 	"map":                 {"", ""},                                                            // virtual – populated via map_server services
-	"path":                {"/FollowCoveragePath/global_plan", "nav_msgs/msg/Path"},            // infrequent event
+	"path":                {"/controller_server/FollowCoveragePath/global_plan", "nav_msgs/msg/Path"}, // coverage plan
 	"plan":                {"/plan", "nav_msgs/msg/Path"},                                      // infrequent event
 	"coverageCells":       {"/map_server_node/coverage_cells", "nav_msgs/msg/OccupancyGrid"},   // large message
 	"power":               {"/hardware_bridge/power", "mowgli_interfaces/msg/Power"},

--- a/gui/pkg/providers/session_tracker.go
+++ b/gui/pkg/providers/session_tracker.go
@@ -22,6 +22,7 @@ type MowingSessionRecord struct {
 	StripsSkipped   uint32   `json:"strips_skipped"`
 	DistanceMeters  float64  `json:"distance_meters"`
 	Status          string   `json:"status"`
+	RechargePauses  int      `json:"recharge_pauses"`
 	Errors          []string `json:"errors"`
 }
 
@@ -33,6 +34,12 @@ type SessionTracker struct {
 	currentState string
 	sessionStart time.Time
 	inSession    bool
+	// paused is set while the robot has docked to recharge mid-session and the
+	// BT is expected to auto-resume mowing once topped up. A paused session is
+	// kept OPEN (not finalized) so a recharge no longer produces a spurious
+	// "aborted" record. pauseCount tallies the recharge cycles for the record.
+	paused     bool
+	pauseCount int
 }
 
 const sessionsDBKey = "mowing.sessions"
@@ -70,14 +77,38 @@ func (s *SessionTracker) OnHighLevelStatus(msg []byte) {
 	// Start session
 	if isMowing && !s.inSession {
 		s.inSession = true
+		s.paused = false
+		s.pauseCount = 0
 		s.sessionStart = time.Now().UTC()
 		log.Printf("SessionTracker: mowing session started (state=%s)", status.StateName)
+		return
+	}
+
+	// Resume after a recharge pause: mowing came back on the SAME session.
+	if isMowing && s.inSession && s.paused {
+		s.paused = false
+		log.Printf("SessionTracker: mowing session resumed after recharge")
+		return
+	}
+
+	// Pause for recharge: the robot docked to charge mid-session (low battery)
+	// and the BT auto-resumes once topped up. Keep the session OPEN instead of
+	// finalizing it as "aborted" — the recharge is a pause, not an end. A
+	// genuine end-of-mow that happens to charge (prevState MOWING_COMPLETE) is
+	// excluded so it still finalizes as "completed" below.
+	if s.inSession && !isMowing && status.StateName == "CHARGING" && prevState != "MOWING_COMPLETE" {
+		if !s.paused {
+			s.paused = true
+			s.pauseCount++
+			log.Printf("SessionTracker: mowing session paused for recharge (pause #%d)", s.pauseCount)
+		}
 		return
 	}
 
 	// End session
 	if s.inSession && !isMowing && !wasMowing {
 		s.inSession = false
+		s.paused = false
 		endTime := time.Now().UTC()
 		duration := endTime.Sub(s.sessionStart).Seconds()
 
@@ -97,13 +128,14 @@ func (s *SessionTracker) OnHighLevelStatus(msg []byte) {
 		}
 
 		session := MowingSessionRecord{
-			ID:          fmt.Sprintf("%d", s.sessionStart.UnixMilli()),
-			StartTime:   s.sessionStart.Format(time.RFC3339),
-			EndTime:     endTime.Format(time.RFC3339),
-			DurationSec: duration,
-			AreaIndex:   status.Area,
-			Status:      sessionStatus,
-			Errors:      []string{},
+			ID:             fmt.Sprintf("%d", s.sessionStart.UnixMilli()),
+			StartTime:      s.sessionStart.Format(time.RFC3339),
+			EndTime:        endTime.Format(time.RFC3339),
+			DurationSec:    duration,
+			AreaIndex:      status.Area,
+			Status:         sessionStatus,
+			RechargePauses: s.pauseCount,
+			Errors:         []string{},
 		}
 
 		if status.Emergency {

--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -3,7 +3,7 @@ import {useApi} from "../hooks/useApi.ts";
 import {App} from "antd";
 import turfArea from "@turf/area";
 import React, {useCallback, useEffect, useMemo, useRef, useState} from "react";
-import {MapArea, Marker} from "../types/ros.ts";
+import {MapArea} from "../types/ros.ts";
 import DrawControl from "../components/DrawControl.tsx";
 import Map, {Layer, Source} from 'react-map-gl/mapbox';
 import type {Map as MapboxMap} from 'mapbox-gl';
@@ -224,18 +224,17 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
             const dock_lonlat = transpose(offsetX, offsetY, datum, map?.dock_y!!, map?.dock_x!!)
             newFeatures["dock"] = new DockFeatureBase(dock_lonlat, map?.dock_heading ?? 0);
         }
-        if (path?.markers) {
-            Object.values<Marker>(path.markers).filter((f) => {
-                return f.type == 4 && f.action == 0
-            }).forEach((marker, index) => {
-                const line: Position[] = marker.points?.map(point => {
-                    return transpose(offsetX, offsetY, datum, point.y!!, point.x!!)
-                }) ?? []
-
-                const feature = new PathFeature("path-" + index.toString(), line, `rgba(${(marker.color?.r ?? 0) * 255}, ${(marker.color?.g ?? 0) * 255}, ${(marker.color?.b ?? 0) * 255}, ${(marker.color?.a ?? 1) * 255})`);
+        if (path?.poses) {
+            // Coverage plan: the F2C swaths the robot is about to mow
+            // (/controller_server/FollowCoveragePath/global_plan, a nav_msgs/Path).
+            // Rendered green so it reads distinctly from the transit plan below.
+            const coordinates: Position[] = path.poses.map((pose) => {
+                return transpose(offsetX, offsetY, datum, pose.pose?.position?.y!, pose.pose?.position?.x!)
+            });
+            if (coordinates.length > 1) {
+                const feature = new PathFeature("coverage-path", coordinates, "rgba(80, 200, 120, 0.9)", 2);
                 newFeatures[feature.id] = feature
-
-            })
+            }
         }
         if (plan?.poses) {
             const coordinates = plan.poses.map((pose) => {

--- a/gui/web/src/pages/StatisticsPage.tsx
+++ b/gui/web/src/pages/StatisticsPage.tsx
@@ -18,6 +18,7 @@ interface MowingSession {
   strips_skipped: number;
   distance_meters: number;
   status: "completed" | "aborted" | "error";
+  recharge_pauses?: number;
   errors: string[];
 }
 
@@ -143,9 +144,16 @@ export const StatisticsPage = () => {
     },
     ...(!isMobile ? [{
       title: "Status", dataIndex: "status", key: "status",
-      render: (v: string) => {
+      render: (v: string, record: MowingSession) => {
         const c = v === "completed" ? "success" : v === "aborted" ? "warning" : "error";
-        return <Tag color={c}>{v ?? "--"}</Tag>;
+        return (
+          <span style={{display: 'inline-flex', gap: 6, alignItems: 'center'}}>
+            <Tag color={c}>{v ?? "--"}</Tag>
+            {record.recharge_pauses ? (
+              <Tag color="processing">⏸ {record.recharge_pauses}× recharge</Tag>
+            ) : null}
+          </span>
+        );
       },
     }] : []),
   ];

--- a/gui/web/src/pages/map/hooks/useMapStreams.ts
+++ b/gui/web/src/pages/map/hooks/useMapStreams.ts
@@ -6,7 +6,6 @@ import {
     AbsolutePose,
     LaserScan,
     Map as MapType,
-    MarkerArray,
     ObstacleArray,
     OccupancyGrid,
     Path,
@@ -132,7 +131,7 @@ export function useMapStreams({
     robotPoseRef,
 }: UseMapStreamsOptions) {
     const [map, setMap] = useState<MapType | undefined>(undefined);
-    const [path, setPath] = useState<MarkerArray | undefined>(undefined);
+    const [path, setPath] = useState<Path | undefined>(undefined);
     const [plan, setPlan] = useState<Path | undefined>(undefined);
     const [lidarCollection, setLidarCollection] = useState<GeoJSON.FeatureCollection>({
         type: "FeatureCollection",
@@ -222,7 +221,7 @@ export function useMapStreams({
             console.log({ message: "PATH Stream connected" });
         },
         (e) => {
-            const parse = JSON.parse(e) as MarkerArray;
+            const parse = JSON.parse(e) as Path;
             setPath(parse);
         }
     );


### PR DESCRIPTION
Two field-reported GUI issues.

## 1. Coverage plan never visible on the map

Two compounding bugs meant the planned coverage path (the F2C swaths) never drew:

- **Wrong topic.** Backend subscribed to `/FollowCoveragePath/global_plan`, but the FTC controller publishes on **`/controller_server/FollowCoveragePath/global_plan`** (`nav2_params.yaml` `plan_topic`, line 151) — no data ever arrived.
- **Wrong type.** The frontend parsed that `nav_msgs/Path` as a `MarkerArray` and read `path.markers` (always `undefined` on a Path) — so even with data, nothing rendered.

**Fix:** corrected the backend topic; the frontend now types/parses `path` as `Path` and renders `path.poses` as a green coverage line (`PathFeature "coverage-path"`), visually distinct from the transit plan (`ActivePathFeature`). Dropped the now-unused `Marker`/`MarkerArray` imports.

## 2. Return-to-charge logged as "aborted"

When the battery runs low mid-mow the robot docks (`MOWING → CHARGING`) and the BT auto-resumes once topped up — but `SessionTracker` finalized the session as **aborted** the moment it saw `CHARGING`.

**Fix** (`session_tracker.go`): a recharge now **pauses** the session (kept open, `pauseCount++`) and **resumes the same session** when mowing continues, so it finalizes exactly once — as `completed` — carrying a `recharge_pauses` count surfaced as a `⏸ N× recharge` tag in Statistics. A genuine end that happens to charge (`prevState == MOWING_COMPLETE`) is excluded, and real terminal states (dock failures, emergency) still finalize as before.

Plumbed `recharge_pauses` through the API `MowingSession` type and the `StatisticsPage` row.

## Notes
- Frontend edits reviewed against `tsc` strict rules (dropped unused imports under `noUnusedLocals`); no host Go toolchain — relying on CI.
- Behavior-tree auto-resume already exists; this is purely how the GUI records/labels it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)