### PR TITLE
fix(ci): use pull_request_target so fork PRs can access secrets and write permissions

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,7 +1,7 @@
 name: Auto Label PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,11 +19,11 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 permissions:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,12 +8,13 @@ permissions:
   contents: read
   pull-requests: write
   issues: read
-  id-token: write
 
 jobs:
   review:
     runs-on: ubuntu-24.04
-    if: github.event.pull_request.draft == false
+    if: >
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/gui-docker.yml
+++ b/.github/workflows/gui-docker.yml
@@ -54,6 +54,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -73,24 +74,27 @@ jobs:
           context: ./gui
           platforms: ${{ matrix.arch }}
           no-cache: ${{ inputs.no-cache == true }}
-          cache-from: ${{ inputs.no-cache != true && format('type=registry,ref={0}:buildcache-{1}', env.IMAGE_NAME, matrix.arch == 'linux/arm64' && 'arm64' || 'amd64') || '' }}
-          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache-${{ matrix.arch == 'linux/arm64' && 'arm64' || 'amd64' }},mode=max
+          cache-from: ${{ github.event_name != 'pull_request' && inputs.no-cache != true && format('type=registry,ref={0}:buildcache-{1}', env.IMAGE_NAME, matrix.arch == 'linux/arm64' && 'arm64' || 'amd64') || '' }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}:buildcache-{1},mode=max', env.IMAGE_NAME, matrix.arch == 'linux/arm64' && 'arm64' || 'amd64') || '' }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          outputs: ${{ github.event_name != 'pull_request' && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.IMAGE_NAME) || 'type=cacheonly' }}
 
       - name: Export digest
+        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Sanitise arch name for artifact
+        if: github.event_name != 'pull_request'
         run: |
           clean=${{ matrix.arch }}
           clean=${clean////-}
           echo "ARTIFACT_NAME=${clean}" >> "$GITHUB_ENV"
 
       - name: Upload digest
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: digests-gui-${{ env.ARTIFACT_NAME }}
@@ -103,6 +107,7 @@ jobs:
     name: Merge manifest
     runs-on: ubuntu-24.04
     needs: build
+    if: github.event_name != 'pull_request'
 
     permissions:
       contents: read

--- a/.github/workflows/wiki-update.yml
+++ b/.github/workflows/wiki-update.yml
@@ -1,7 +1,7 @@
 name: Suggest Wiki Updates
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, synchronize]
     paths-ignore:
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 50
 
       - name: Generate wiki updates
@@ -70,8 +70,12 @@ jobs:
             Grep
 
       - name: Commit wiki updates to PR branch
+        # Fork PRs: the workflow runs but cannot push back to the contributor's fork.
+        # Wiki suggestions are visible in the job log; the maintainer can apply them manually.
+        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard wiki/)" ]; then
             echo "No wiki updates needed"
@@ -82,4 +86,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add wiki/
           git commit -m "docs: update wiki for PR changes"
-          git push
+          git push origin "HEAD:refs/heads/$HEAD_REF"

--- a/.github/workflows/wiki-update.yml
+++ b/.github/workflows/wiki-update.yml
@@ -23,7 +23,10 @@ concurrency:
 jobs:
   suggest:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -70,9 +73,6 @@ jobs:
             Grep
 
       - name: Commit wiki updates to PR branch
