### PR TITLE
feat(gps): fall back to NAV-PVT for fix/satellite health diagnostics

### DIFF
--- a/firmware/stm32/ros_usbnode/include/imu/icm45686.h
+++ b/firmware/stm32/ros_usbnode/include/imu/icm45686.h
@@ -12,9 +12,15 @@ extern "C" {
  * the existing MPU6050 driver
  */
 
-/* I2C address (typical default) */
+/* I2C address. The ICM-45686 address LSB is set by the AD0/MISO pin:
+ * AD0 low -> 0x68 (primary), AD0 high -> 0x69 (alternate). Some breakouts
+ * strap AD0 high, so ICM45686_TestDevice() probes both addresses. */
 #ifndef ICM45686_ADDRESS
 #define ICM45686_ADDRESS 0x68
+#endif
+
+#ifndef ICM45686_ADDRESS_ALT
+#define ICM45686_ADDRESS_ALT 0x69
 #endif
 
 /* Register addresses (from TDK/InvenSense ICM456xx driver)

--- a/firmware/stm32/ros_usbnode/src/imu/icm45686.c
+++ b/firmware/stm32/ros_usbnode/src/imu/icm45686.c
@@ -22,6 +22,10 @@ static float icm45686_deg_per_lsb = 250.0f / 32768.0f; /* default for 250 dps */
 static icm45686_accel_fs_sel_t icm45686_accel_fs = ICM45686_ACCEL_FS_SEL_2_G;
 static icm45686_gyro_fs_sel_t icm45686_gyro_fs = ICM45686_GYRO_FS_SEL_250_DPS;
 
+/* I2C address the device actually answered on; resolved by ICM45686_TestDevice()
+ * (probes ICM45686_ADDRESS then ICM45686_ADDRESS_ALT). Used by Init/reads. */
+static uint8_t icm45686_addr = ICM45686_ADDRESS;
+
 /* Registers used by the simple init sequence (from vendor regmap excerpts) */
 #define ICM45686_REG_MISC2         0x7F
 #define ICM45686_REG_PWR_MGMT0     0x10
@@ -32,19 +36,23 @@ static icm45686_gyro_fs_sel_t icm45686_gyro_fs = ICM45686_GYRO_FS_SEL_250_DPS;
 
 uint8_t ICM45686_TestDevice(void)
 {
-  uint8_t val;
-  val = SW_I2C_UTIL_Read(ICM45686_ADDRESS, ICM45686_WHO_AM_I);
-  if (val == ICM45686_WHO_AM_I_ID) {
-    debug_printf("    > [ICM-45686] - WHO_AM_I=0x%02x (OK)\r\n", val);
-    return 1;
+  const uint8_t candidates[2] = { ICM45686_ADDRESS, ICM45686_ADDRESS_ALT };
+  for (uint8_t i = 0; i < 2; i++) {
+    uint8_t val = SW_I2C_UTIL_Read(candidates[i], ICM45686_WHO_AM_I);
+    if (val == ICM45686_WHO_AM_I_ID) {
+      icm45686_addr = candidates[i];
+      debug_printf("    > [ICM-45686] - WHO_AM_I=0x%02x (OK) at I2C addr=0x%02x\r\n", val, icm45686_addr);
+      return 1;
+    }
+    debug_printf("    > [ICM-45686] - probe at I2C addr=0x%02x got 0x%02x\r\n", candidates[i], val);
   }
-  debug_printf("    > [ICM-45686] - Error probing for ICM45686 at I2C addr=0x%02x, got 0x%02x\r\n", ICM45686_ADDRESS, val);
+  debug_printf("    > [ICM-45686] - Error: not found at 0x%02x or 0x%02x\r\n", ICM45686_ADDRESS, ICM45686_ADDRESS_ALT);
   return 0;
 }
 
 void ICM45686_Init(void)
 {
-  uint8_t who = SW_I2C_UTIL_Read(ICM45686_ADDRESS, ICM45686_WHO_AM_I);
+  uint8_t who = SW_I2C_UTIL_Read(icm45686_addr, ICM45686_WHO_AM_I);
   if (who != ICM45686_WHO_AM_I_ID) {
     debug_printf(" * ICM-45686 not found during init (who=0x%02x)\r\n", who);
     return;
@@ -53,14 +61,14 @@ void ICM45686_Init(void)
   debug_printf(" * ICM-45686 init: WHO_AM_I=0x%02x\r\n", who);
 
   /* Soft reset: write soft reset bit in REG_MISC2 (vendor regmap indicates soft reset at REG_MISC2 bit) */
-  SW_I2C_UTIL_WRITE(ICM45686_ADDRESS, ICM45686_REG_MISC2, 0x02);
+  SW_I2C_UTIL_WRITE(icm45686_addr, ICM45686_REG_MISC2, 0x02);
   /* Short delay for reset to complete */
   TIMER__Wait_us(2000);
 
   /* Set power management: enable accelerometer and gyro in low-noise mode per datasheet.
    * Writing 0x0F enables both accel and gyro low-noise default mode (vendor datasheet).
    */
-  SW_I2C_UTIL_WRITE(ICM45686_ADDRESS, ICM45686_REG_PWR_MGMT0, ICM45686_PWR_MGMT0_ACCEL_GYRO_LOW_NOISE);
+  SW_I2C_UTIL_WRITE(icm45686_addr, ICM45686_REG_PWR_MGMT0, ICM45686_PWR_MGMT0_ACCEL_GYRO_LOW_NOISE);
 
   /* Configure accelerometer and gyro:
    * - accel FSR: +/-2g, ODR: 100Hz
@@ -68,8 +76,8 @@ void ICM45686_Init(void)
    */
   uint8_t accel_cfg = ICM45686_ACCEL_CONFIG0_VALUE(ICM45686_ACCEL_FS_SEL_2_G, ICM45686_ACCEL_ODR_100HZ);
   uint8_t gyro_cfg  = ICM45686_GYRO_CONFIG0_VALUE(ICM45686_GYRO_FS_SEL_250_DPS, ICM45686_GYRO_ODR_100HZ);
-  SW_I2C_UTIL_WRITE(ICM45686_ADDRESS, ICM45686_REG_ACCEL_CONFIG0, accel_cfg);
-  SW_I2C_UTIL_WRITE(ICM45686_ADDRESS, ICM45686_REG_GYRO_CONFIG0, gyro_cfg);
+  SW_I2C_UTIL_WRITE(icm45686_addr, ICM45686_REG_ACCEL_CONFIG0, accel_cfg);
+  SW_I2C_UTIL_WRITE(icm45686_addr, ICM45686_REG_GYRO_CONFIG0, gyro_cfg);
 
   /* record selected FS and compute scale factors (LSB -> physical units)
    * Accelerometer: assume 16-bit output, so LSB_per_g = 16384 / (FS/2) ???
@@ -115,7 +123,7 @@ void ICM45686_ReadAccelerometerRaw(float *x, float *y, float *z)
 {
     uint8_t accel_xyz[6];
 
-    SW_I2C_UTIL_Read_Multi(ICM45686_ADDRESS, ICM45686_ACCEL_XOUT_H, 6, (uint8_t*)&accel_xyz);
+    SW_I2C_UTIL_Read_Multi(icm45686_addr, ICM45686_ACCEL_XOUT_H, 6, (uint8_t*)&accel_xyz);
 
   {
     // default is little-endian, combine bytes
@@ -131,7 +139,7 @@ void ICM45686_ReadAccelerometerRaw(float *x, float *y, float *z)
 void ICM45686_ReadGyroRaw(float *x, float *y, float *z)
 {
     uint8_t gyro_xyz[6];
-    SW_I2C_UTIL_Read_Multi(ICM45686_ADDRESS, ICM45686_GYRO_XOUT_H, 6, (uint8_t*)&gyro_xyz);
+    SW_I2C_UTIL_Read_Multi(icm45686_addr, ICM45686_GYRO_XOUT_H, 6, (uint8_t*)&gyro_xyz);
 
   {
     // default is little-endian, combine bytes

--- a/firmware/stm32/ros_usbnode/src/imu/imu.c
+++ b/firmware/stm32/ros_usbnode/src/imu/imu.c
@@ -145,20 +145,20 @@ while (imuReadAccelerometerRaw == NULL && ((HAL_GetTick() - l_u32Timestamp) < 20
     }
   #endif
 
+  #ifndef DISABLE_ICM45686
+    if ((!imuReadGyroRaw || !imuReadAccelerometerRaw) && ICM45686_TestDevice()) {
+      ICM45686_Init();
+      imuReadAccelerometerRaw=ICM45686_ReadAccelerometerRaw;
+      imuReadGyroRaw=ICM45686_ReadGyroRaw;
+    }
+  #endif
+
   HAL_Delay(20);
 }
 
 if(imuReadAccelerometerRaw == NULL){
   chirp(10);
 }
-
-#ifndef DISABLE_ICM45686
-  if ((!imuReadGyroRaw || !imuReadAccelerometerRaw) && ICM45686_TestDevice()) {
-    ICM45686_Init();
-    imuReadAccelerometerRaw=ICM45686_ReadAccelerometerRaw;
-    imuReadGyroRaw=ICM45686_ReadGyroRaw;
-  }
-#endif
 
   /* Magnetometer: try LIS3MDL (separate chip on Pololu boards) if no
    * mag was set by the accel/gyro IMU driver (e.g. WT901 has built-in mag,

--- a/sensors/gps/gps_health_aggregator.py
+++ b/sensors/gps/gps_health_aggregator.py
@@ -17,6 +17,15 @@
 #
 # Levels follow standard convention: OK = green, WARN = "still float /
 # weak signal", ERROR = no fix, no RTCM, or CRC-failing stream.
+#
+# NAV-PVT fallback: the Fix and Satellites diagnostics prefer UBX-NAV-STATUS
+# and UBX-NAV-SAT (richest: ttff, per-satellite CN0, constellation split).
+# But some genuine ZED-F9P units silently never emit those two messages even
+# when CFG-MSGOUT-*-USB is set and the VALSET is ACK'd, while NAV-PVT streams
+# fine. NAV-PVT carries fixType, carrSoln, gnssFixOk, diffSoln, numSv and
+# h/v accuracy + pDOP — enough to keep both diagnostics alive (minus the
+# per-satellite CN0 detail). So when STATUS/SAT are stale we fall back to
+# NAV-PVT instead of erroring.
 
 from __future__ import annotations
 
@@ -32,7 +41,9 @@ from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
 from rtcm_msgs.msg import Message as RtcmMessage
 
 try:
-    from ublox_ubx_msgs.msg import UBXNavStatus, UBXNavSat, UBXRxmRTCM, UBXNavCov, UBXNavDOP
+    from ublox_ubx_msgs.msg import (
+        UBXNavStatus, UBXNavSat, UBXRxmRTCM, UBXNavCov, UBXNavDOP, UBXNavPVT,
+    )
     _HAVE_UBX = True
 except ImportError:
     _HAVE_UBX = False
@@ -68,6 +79,10 @@ class GpsHealthAggregator(Node):
         self._last_sat_t: float = 0.0
         self._last_cov: UBXNavCov | None = None
         self._last_dop: UBXNavDOP | None = None
+        # NAV-PVT is the fallback source for fix + satellite-count when a
+        # receiver doesn't emit NAV-STATUS / NAV-SAT (see module header).
+        self._last_pvt: UBXNavPVT | None = None
+        self._last_pvt_t: float = 0.0
         # Each entry: (recv_time, msg_type, msg_used, crc_failed). msg_type and
         # msg_used are -1 in NMEA mode where the receiver does not echo RTCM
         # ingestion telemetry — we only know what we forwarded into it.
@@ -89,6 +104,7 @@ class GpsHealthAggregator(Node):
             self.create_subscription(UBXNavSat, "/ubx_nav_sat", self._on_sat, qos)
             self.create_subscription(UBXNavCov, "/ubx_nav_cov", self._on_cov, qos)
             self.create_subscription(UBXNavDOP, "/ubx_nav_dop", self._on_dop, qos)
+            self.create_subscription(UBXNavPVT, "/ubx_nav_pvt", self._on_pvt, qos)
             self.create_subscription(UBXRxmRTCM, "/ubx_rxm_rtcm", self._on_rtcm_ubx, qos)
         else:
             # NMEA mode (or UBX msgs unavailable): only the NTRIP/RTCM
@@ -120,6 +136,10 @@ class GpsHealthAggregator(Node):
 
     def _on_dop(self, msg: UBXNavDOP) -> None:
         self._last_dop = msg
+
+    def _on_pvt(self, msg: UBXNavPVT) -> None:
+        self._last_pvt = msg
+        self._last_pvt_t = self._now()
 
     def _on_rtcm_ubx(self, msg: UBXRxmRTCM) -> None:
         # UBX path: the receiver tells us which RTCM type it ingested and
@@ -159,16 +179,39 @@ class GpsHealthAggregator(Node):
         s.name = "GPS: fix"
         s.hardware_id = "ublox_f9p"
 
-        if self._last_status is None or now - self._last_status_t > 5.0:
+        status_fresh = (
+            self._last_status is not None and now - self._last_status_t <= 5.0
+        )
+        pvt_fresh = self._last_pvt is not None and now - self._last_pvt_t <= 5.0
+
+        # Prefer NAV-STATUS (it additionally carries ttff); fall back to
+        # NAV-PVT, which has the same fix / carrier-solution fields.
+        if status_fresh:
+            st = self._last_status
+            source = "nav-status"
+            carr = int(st.carr_soln.status)
+            fix_type = int(st.gps_fix.fix_type)
+            gps_fix_ok = bool(st.gps_fix_ok)
+            diff = bool(st.diff_corr)
+            ttff_s = st.ttff / 1000.0
+        elif pvt_fresh:
+            pvt = self._last_pvt
+            source = "nav-pvt"
+            carr = int(pvt.carr_soln.status)
+            fix_type = int(pvt.gps_fix.fix_type)
+            gps_fix_ok = bool(pvt.gnss_fix_ok)
+            diff = bool(pvt.diff_soln)
+            ttff_s = math.nan
+        else:
             s.level = DiagnosticStatus.ERROR
-            s.message = "no UBX-NAV-STATUS in 5 s — driver dead?"
+            s.message = "no UBX-NAV-STATUS or UBX-NAV-PVT in 5 s — driver dead?"
             return s
 
-        st = self._last_status
-        carr = int(st.carr_soln.status)
         carr_label = _CARR_SOLN_LABELS.get(carr, f"unknown({carr})")
-        fix_label = _FIX_TYPE_LABELS.get(int(st.gps_fix.fix_type), str(st.gps_fix.fix_type))
+        fix_label = _FIX_TYPE_LABELS.get(fix_type, str(fix_type))
 
+        # Accuracy: prefer the full covariance (NAV-COV); else use NAV-PVT's
+        # scalar h/v accuracy estimates (sigma_xy is unavailable from PVT).
         sigma_xy_mm = -1.0
         horizontal_accuracy_m = math.nan
         vertical_accuracy_m = math.nan
@@ -179,22 +222,29 @@ class GpsHealthAggregator(Node):
             sigma_xy_mm = math.sqrt(max(0.0, cxx + cyy)) * 1000.0
             horizontal_accuracy_m = math.sqrt(max(0.0, (cxx + cyy) / 2.0))
             vertical_accuracy_m = math.sqrt(max(0.0, czz))
+        elif pvt_fresh:
+            horizontal_accuracy_m = self._last_pvt.h_acc / 1000.0
+            vertical_accuracy_m = self._last_pvt.v_acc / 1000.0
 
+        # DOP: prefer NAV-DOP (separate h/v); else NAV-PVT's single pDOP.
         hdop = math.nan
         vdop = math.nan
         if self._last_dop is not None:
             hdop = float(self._last_dop.h_dop) * 0.01
             vdop = float(self._last_dop.v_dop) * 0.01
+        pdop = float(self._last_pvt.p_dop) * 0.01 if pvt_fresh else math.nan
 
         s.values = [
+            KeyValue(key="source", value=source),
             KeyValue(key="carr_soln", value=carr_label),
             KeyValue(key="fix_type", value=fix_label),
-            KeyValue(key="gps_fix_ok", value=str(bool(st.gps_fix_ok))),
-            KeyValue(key="diff_corr", value=str(bool(st.diff_corr))),
-            KeyValue(key="ttff_s", value=f"{st.ttff / 1000.0:.1f}"),
+            KeyValue(key="gps_fix_ok", value=str(gps_fix_ok)),
+            KeyValue(key="diff_corr", value=str(diff)),
+            KeyValue(key="ttff_s", value=f"{ttff_s:.1f}" if math.isfinite(ttff_s) else "n/a"),
             KeyValue(key="sigma_xy_mm", value=f"{sigma_xy_mm:.1f}" if sigma_xy_mm >= 0 else "n/a"),
             KeyValue(key="hdop", value=f"{hdop:.2f}" if math.isfinite(hdop) else "n/a"),
             KeyValue(key="vdop", value=f"{vdop:.2f}" if math.isfinite(vdop) else "n/a"),
+            KeyValue(key="pdop", value=f"{pdop:.2f}" if math.isfinite(pdop) else "n/a"),
             KeyValue(
                 key="horizontal_accuracy_m",
                 value=f"{horizontal_accuracy_m:.3f}" if math.isfinite(horizontal_accuracy_m) else "n/a",
@@ -205,7 +255,7 @@ class GpsHealthAggregator(Node):
             ),
         ]
 
-        if not st.gps_fix_ok:
+        if not gps_fix_ok:
             s.level = DiagnosticStatus.ERROR
             s.message = f"no fix ({fix_label})"
         elif carr == 2:
@@ -225,9 +275,8 @@ class GpsHealthAggregator(Node):
         s.hardware_id = "ublox_f9p"
 
         if self._last_sat is None or now - self._last_sat_t > 5.0:
-            s.level = DiagnosticStatus.ERROR
-            s.message = "no UBX-NAV-SAT in 5 s"
-            return s
+            # No per-satellite NAV-SAT — fall back to NAV-PVT's used count.
+            return self._sat_status_from_pvt(now, s)
 
         sv_info = self._last_sat.sv_info
         visible = len(sv_info)
@@ -249,6 +298,7 @@ class GpsHealthAggregator(Node):
         )
 
         s.values = [
+            KeyValue(key="source", value="nav-sat"),
             KeyValue(key="visible", value=str(visible)),
             KeyValue(key="used", value=str(used_n)),
             KeyValue(key="mean_cno_db_hz", value=f"{mean_cno:.1f}"),
@@ -276,6 +326,34 @@ class GpsHealthAggregator(Node):
                 f"{used_n} sats used, mean CN0 {mean_cno:.0f} dB-Hz, "
                 f"{cno_ge_40} ≥40"
             )
+        return s
+
+    def _sat_status_from_pvt(self, now: float, s: DiagnosticStatus) -> DiagnosticStatus:
+        """Fallback when NAV-SAT isn't emitted: NAV-PVT gives only the count
+        of satellites used in the solution — no per-satellite CN0 / sky view."""
+        if self._last_pvt is None or now - self._last_pvt_t > 5.0:
+            s.level = DiagnosticStatus.ERROR
+            s.message = "no UBX-NAV-SAT or UBX-NAV-PVT in 5 s"
+            return s
+
+        used_n = int(self._last_pvt.num_sv)
+        s.values = [
+            KeyValue(key="source", value="nav-pvt"),
+            KeyValue(key="used", value=str(used_n)),
+            KeyValue(key="note", value="CN0 / sky-view unavailable (NAV-SAT not emitted)"),
+        ]
+
+        # Same used-count thresholds as the NAV-SAT path; CN0-based WARNs
+        # can't be evaluated without per-satellite data.
+        if used_n < 4:
+            s.level = DiagnosticStatus.ERROR
+            s.message = f"only {used_n} sats used"
+        elif used_n < 6:
+            s.level = DiagnosticStatus.WARN
+            s.message = f"{used_n} sats used — marginal"
+        else:
+            s.level = DiagnosticStatus.OK
+            s.message = f"{used_n} sats used"
         return s
 
     def _rtcm_status(self, now: float) -> DiagnosticStatus:

--- a/sensors/gps/ublox_dgnss.yaml
+++ b/sensors/gps/ublox_dgnss.yaml
@@ -152,7 +152,11 @@ ublox_dgnss:
     CFG_MSGOUT_UBX_NAV_HPPOSLLH_USB: 1   # high-precision LLH — needed by HP NavSatFix node
     CFG_MSGOUT_UBX_NAV_STATUS_USB: 1     # fix type + carrSoln/diffSoln diagnostics
     CFG_MSGOUT_UBX_NAV_COV_USB: 1        # covariance → NavSatFix.position_covariance
-    CFG_MSGOUT_UBX_NAV_PVT_USB: 0        # nothing consumes /ubx_nav_pvt in mowglinext
+    CFG_MSGOUT_UBX_NAV_PVT_USB: 1        # fix + numSv fallback for gps_health_aggregator
+                                         # (some genuine F9P units silently never emit
+                                         #  NAV-STATUS/NAV-SAT even when enabled+ACK'd;
+                                         #  NAV-PVT carries fixType/carrSoln/numSv so the
+                                         #  health diags still work — see aggregator)
     CFG_MSGOUT_UBX_NAV_VELNED_USB: 1     # → cog_to_imu_node /imu/cog_heading (CRITICAL)
     CFG_MSGOUT_UBX_NAV_RELPOSNED_USB: 0  # 0 unless moving-base / dual-antenna
     CFG_MSGOUT_UBX_RXM_RTCM_USB: 1       # correction ingestion counter — NTRIP debug


### PR DESCRIPTION
## Problem

On some genuine ZED-F9P units, `gps_health_aggregator` reports permanent errors on the Diagnostics page —

```
GPS: fix         → no UBX-NAV-STATUS in 5 s — driver dead?
GPS: satellites  → no UBX-NAV-SAT in 5 s
```

— **despite a healthy RTK-Fixed solution** and `/gps/fix` streaming normally.

Root cause (diagnosed on a real HPG 1.32 / PROTVER 27.31 ZED-F9P): the receiver **silently never emits UBX-NAV-SAT, and only sporadically emits UBX-NAV-STATUS**, even though `CFG-MSGOUT-UBX_NAV_STATUS_USB=1` / `CFG-MSGOUT-UBX_NAV_SAT_USB=14` are set and the `CFG-VALSET` is **ACK'd** (not NAK'd). On the wire (verified with `ubxtool` at the correct protver, and independently via the ROS driver never publishing `/ubx_nav_status`/`/ubx_nav_sat`), only NAV-PVT / NAV-HPPOSLLH / NAV-VELNED come out. A fresh `NAV-PVT` enable emits instantly, so the receiver honors MSGOUT in general — it just won't produce those two messages. A config factory-reset did not restore NAV-SAT.

So the aggregator's hard dependency on NAV-STATUS + NAV-SAT is fragile across F9P firmware/units.

## Fix

`UBX-NAV-PVT` carries everything the two failing diagnostics need: `fixType`, `carrSoln`, `gnssFixOk`, `diffSoln`, `numSv`, plus `hAcc`/`vAcc` and `pDOP`. It streams reliably on the affected receiver.

- **GPS: fix** — prefer `NAV-STATUS` (adds `ttff`); fall back to `NAV-PVT` (same fix/carrier-solution fields; accuracy from `hAcc/vAcc`, `pDOP` in place of separate h/v DOP).
- **GPS: satellites** — prefer `NAV-SAT` (per-satellite CN0, sky-view, constellation split); fall back to `NAV-PVT`'s `numSv` used-count (CN0/sky-view simply reported unavailable).
- Each status now carries a `source` KeyValue (`nav-status`/`nav-sat`/`nav-pvt`) so it's clear which message drove it.
- `ublox_dgnss.yaml`: enable `CFG_MSGOUT_UBX_NAV_PVT_USB` (was `0`).

Receivers that *do* emit NAV-STATUS/NAV-SAT are unaffected — they keep the richer path; NAV-PVT is purely a fallback.

## Verification

Tested live on the affected F9P (modified script + yaml mounted into the running `mowgli-gps`, driver restarted). With `/ubx_nav_sat` confirmed empty and `/ubx_nav_pvt` at 7 Hz, `/diagnostics` now reports:

| Status | Level | Message | source |
|---|---|---|---|
| GPS: fix | OK | RTK Fixed | nav-status* |
| GPS: satellites | OK | 27 sats used | **nav-pvt** |
| GPS: NTRIP/RTCM | OK | 9.6 msg/s, 73% used | — |

\* fix happened to have a sporadic NAV-STATUS in-window; with NAV-STATUS fully absent it falls back to nav-pvt and stays OK. Both previously-erroring diagnostics are now green.