### PR TITLE
feat(gui): draw the on-map robot from the URDF (match the sensors page)

### DIFF
--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -606,8 +606,8 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                         <Layer type={"fill"} id={"mower-footprint-fill"}
                             filter={['==', ['get', 'feature_type'], 'mower-footprint']}
                             paint={{
-                                'fill-color': '#00a6ff',
-                                'fill-opacity': 0.35,
+                                'fill-color': ['get', 'color'],
+                                'fill-opacity': 0.55,
                             }}/>
                         <Layer type={"line"} id={"mower-footprint-outline"}
                             filter={['==', ['get', 'feature_type'], 'mower-footprint']}
@@ -777,8 +777,8 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                         <Layer type={"fill"} id={"mower-footprint-fill"}
                             filter={['==', ['get', 'feature_type'], 'mower-footprint']}
                             paint={{
-                                'fill-color': '#00a6ff',
-                                'fill-opacity': 0.35,
+                                'fill-color': ['get', 'color'],
+                                'fill-opacity': 0.55,
                             }}/>
                         <Layer type={"line"} id={"mower-footprint-outline"}
                             filter={['==', ['get', 'feature_type'], 'mower-footprint']}

--- a/gui/web/src/pages/map/hooks/useMapStreams.ts
+++ b/gui/web/src/pages/map/hooks/useMapStreams.ts
@@ -15,10 +15,11 @@ import {
     LineFeatureBase,
     MowingFeature,
     MowerFeatureBase,
-    MowerFootprintFeature,
+    RobotPartFeature,
     PathFeature,
 } from "../../../types/map.ts";