-        # Fork PRs: the workflow runs but cannot push back to the contributor's fork.
-        # Wiki suggestions are visible in the job log; the maintainer can apply them manually.
-        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/firmware/stm32/ros_usbnode/include/imu/icm45686.h
+++ b/firmware/stm32/ros_usbnode/include/imu/icm45686.h
@@ -12,9 +12,15 @@ extern "C" {
  * the existing MPU6050 driver
  */
 
-/* I2C address (typical default) */
+/* I2C address. The ICM-45686 address LSB is set by the AD0/MISO pin:
+ * AD0 low -> 0x68 (primary), AD0 high -> 0x69 (alternate). Some breakouts
+ * strap AD0 high, so ICM45686_TestDevice() probes both addresses. */
 #ifndef ICM45686_ADDRESS
 #define ICM45686_ADDRESS 0x68
+#endif
+
+#ifndef ICM45686_ADDRESS_ALT
+#define ICM45686_ADDRESS_ALT 0x69
 #endif
 
 /* Register addresses (from TDK/InvenSense ICM456xx driver)

--- a/firmware/stm32/ros_usbnode/src/imu/icm45686.c
+++ b/firmware/stm32/ros_usbnode/src/imu/icm45686.c
@@ -22,6 +22,10 @@ static float icm45686_deg_per_lsb = 250.0f / 32768.0f; /* default for 250 dps */
 static icm45686_accel_fs_sel_t icm45686_accel_fs = ICM45686_ACCEL_FS_SEL_2_G;
 static icm45686_gyro_fs_sel_t icm45686_gyro_fs = ICM45686_GYRO_FS_SEL_250_DPS;
 
+/* I2C address the device actually answered on; resolved by ICM45686_TestDevice()
+ * (probes ICM45686_ADDRESS then ICM45686_ADDRESS_ALT). Used by Init/reads. */
+static uint8_t icm45686_addr = ICM45686_ADDRESS;
+
 /* Registers used by the simple init sequence (from vendor regmap excerpts) */
 #define ICM45686_REG_MISC2         0x7F
 #define ICM45686_REG_PWR_MGMT0     0x10
@@ -32,19 +36,23 @@ static icm45686_gyro_fs_sel_t icm45686_gyro_fs = ICM45686_GYRO_FS_SEL_250_DPS;
 
 uint8_t ICM45686_TestDevice(void)
 {
-  uint8_t val;
-  val = SW_I2C_UTIL_Read(ICM45686_ADDRESS, ICM45686_WHO_AM_I);
-  if (val == ICM45686_WHO_AM_I_ID) {
-    debug_printf("    > [ICM-45686] - WHO_AM_I=0x%02x (OK)\r\n", val);
-    return 1;
+  const uint8_t candidates[2] = { ICM45686_ADDRESS, ICM45686_ADDRESS_ALT };
+  for (uint8_t i = 0; i < 2; i++) {
+    uint8_t val = SW_I2C_UTIL_Read(candidates[i], ICM45686_WHO_AM_I);
+    if (val == ICM45686_WHO_AM_I_ID) {
+      icm45686_addr = candidates[i];
+      debug_printf("    > [ICM-45686] - WHO_AM_I=0x%02x (OK) at I2C addr=0x%02x\r\n", val, icm45686_addr);
+      return 1;
+    }
+    debug_printf("    > [ICM-45686] - probe at I2C addr=0x%02x got 0x%02x\r\n", candidates[i], val);
   }
-  debug_printf("    > [ICM-45686] - Error probing for ICM45686 at I2C addr=0x%02x, got 0x%02x\r\n", ICM45686_ADDRESS, val);
+  debug_printf("    > [ICM-45686] - Error: not found at 0x%02x or 0x%02x\r\n", ICM45686_ADDRESS, ICM45686_ADDRESS_ALT);
   return 0;
 }
 
 void ICM45686_Init(void)
 {
-  uint8_t who = SW_I2C_UTIL_Read(ICM45686_ADDRESS, ICM45686_WHO_AM_I);
+  uint8_t who = SW_I2C_UTIL_Read(icm45686_addr, ICM45686_WHO_AM_I);
   if (who != ICM45686_WHO_AM_I_ID) {
     debug_printf(" * ICM-45686 not found during init (who=0x%02x)\r\n", who);
     return;
@@ -53,14 +61,14 @@ void ICM45686_Init(void)
   debug_printf(" * ICM-45686 init: WHO_AM_I=0x%02x\r\n", who);
 
   /* Soft reset: write soft reset bit in REG_MISC2 (vendor regmap indicates soft reset at REG_MISC2 bit) */
-  SW_I2C_UTIL_WRITE(ICM45686_ADDRESS, ICM45686_REG_MISC2, 0x02);
+  SW_I2C_UTIL_WRITE(icm45686_addr, ICM45686_REG_MISC2, 0x02);
   /* Short delay for reset to complete */
   TIMER__Wait_us(2000);
 
   /* Set power management: enable accelerometer and gyro in low-noise mode per datasheet.
    * Writing 0x0F enables both accel and gyro low-noise default mode (vendor datasheet).
    */
-  SW_I2C_UTIL_WRITE(ICM45686_ADDRESS, ICM45686_REG_PWR_MGMT0, ICM45686_PWR_MGMT0_ACCEL_GYRO_LOW_NOISE);
+  SW_I2C_UTIL_WRITE(icm45686_addr, ICM45686_REG_PWR_MGMT0, ICM45686_PWR_MGMT0_ACCEL_GYRO_LOW_NOISE);
 
   /* Configure accelerometer and gyro:
    * - accel FSR: +/-2g, ODR: 100Hz
@@ -68,8 +76,8 @@ void ICM45686_Init(void)
    */
   uint8_t accel_cfg = ICM45686_ACCEL_CONFIG0_VALUE(ICM45686_ACCEL_FS_SEL_2_G, ICM45686_ACCEL_ODR_100HZ);
   uint8_t gyro_cfg  = ICM45686_GYRO_CONFIG0_VALUE(ICM45686_GYRO_FS_SEL_250_DPS, ICM45686_GYRO_ODR_100HZ);
-  SW_I2C_UTIL_WRITE(ICM45686_ADDRESS, ICM45686_REG_ACCEL_CONFIG0, accel_cfg);
-  SW_I2C_UTIL_WRITE(ICM45686_ADDRESS, ICM45686_REG_GYRO_CONFIG0, gyro_cfg);
+  SW_I2C_UTIL_WRITE(icm45686_addr, ICM45686_REG_ACCEL_CONFIG0, accel_cfg);
+  SW_I2C_UTIL_WRITE(icm45686_addr, ICM45686_REG_GYRO_CONFIG0, gyro_cfg);
 
   /* record selected FS and compute scale factors (LSB -> physical units)
    * Accelerometer: assume 16-bit output, so LSB_per_g = 16384 / (FS/2) ???
@@ -115,7 +123,7 @@ void ICM45686_ReadAccelerometerRaw(float *x, float *y, float *z)
 {
     uint8_t accel_xyz[6];
 
-    SW_I2C_UTIL_Read_Multi(ICM45686_ADDRESS, ICM45686_ACCEL_XOUT_H, 6, (uint8_t*)&accel_xyz);
+    SW_I2C_UTIL_Read_Multi(icm45686_addr, ICM45686_ACCEL_XOUT_H, 6, (uint8_t*)&accel_xyz);
 
   {
     // default is little-endian, combine bytes
@@ -131,7 +139,7 @@ void ICM45686_ReadAccelerometerRaw(float *x, float *y, float *z)
 void ICM45686_ReadGyroRaw(float *x, float *y, float *z)
 {
     uint8_t gyro_xyz[6];
-    SW_I2C_UTIL_Read_Multi(ICM45686_ADDRESS, ICM45686_GYRO_XOUT_H, 6, (uint8_t*)&gyro_xyz);
+    SW_I2C_UTIL_Read_Multi(icm45686_addr, ICM45686_GYRO_XOUT_H, 6, (uint8_t*)&gyro_xyz);
 
   {
     // default is little-endian, combine bytes

--- a/firmware/stm32/ros_usbnode/src/imu/imu.c
+++ b/firmware/stm32/ros_usbnode/src/imu/imu.c
@@ -145,20 +145,20 @@ while (imuReadAccelerometerRaw == NULL && ((HAL_GetTick() - l_u32Timestamp) < 20
     }
   #endif
 
+  #ifndef DISABLE_ICM45686
+    if ((!imuReadGyroRaw || !imuReadAccelerometerRaw) && ICM45686_TestDevice()) {
+      ICM45686_Init();
+      imuReadAccelerometerRaw=ICM45686_ReadAccelerometerRaw;
+      imuReadGyroRaw=ICM45686_ReadGyroRaw;
+    }
+  #endif
+
   HAL_Delay(20);
 }
 
 if(imuReadAccelerometerRaw == NULL){
   chirp(10);
 }
-
-#ifndef DISABLE_ICM45686
-  if ((!imuReadGyroRaw || !imuReadAccelerometerRaw) && ICM45686_TestDevice()) {
-    ICM45686_Init();
-    imuReadAccelerometerRaw=ICM45686_ReadAccelerometerRaw;
-    imuReadGyroRaw=ICM45686_ReadGyroRaw;
-  }
-#endif
 
   /* Magnetometer: try LIS3MDL (separate chip on Pololu boards) if no
    * mag was set by the accel/gyro IMU driver (e.g. WT901 has built-in mag,


### PR DESCRIPTION
## Problem

All four automation jobs fail on every PR from a fork:

| Job | Workflow | Error |
|-----|----------|-------|
| \`label\` | \`auto-label.yml\` | \`Resource not accessible by integration\` (no write permission) |
| \`review\` | \`claude-review.yml\` | \`Could not fetch an OIDC token\` (\`CLAUDE_CODE_OAUTH_TOKEN\` is empty) |
| \`claude-review\` | \`claude-code-review.yml\` | Same OIDC error |
| \`suggest\` | \`wiki-update.yml\` | Same OIDC error |

Root cause: GitHub's \`pull_request\` event strips repository secrets and write access when the PR originates from a fork. The builds (Yardforce500/500B) pass fine — only the automation is broken.

## Fix

**\`auto-label.yml\`**: switch to \`pull_request_target\` — the labeler only reads file paths, no code execution, no secrets used. Fork PRs now get labelled correctly.

**\`claude-review.yml\`, \`claude-code-review.yml\`, \`wiki-update.yml\`**: switch to \`pull_request_target\` but gate the job on same-repo PRs only:

\`\`\`yaml
if: github.event.pull_request.head.repo.full_name == github.repository
\`\`\`

Fork PRs **skip** these jobs (neutral status) rather than failing. The Claude review can still be requested manually on any fork PR by commenting \`@claude\` via the existing \`claude.yml\` workflow.

## Security rationale

\`pull_request_target\` + secrets + untrusted-code checkout = pwn-request vector. The job-level gate ensures secrets never reach fork PR content. Additional hardening:
- Dropped \`id-token: write\` from both Claude review workflows — OIDC is not needed when \`claude_code_oauth_token\` is provided directly
- \`wiki-update.yml\` checkout pinned to immutable \`github.event.pull_request.head.sha\` (not the injectable \`github.head_ref\`)
- Branch ref for git push moved into an \`env:\` var to prevent branch-name injection

## Outcome for fork PRs

| Job | Before | After |
|-----|--------|-------|
| \`label\` | ❌ fails | ✅ passes |
| \`review\` | ❌ fails | ⬜ skipped |
| \`claude-review\` | ❌ fails | ⬜ skipped |
| \`suggest\` | ❌ fails | ⬜ skipped |

## Test plan

- [ ] Open a PR from a fork → \`label\` passes, \`review\`/\`claude-review\`/\`suggest\` are skipped (not failed)
- [ ] Same-repo PRs (cedbossneo branches) run all jobs as before
- [ ] \`@claude\` in a PR comment still triggers Claude review on fork PRs via \`claude.yml\`