### PR TITLE
fix(firmware/imu): detect ICM-45686 at 0x68 or 0x69 and probe it in the detection loop

### DIFF
--- a/firmware/stm32/ros_usbnode/include/imu/icm45686.h
+++ b/firmware/stm32/ros_usbnode/include/imu/icm45686.h
@@ -12,9 +12,15 @@ extern "C" {
  * the existing MPU6050 driver
  */
 
-/* I2C address (typical default) */
+/* I2C address. The ICM-45686 address LSB is set by the AD0/MISO pin:
+ * AD0 low -> 0x68 (primary), AD0 high -> 0x69 (alternate). Some breakouts
+ * strap AD0 high, so ICM45686_TestDevice() probes both addresses. */
 #ifndef ICM45686_ADDRESS
 #define ICM45686_ADDRESS 0x68
+#endif
+
+#ifndef ICM45686_ADDRESS_ALT
+#define ICM45686_ADDRESS_ALT 0x69
 #endif
 
 /* Register addresses (from TDK/InvenSense ICM456xx driver)

--- a/firmware/stm32/ros_usbnode/src/imu/icm45686.c
+++ b/firmware/stm32/ros_usbnode/src/imu/icm45686.c
@@ -22,6 +22,10 @@ static float icm45686_deg_per_lsb = 250.0f / 32768.0f; /* default for 250 dps */
 static icm45686_accel_fs_sel_t icm45686_accel_fs = ICM45686_ACCEL_FS_SEL_2_G;
 static icm45686_gyro_fs_sel_t icm45686_gyro_fs = ICM45686_GYRO_FS_SEL_250_DPS;
 
+/* I2C address the device actually answered on; resolved by ICM45686_TestDevice()
+ * (probes ICM45686_ADDRESS then ICM45686_ADDRESS_ALT). Used by Init/reads. */
+static uint8_t icm45686_addr = ICM45686_ADDRESS;
+
 /* Registers used by the simple init sequence (from vendor regmap excerpts) */
 #define ICM45686_REG_MISC2         0x7F
 #define ICM45686_REG_PWR_MGMT0     0x10
@@ -32,19 +36,23 @@ static icm45686_gyro_fs_sel_t icm45686_gyro_fs = ICM45686_GYRO_FS_SEL_250_DPS;
 
 uint8_t ICM45686_TestDevice(void)
 {
-  uint8_t val;
-  val = SW_I2C_UTIL_Read(ICM45686_ADDRESS, ICM45686_WHO_AM_I);
-  if (val == ICM45686_WHO_AM_I_ID) {
-    debug_printf("    > [ICM-45686] - WHO_AM_I=0x%02x (OK)\r\n", val);
-    return 1;
+  const uint8_t candidates[2] = { ICM45686_ADDRESS, ICM45686_ADDRESS_ALT };
+  for (uint8_t i = 0; i < 2; i++) {
+    uint8_t val = SW_I2C_UTIL_Read(candidates[i], ICM45686_WHO_AM_I);
+    if (val == ICM45686_WHO_AM_I_ID) {
+      icm45686_addr = candidates[i];
+      debug_printf("    > [ICM-45686] - WHO_AM_I=0x%02x (OK) at I2C addr=0x%02x\r\n", val, icm45686_addr);
+      return 1;
+    }
+    debug_printf("    > [ICM-45686] - probe at I2C addr=0x%02x got 0x%02x\r\n", candidates[i], val);
   }
-  debug_printf("    > [ICM-45686] - Error probing for ICM45686 at I2C addr=0x%02x, got 0x%02x\r\n", ICM45686_ADDRESS, val);
+  debug_printf("    > [ICM-45686] - Error: not found at 0x%02x or 0x%02x\r\n", ICM45686_ADDRESS, ICM45686_ADDRESS_ALT);
   return 0;
 }
 
 void ICM45686_Init(void)
 {
-  uint8_t who = SW_I2C_UTIL_Read(ICM45686_ADDRESS, ICM45686_WHO_AM_I);
+  uint8_t who = SW_I2C_UTIL_Read(icm45686_addr, ICM45686_WHO_AM_I);
   if (who != ICM45686_WHO_AM_I_ID) {
     debug_printf(" * ICM-45686 not found during init (who=0x%02x)\r\n", who);
     return;
@@ -53,14 +61,14 @@ void ICM45686_Init(void)
   debug_printf(" * ICM-45686 init: WHO_AM_I=0x%02x\r\n", who);
 
   /* Soft reset: write soft reset bit in REG_MISC2 (vendor regmap indicates soft reset at REG_MISC2 bit) */
-  SW_I2C_UTIL_WRITE(ICM45686_ADDRESS, ICM45686_REG_MISC2, 0x02);
+  SW_I2C_UTIL_WRITE(icm45686_addr, ICM45686_REG_MISC2, 0x02);
   /* Short delay for reset to complete */
   TIMER__Wait_us(2000);
 
   /* Set power management: enable accelerometer and gyro in low-noise mode per datasheet.
    * Writing 0x0F enables both accel and gyro low-noise default mode (vendor datasheet).
    */
-  SW_I2C_UTIL_WRITE(ICM45686_ADDRESS, ICM45686_REG_PWR_MGMT0, ICM45686_PWR_MGMT0_ACCEL_GYRO_LOW_NOISE);
+  SW_I2C_UTIL_WRITE(icm45686_addr, ICM45686_REG_PWR_MGMT0, ICM45686_PWR_MGMT0_ACCEL_GYRO_LOW_NOISE);
 
   /* Configure accelerometer and gyro:
    * - accel FSR: +/-2g, ODR: 100Hz
@@ -68,8 +76,8 @@ void ICM45686_Init(void)
    */
   uint8_t accel_cfg = ICM45686_ACCEL_CONFIG0_VALUE(ICM45686_ACCEL_FS_SEL_2_G, ICM45686_ACCEL_ODR_100HZ);
   uint8_t gyro_cfg  = ICM45686_GYRO_CONFIG0_VALUE(ICM45686_GYRO_FS_SEL_250_DPS, ICM45686_GYRO_ODR_100HZ);
-  SW_I2C_UTIL_WRITE(ICM45686_ADDRESS, ICM45686_REG_ACCEL_CONFIG0, accel_cfg);
-  SW_I2C_UTIL_WRITE(ICM45686_ADDRESS, ICM45686_REG_GYRO_CONFIG0, gyro_cfg);
+  SW_I2C_UTIL_WRITE(icm45686_addr, ICM45686_REG_ACCEL_CONFIG0, accel_cfg);
+  SW_I2C_UTIL_WRITE(icm45686_addr, ICM45686_REG_GYRO_CONFIG0, gyro_cfg);
 
   /* record selected FS and compute scale factors (LSB -> physical units)
    * Accelerometer: assume 16-bit output, so LSB_per_g = 16384 / (FS/2) ???
@@ -115,7 +123,7 @@ void ICM45686_ReadAccelerometerRaw(float *x, float *y, float *z)
 {
     uint8_t accel_xyz[6];
 
-    SW_I2C_UTIL_Read_Multi(ICM45686_ADDRESS, ICM45686_ACCEL_XOUT_H, 6, (uint8_t*)&accel_xyz);
+    SW_I2C_UTIL_Read_Multi(icm45686_addr, ICM45686_ACCEL_XOUT_H, 6, (uint8_t*)&accel_xyz);
 
   {
     // default is little-endian, combine bytes
@@ -131,7 +139,7 @@ void ICM45686_ReadAccelerometerRaw(float *x, float *y, float *z)
 void ICM45686_ReadGyroRaw(float *x, float *y, float *z)
 {
     uint8_t gyro_xyz[6];
-    SW_I2C_UTIL_Read_Multi(ICM45686_ADDRESS, ICM45686_GYRO_XOUT_H, 6, (uint8_t*)&gyro_xyz);
+    SW_I2C_UTIL_Read_Multi(icm45686_addr, ICM45686_GYRO_XOUT_H, 6, (uint8_t*)&gyro_xyz);
 
   {
     // default is little-endian, combine bytes

--- a/firmware/stm32/ros_usbnode/src/imu/imu.c
+++ b/firmware/stm32/ros_usbnode/src/imu/imu.c
@@ -145,20 +145,20 @@ while (imuReadAccelerometerRaw == NULL && ((HAL_GetTick() - l_u32Timestamp) < 20
     }
   #endif
 
+  #ifndef DISABLE_ICM45686
+    if ((!imuReadGyroRaw || !imuReadAccelerometerRaw) && ICM45686_TestDevice()) {
+      ICM45686_Init();
+      imuReadAccelerometerRaw=ICM45686_ReadAccelerometerRaw;
+      imuReadGyroRaw=ICM45686_ReadGyroRaw;
+    }
+  #endif
+
   HAL_Delay(20);
 }
 
 if(imuReadAccelerometerRaw == NULL){
   chirp(10);
 }
-
-#ifndef DISABLE_ICM45686
-  if ((!imuReadGyroRaw || !imuReadAccelerometerRaw) && ICM45686_TestDevice()) {
-    ICM45686_Init();
-    imuReadAccelerometerRaw=ICM45686_ReadAccelerometerRaw;
-    imuReadGyroRaw=ICM45686_ReadGyroRaw;
-  }
-#endif
 
   /* Magnetometer: try LIS3MDL (separate chip on Pololu boards) if no
    * mag was set by the accel/gyro IMU driver (e.g. WT901 has built-in mag,


### PR DESCRIPTION
Two portability fixes for the ICM-45686 IMU driver, both observed on real
hardware running the ROS1 Mowgli firmware of the same lineage.

### A. Dual I2C address probe
The ICM-45686 address LSB is set by the AD0/MISO pin (AD0 low → `0x68`,
AD0 high → `0x69`). Several breakouts strap AD0 high, so the module answers
only at `0x69` and was never detected. `ICM45686_TestDevice()` now probes
`0x68` then `0x69`, stores the winning address in a new static
`icm45686_addr`, and `Init`/reads use it.

### B. Probe inside the detection loop
The ICM45686 block sat *after* the 20 s detection while-loop and after
`chirp(10)`, so an ICM-only board stalled the full 20 s and emitted the
10 "no IMU" chirps before the sensor was found. Moved it next to the other
accel/gyro drivers inside the loop; the LIS3MDL magnetometer probe stays
after the loop, unchanged.

### Notes
- Calibration is intentionally **not** added here — MowgliNext handles IMU
  bias/covariance on the ROS2 side (`hardware_bridge_node imu_cal_*`).
- Built clean: `pio run -e Yardforce500` (Flash 23.6%, RAM 31.7%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)