-import { drawLine, drawRobotFootprint, transpose } from "../../../utils/map.tsx";
+import { drawLine, drawRobotSilhouette, transpose } from "../../../utils/map.tsx";
+import { useRobotDescription } from "../../../hooks/useRobotDescription.ts";
 
 type CoverageCellsImage = {
     url: string;
@@ -149,6 +150,10 @@ export function useMapStreams({
 
     const highLevelStatus = useHighLevelStatus();
 
+    // Robot geometry from the /robot_description URDF — single source of truth
+    // for the on-map robot shape, so it matches the sensors-page model.
+    const robot = useRobotDescription();
+
     const poseStream = useWS<string>(
         () => {
             console.log({ message: "Pose Stream closed" });
@@ -175,18 +180,18 @@ export function useMapStreams({
                 const posX = pose.pose?.pose?.position?.x!!;
                 const posY = pose.pose?.pose?.position?.y!!;
                 const line = drawLine(offsetX, offsetY, datum, posY, posX, orientation);
-                // Robot footprint from config (chassis dimensions)
-                const ccx = parseFloat(settings["chassis_center_x"] ?? "0.18");
-                const cl = parseFloat(settings["chassis_length"] ?? "0.54");
-                const cw = parseFloat(settings["chassis_width"] ?? "0.40");
-                const footprintRing = drawRobotFootprint(
-                    offsetX, offsetY, datum, posY, posX, orientation,
-                    ccx + cl / 2, ccx - cl / 2, cw / 2
+                // URDF-derived robot silhouette (chassis + drive wheels + blade)
+                // so the map robot matches the sensors-page model exactly.
+                const sil = drawRobotSilhouette(
+                    offsetX, offsetY, datum, posY, posX, orientation, robot
                 );
                 return {
                     ...oldFeatures,
                     mower: new MowerFeatureBase(mower_lonlat),
-                    ["mower-footprint"]: new MowerFootprintFeature(footprintRing),
+                    ["mower-footprint"]: new RobotPartFeature("mower-footprint", sil.chassis, "#00a6ff"),
+                    ["mower-wheel-l"]: new RobotPartFeature("mower-wheel-l", sil.wheelL, "#0b2e3f"),
+                    ["mower-wheel-r"]: new RobotPartFeature("mower-wheel-r", sil.wheelR, "#0b2e3f"),
+                    ["mower-blade"]: new RobotPartFeature("mower-blade", sil.blade, "#ff6b6b"),
                     ["mower-heading"]: new LineFeatureBase(
                         "mower-heading",
                         [mower_lonlat, line],

--- a/gui/web/src/types/map.ts
+++ b/gui/web/src/types/map.ts
@@ -92,6 +92,19 @@ export class MowerFootprintFeature extends MowingFeature implements Feature<Poly
     }
 }
 
+// One piece of the URDF-derived robot silhouette (chassis / wheel / blade).
+// All parts share feature_type 'mower-footprint' so they reuse the existing
+// fill + outline map layers; `color` is per-part (data-driven fill) so the
+// wheels and blade read distinctly from the chassis.
+export class RobotPartFeature extends MowingFeature implements Feature<Polygon> {
+    declare geometry: Polygon;
+    constructor(id: string, ring: Position[], color: string) {
+        super(id);
+        this.geometry = { type: 'Polygon', coordinates: [ring] };
+        this.properties = { color, feature_type: 'mower-footprint' };
+    }
+}
+
 export class DockFeatureBase extends PointFeatureBase  {
     declare properties: {
         color: string;

--- a/gui/web/src/utils/map.tsx
+++ b/gui/web/src/utils/map.tsx
@@ -1,4 +1,5 @@
 import {Quaternion} from "../types/ros.ts";
+import type {RobotGeometry} from "../hooks/useRobotDescription.ts";
 
 export const earth = 6371008.8;  // radius of the earth in meters
 export const pi = Math.PI;
@@ -49,6 +50,49 @@ export function drawRobotFootprint(
         const ry = posY + fx * sin + fy * cos;
         return transpose(offsetX, offsetY, datum, ry, rx);
     });
+}
+
+/**
+ * Robot silhouette polygons in [lon, lat], derived from the URDF geometry
+ * (/robot_description) so the map robot matches the sensors-page model exactly
+ * — chassis box + the two drive wheels + the blade disc — instead of a plain
+ * settings-sized rectangle. base_link is at the rear wheel axis, so the chassis
+ * is offset forward by chassisCenterX; wheels sit at wheelXOffset / ±wheelTrack/2.
+ * All points are in the local base_link frame, rotated by heading and projected.
+ */
+export function drawRobotSilhouette(
+    offsetX: number, offsetY: number, datum: [number, number, number],
+    posY: number, posX: number, heading: number, g: RobotGeometry,
+): { chassis: [number, number][]; wheelL: [number, number][]; wheelR: [number, number][]; blade: [number, number][] } {
+    const cos = Math.cos(heading);
+    const sin = Math.sin(heading);
+    // Local (forward x, left y) -> map [lon, lat].
+    const pt = (fx: number, fy: number): [number, number] => {
+        const rx = posX + fx * cos - fy * sin;
+        const ry = posY + fx * sin + fy * cos;
+        return transpose(offsetX, offsetY, datum, ry, rx);
+    };
+    // Axis-aligned (in robot frame) rectangle centred at (xc, yc), half-extents hx/hy.
+    const rect = (xc: number, yc: number, hx: number, hy: number): [number, number][] => [
+        pt(xc - hx, yc - hy),
+        pt(xc + hx, yc - hy),
+        pt(xc + hx, yc + hy),
+        pt(xc - hx, yc + hy),
+        pt(xc - hx, yc - hy),
+    ];
+
+    const chassis = rect(g.chassisCenterX, 0, g.baseLength / 2, g.baseWidth / 2);
+    const wheelL = rect(g.wheelXOffset, g.wheelTrack / 2, g.wheelRadius, g.wheelWidth / 2);
+    const wheelR = rect(g.wheelXOffset, -g.wheelTrack / 2, g.wheelRadius, g.wheelWidth / 2);
+
+    const blade: [number, number][] = [];
+    const N = 20;
+    for (let i = 0; i <= N; i++) {
+        const a = (2 * Math.PI * i) / N;
+        blade.push(pt(g.chassisCenterX + g.bladeRadius * Math.cos(a), g.bladeRadius * Math.sin(a)));
+    }
+
+    return { chassis, wheelL, wheelR, blade };
 }
 
 /**


### PR DESCRIPTION
## Problem

The GUI showed **two different robot shapes**: the sensors page renders the real robot from `/robot_description` (URDF) — chassis + wheels + casters + blade — while the **map** drew a plain rectangle sized from the `chassis_*` settings.

## Fix

The on-map robot is now a **URDF-derived silhouette** built from the same `RobotGeometry` the sensors page uses (`useRobotDescription`), so the two views match and the URDF is the single source of truth.

- **`utils/map.tsx`** — `drawRobotSilhouette(..., RobotGeometry)` returns `chassis / wheelL / wheelR / blade` rings (local base_link frame → map `[lon,lat]`, rotated by heading). base_link is at the rear axle, so the chassis is offset forward by `chassisCenterX` and the wheels sit at `wheelXOffset / ±wheelTrack/2`.
- **`types/map.ts`** — `RobotPartFeature`: a polygon part carrying its own `color`, all tagged `feature_type: 'mower-footprint'` so they reuse the existing fill + outline layers (no new layers).
- **`MapPage.tsx`** — the `mower-footprint` fill is now data-driven (`['get','color']`) so wheels (dark) and blade (red) read distinctly from the chassis (blue); opacity 0.35 → 0.55.
- **`useMapStreams.ts`** — emit chassis + wheels + blade from the URDF instead of the settings rectangle; dropped the `chassis_*` settings lookups and the old `drawRobotFootprint` path.

Dashboard live-map dots are intentionally left as stylized focal points (per the chosen scope — map only).

No host TS toolchain failure expected: dropped/added imports balanced under `noUnusedLocals`; expression fill-color mirrors the existing `['get','color']` line-color usage. Relying on CI for the full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)