### PR TITLE
feat: firmware PX4 wheel-PI + localization/launch/docking fixes (host-wheel-pi → dev)

### DIFF
--- a/.github/workflows/firmware-ci.yml
+++ b/.github/workflows/firmware-ci.yml
@@ -2,9 +2,13 @@ name: Firmware CI
 
 on:
   push:
-    branches: [main]
+    # Build-check feature branches too (the GUI flashes firmware FROM the branch
+    # source via `platformio run`, so a branch must compile before it can be
+    # flashed). Mirrors ros2-ci.yml's branch set.
+    branches: [main, dev, 'feat/**', 'fix/**', 'refactor/**', 'chore/**', 'perf/**']
     paths:
       - 'firmware/**'
+      - '.github/workflows/firmware-ci.yml'
   pull_request:
     paths:
       - 'firmware/**'

--- a/firmware/stm32/ros_usbnode/include/pid.hpp
+++ b/firmware/stm32/ros_usbnode/include/pid.hpp
@@ -1,0 +1,133 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022-2024 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/*
+ * Vendored from PX4-Autopilot src/lib/pid/PID.{hpp,cpp} (BSD-3-Clause).
+ * Modifications for this firmware:
+ *   - Made header-only (method bodies inlined here).
+ *   - Replaced PX4 math::constrain() with a local pid_constrain() so the
+ *     file has no PX4 mathlib dependency (only <cmath>/<cfloat>).
+ * Behaviour is otherwise identical to upstream.
+ *
+ * Battle-tested velocity/position PID with:
+ *   - derivative on measurement (no derivative kick),
+ *   - conditional-integration anti-windup via the update_integral argument
+ *     (pass false when the actuator output is saturated),
+ *   - integral and output magnitude limits,
+ *   - NaN/inf guards on the integral and derivative.
+ */
+
+#ifndef MOWGLI_PID_HPP_
+#define MOWGLI_PID_HPP_
+
+#include <cfloat>
+#include <cmath>
+
+static inline float pid_constrain(float v, float lo, float hi)
+{
+    if (v < lo) {
+        return lo;
+    }
+    if (v > hi) {
+        return hi;
+    }
+    return v;
+}
+
+class PID
+{
+public:
+    PID() = default;
+
+    void setOutputLimit(const float limit) { _limit_output = limit; }
+    void setIntegralLimit(const float limit) { _limit_integral = limit; }
+    void setGains(const float P, const float I, const float D)
+    {
+        _gain_proportional = P;
+        _gain_integral = I;
+        _gain_derivative = D;
+    }
+    void setSetpoint(const float setpoint) { _setpoint = setpoint; }
+
+    float update(const float feedback, const float dt, const bool update_integral = true)
+    {
+        const float error = _setpoint - feedback;
+        const float output =
+            (_gain_proportional * error) + _integral - (_gain_derivative * updateDerivative(feedback, dt));
+
+        if (update_integral) {
+            updateIntegral(error, dt);
+        }
+
+        _last_feedback = feedback;
+        return pid_constrain(output, -_limit_output, _limit_output);
+    }
+
+    float getIntegral() { return _integral; }
+    void resetIntegral() { _integral = 0.f; }
+    void resetDerivative() { _last_feedback = NAN; }
+
+private:
+    void updateIntegral(float error, const float dt)
+    {
+        const float integral_new = _integral + _gain_integral * error * dt;
+
+        if (std::isfinite(integral_new)) {
+            _integral = pid_constrain(integral_new, -_limit_integral, _limit_integral);
+        }
+    }
+
+    float updateDerivative(float feedback, const float dt)
+    {
+        float feedback_change = 0.f;
+
+        if ((dt > FLT_EPSILON) && std::isfinite(_last_feedback)) {
+            feedback_change = (feedback - _last_feedback) / dt;
+        }
+
+        return feedback_change;
+    }
+
+    float _setpoint{0.f};   ///< current setpoint to track
+    float _integral{0.f};   ///< integral state
+    float _last_feedback{NAN};
+
+    // Gains, Limits
+    float _gain_proportional{0.f};
+    float _gain_integral{0.f};
+    float _gain_derivative{0.f};
+    float _limit_integral{0.f};
+    float _limit_output{0.f};
+};
+
+#endif  // MOWGLI_PID_HPP_

--- a/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
+++ b/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
@@ -28,6 +28,7 @@
 #include "emergency.h"
 #include "drivemotor.h"
 #include "blademotor.h"
+#include "pid.hpp"
 #include "ultrasonic_sensor.h"
 #include "stm32f_board_hal.h"
 #include "nbt.h"
@@ -113,8 +114,12 @@ static int16_t right_pwm_signed = 0;
 #define WHEEL_PI_DT_S            (MOTORS_NBT_TIME_MS / 1000.0f)
 #define WHEEL_PI_TICKS_PER_M    300.0f    /* must match mowgli_robot.yaml: ticks_per_meter */
 
-static float left_pi_int_pwm  = 0.0f;
-static float right_pi_int_pwm = 0.0f;
+/* Per-wheel velocity PI — battle-tested PX4 PID core (pid.hpp). Gains/limits
+ * set once in init_ROS(). The integrator (kept inside the PID object) is what
+ * bridges the static-friction deadband; output is the closed-loop PWM trim
+ * added to the open-loop feedforward below. */
+static PID left_wheel_pid;
+static PID right_wheel_pid;
 static int32_t prev_left_ticks_signed_pi  = 0;
 static int32_t prev_right_ticks_signed_pi = 0;
 static float prev_left_target_mps  = 0.0f;
@@ -427,13 +432,9 @@ extern "C" void motors_handler()
         const float r_actual_mps =
             ((float)dright_ticks) / WHEEL_PI_TICKS_PER_M / WHEEL_PI_DT_S;
 
-        const float l_err = l_target - l_actual_mps;
-        const float r_err = r_target - r_actual_mps;
-
-        /* Reset the integral on direction reversal or stop-to-go
-         * transitions. Without this the integral built up while
-         * decelerating would drive the motor backwards as soon as
-         * the chassis stopped, causing micro-oscillations. */
+        /* Reset the integrator on direction reversal / stop-to-go / hard-stop.
+         * Without this the integral built up while decelerating would drive the
+         * motor backwards as soon as the chassis stopped (micro-oscillation). */
         const bool l_target_sign_changed =
             (l_target * prev_left_target_mps  < 0.0f) ||
             (l_target == 0.0f && prev_left_target_mps  != 0.0f) ||
@@ -442,27 +443,47 @@ extern "C" void motors_handler()
             (r_target * prev_right_target_mps < 0.0f) ||
             (r_target == 0.0f && prev_right_target_mps != 0.0f) ||
             hard_stop;
-        if (l_target_sign_changed) left_pi_int_pwm  = 0.0f;
-        if (r_target_sign_changed) right_pi_int_pwm = 0.0f;
+        if (l_target_sign_changed) {
+            left_wheel_pid.resetIntegral();
+            left_wheel_pid.resetDerivative();
+        }
+        if (r_target_sign_changed) {
+            right_wheel_pid.resetIntegral();
+            right_wheel_pid.resetDerivative();
+        }
         prev_left_target_mps  = l_target;
         prev_right_target_mps = r_target;
 
-        /* Integrate error with anti-windup clamp on the PWM-equivalent
-         * accumulator. */
-        left_pi_int_pwm  += WHEEL_PI_KI_PWM_PER_MPS_S * l_err * WHEEL_PI_DT_S;
-        right_pi_int_pwm += WHEEL_PI_KI_PWM_PER_MPS_S * r_err * WHEEL_PI_DT_S;
-        if (left_pi_int_pwm  >  WHEEL_PI_INT_MAX_PWM) left_pi_int_pwm  =  WHEEL_PI_INT_MAX_PWM;
-        if (left_pi_int_pwm  < -WHEEL_PI_INT_MAX_PWM) left_pi_int_pwm  = -WHEEL_PI_INT_MAX_PWM;
-        if (right_pi_int_pwm >  WHEEL_PI_INT_MAX_PWM) right_pi_int_pwm =  WHEEL_PI_INT_MAX_PWM;
-        if (right_pi_int_pwm < -WHEEL_PI_INT_MAX_PWM) right_pi_int_pwm = -WHEEL_PI_INT_MAX_PWM;
+        /* Conditional-integration anti-windup, DIRECTION-AWARE: freeze the
+         * integrator only in the direction that would worsen an already-
+         * saturated output; always allow it to unwind OUT of saturation. Keying
+         * on the error sign (not just the saturation bit) avoids a one-
+         * directional integral latch — e.g. on overspeed (err < 0) while the
+         * output is railed high, the integrator must still be able to wind down
+         * to cut PWM. *_pwm_signed is the previous cycle's total (feedforward +
+         * trim), saturated by DRIVEMOTOR_SetSpeedSigned at ±255. This sits on
+         * top of the PID's own ±100 integral-magnitude clamp. */
+        const float l_err = l_target - l_actual_mps;
+        const float r_err = r_target - r_actual_mps;
+        const bool l_update_integral =
+            !((left_pwm_signed >= 255 && l_err > 0.0f) || (left_pwm_signed <= -255 && l_err < 0.0f));
+        const bool r_update_integral =
+            !((right_pwm_signed >= 255 && r_err > 0.0f) || (right_pwm_signed <= -255 && r_err < 0.0f));
 
-        /* Feedforward + proportional + integrator. Sign carried through. */
-        const float l_pwm_f = l_target * PWM_PER_MPS
-                            + WHEEL_PI_KP_PWM_PER_MPS * l_err
-                            + left_pi_int_pwm;
-        const float r_pwm_f = r_target * PWM_PER_MPS
-                            + WHEEL_PI_KP_PWM_PER_MPS * r_err
-                            + right_pi_int_pwm;
+        /* Closed-loop PI trim (Kp·err + integrator; D gain = 0). The PID
+         * computes error = setpoint − feedback internally and integrates AFTER
+         * forming the output (PX4 form), so a fresh integral increment reaches
+         * the actuator one 50 Hz cycle later than the old integrate-before form
+         * — steady-state identical, ~20 ms transient shift (immaterial here). */
+        left_wheel_pid.setSetpoint(l_target);
+        right_wheel_pid.setSetpoint(r_target);
+        const float l_trim = left_wheel_pid.update(l_actual_mps, WHEEL_PI_DT_S, l_update_integral);
+        const float r_trim = right_wheel_pid.update(r_actual_mps, WHEEL_PI_DT_S, r_update_integral);
+
+        /* Open-loop feedforward (deadband-bridge, preserves the above-deadband
+         * mapping) + closed-loop PI trim. Sign carried through. */
+        const float l_pwm_f = l_target * PWM_PER_MPS + l_trim;
+        const float r_pwm_f = r_target * PWM_PER_MPS + r_trim;
 
         /* When the target is exactly zero AND we're not braking from a
          * larger speed, force PWM to zero outright — avoids the residual
@@ -741,6 +762,20 @@ extern "C" void init_ROS()
     NBT_init(&imu_nbt,     IMU_NBT_TIME_MS);
     NBT_init(&motors_nbt,  MOTORS_NBT_TIME_MS);
     NBT_init(&blade_nbt,   BLADE_NBT_TIME_MS);
+
+#if USE_WHEEL_PI
+    // Per-wheel velocity PI gains/limits (vendored PX4 PID, pid.hpp). D=0 — no
+    // derivative on a velocity loop. Gains/limits are in PWM units, matching the
+    // hand-rolled loop they replace (Kp·err + integrator, integral clamp ±100,
+    // output clamp ±255). The PID adds derivative-on-measurement (unused at D=0)
+    // and conditional-integration anti-windup.
+    left_wheel_pid.setGains(WHEEL_PI_KP_PWM_PER_MPS, WHEEL_PI_KI_PWM_PER_MPS_S, 0.0f);
+    left_wheel_pid.setIntegralLimit(WHEEL_PI_INT_MAX_PWM);
+    left_wheel_pid.setOutputLimit(255.0f);
+    right_wheel_pid.setGains(WHEEL_PI_KP_PWM_PER_MPS, WHEEL_PI_KI_PWM_PER_MPS_S, 0.0f);
+    right_wheel_pid.setIntegralLimit(WHEEL_PI_INT_MAX_PWM);
+    right_wheel_pid.setOutputLimit(255.0f);
+#endif
 
     last_odom_tick      = HAL_GetTick();
     last_heartbeat_tick = 0;

--- a/gui/web/src/components/FlashBoardComponent.tsx
+++ b/gui/web/src/components/FlashBoardComponent.tsx
@@ -128,6 +128,13 @@ export const FlashBoardComponent = (props: { onNext: () => void }) => {
             await fetchEventSource(`/api/setup/flashBoard`, {
                 method: "POST",
                 keepalive: false,
+                // Keep the stream open when the tab is backgrounded / loses
+                // focus. Without this, fetch-event-source closes the connection
+                // on `visibilitychange` (hidden) and RE-OPENS it on return —
+                // and "re-open" re-sends this POST, which makes the backend
+                // start a whole new flash (git clone + platformio build) from
+                // scratch instead of continuing the one in progress.
+                openWhenHidden: true,
                 body: JSON.stringify(values),
                 headers: {
                     Accept: "text/event-stream",
@@ -159,6 +166,11 @@ export const FlashBoardComponent = (props: { onNext: () => void }) => {
                 onerror(err) {
                     setIsFlashing(false);
                     setFlashError(err.toString());
+                    // Re-throw to stop fetch-event-source's automatic retry.
+                    // Otherwise the library re-POSTs on any stream error and
+                    // relaunches the flash; we surface the error in the UI and
+                    // let the user retry deliberately instead.
+                    throw err;
                 },
             });
         } catch (e: any) {

--- a/install/config/mowgli/mowgli_robot.yaml
+++ b/install/config/mowgli/mowgli_robot.yaml
@@ -101,7 +101,10 @@ mowgli:
         # dock_pose is captured by the GUI's IMU yaw calibration
         # (which docks first) or the manual "Set dock to current pose"
         # action — both write back here via line-splice updates.
-        dock_approach_distance: 1
+        # Approach distance = the final straight-in runway (injected as
+        # opennav_docking simple_charging_dock.staging_x_offset). 1.5 m is
+        # a clean, calm approach once the dock pose is correctly pinned.
+        dock_approach_distance: 1.5
         dock_max_retries: 3
         dock_pose_x: 0
         dock_pose_y: 0

--- a/ros2/src/fusion_graph/src/fusion_graph_node.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node.cpp
@@ -1742,7 +1742,14 @@ void FusionGraphNode::PublishLocalOdom()
   t_odom_base.transform.translation.y = dr_y_;
   t_odom_base.transform.translation.z = 0.0;
   t_odom_base.transform.rotation = q_msg;
-  tf_broadcaster_->sendTransform(t_odom_base);
+  // Only the PRIMARY localizer may own odom→base_footprint — same single-
+  // publisher rule as map→odom below. In observer mode (A/B against another
+  // odom source) we still publish /odometry/filtered for comparison but must
+  // NOT broadcast the TF, or two nodes would fight over the same transform.
+  if (primary_mode_)
+  {
+    tf_broadcaster_->sendTransform(t_odom_base);
+  }
 
   nav_msgs::msg::Odometry odom;
   odom.header.stamp = now;

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -213,18 +213,23 @@ private:
             }
           }
 
-          // Derive fix type from flags:
-          //   FLAG_GPS_RTK_FIXED=2 → fix_type 4 (RTK fixed)
-          //   FLAG_GPS_RTK_FLOAT=4 → fix_type 5 (RTK float)
-          //   FLAG_GPS_RTK=1       → fix_type 2 (DGPS/RTK)
-          //   otherwise            → fix_type 0 (no fix / autonomous)
+          // Derive fix type from flags. The ordinal MUST be monotonic in
+          // quality (higher = better) because the undock/preflight gates use
+          // ">= min_fix_type". RTK-Fixed is the best fix, so it must be the
+          // highest value — earlier code ranked Float (5) ABOVE Fixed (4),
+          // which let a robot in RTK-Float pass a "require RTK-Fixed" (min=4)
+          // gate and undock/mow on Float-quality GPS (σ 10-50 cm). Ordering:
+          //   FLAG_GPS_RTK_FIXED → 4 (RTK fixed — best)
+          //   FLAG_GPS_RTK_FLOAT → 3 (RTK float — worse than fixed)
+          //   FLAG_GPS_RTK       → 2 (DGPS/RTK)
+          //   otherwise          → 0 (no fix / autonomous)
           if (msg->flags & AP::FLAG_GPS_RTK_FIXED)
           {
             context_->gps_fix_type = 4;
           }
           else if (msg->flags & AP::FLAG_GPS_RTK_FLOAT)
           {
-            context_->gps_fix_type = 5;
+            context_->gps_fix_type = 3;
           }
           else if (msg->flags & AP::FLAG_GPS_RTK)
           {

--- a/ros2/src/mowgli_behavior/src/condition_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/condition_nodes.cpp
@@ -158,7 +158,16 @@ BT::NodeStatus IsCommand::tick()
     return BT::NodeStatus::FAILURE;
   }
 
-  return ctx->current_command == res.value() ? BT::NodeStatus::SUCCESS : BT::NodeStatus::FAILURE;
+  // Lock the read: current_command is written by the HighLevelControl service
+  // handler under context_mutex. The single default callback group serialises
+  // tick and service today, but lock here too so the read is correct
+  // regardless of executor/callback-group changes (matches RecordArea).
+  uint8_t current;
+  {
+    std::lock_guard<std::mutex> lock(ctx->context_mutex);
+    current = ctx->current_command;
+  }
+  return current == res.value() ? BT::NodeStatus::SUCCESS : BT::NodeStatus::FAILURE;
 }
 
 // ---------------------------------------------------------------------------
@@ -399,8 +408,10 @@ BT::NodeStatus PreFlightCheck::tick()
   }
   if (static_cast<int>(fix_type) < min_gps_fix_type)
   {
-    const char* names[] = {"no-fix", "auto", "DGPS", "?", "RTK-fix", "RTK-float"};
-    const char* current = (fix_type < 6) ? names[fix_type] : "?";
+    // Indices match the quality-monotonic encoding in behavior_tree_node.cpp:
+    // 0=no-fix, 2=DGPS, 3=RTK-float, 4=RTK-fix (1 unused/"auto").
+    const char* names[] = {"no-fix", "auto", "DGPS", "RTK-float", "RTK-fix"};
+    const char* current = (fix_type < 5) ? names[fix_type] : "?";
     char buf[80];
     snprintf(buf, sizeof(buf), "gps_fix=%s (%u, need >=%d)", current, fix_type, min_gps_fix_type);
     failures.emplace_back(buf);

--- a/ros2/src/mowgli_bringup/config/hardware_bridge.yaml
+++ b/ros2/src/mowgli_bringup/config/hardware_bridge.yaml
@@ -3,6 +3,10 @@ hardware_bridge:
     serial_port: "/dev/mowgli"
     baud_rate: 115200
     heartbeat_rate: 4.0   # Hz – keep-alive messages sent to firmware
+    # Serial-link RX watchdog: reopen the port if no STM32 bytes arrive for this
+    # long (auto-reconnect after a firmware flash / board reboot / USB
+    # re-enumeration, which otherwise leaves the bridge writing to a dead fd).
+    serial_rx_timeout_s: 2.0
     publish_rate: 100.0   # Hz – sensor read tick. Actual /imu/data rate
                           # is capped by the firmware packet rate (~47 Hz);
                           # 100 Hz tick ensures every available packet is

--- a/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
+++ b/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
@@ -194,10 +194,24 @@ mowgli:
     # -----------------------------------------------------------------
     dock_pose_x: 0.0              # dock position in map frame (set per-site)
     dock_pose_y: 0.0
-    dock_pose_yaw: 4.17            # measured with phone compass (239°)
+    # dock_pose_yaw MUST be a map-frame ENU yaw (rad) — opennav_docking
+    # consumes it directly as the dock heading. Set it via the GUI
+    # "Set Docking Point" button (robot seated on dock, charging,
+    # RTK-Fixed, yaw converged) or the undock GPS-trajectory calibration;
+    # both write the correct ENU value. A correctly-seated robot's
+    # /odometry/filtered_map yaw equals this. NOTE: 4.17 below is a stale
+    # hand-entered phone-compass seed (239°) — NOT a valid ENU yaw;
+    # recalibrate per-site before relying on docking.
+    dock_pose_yaw: 4.17
     undock_distance: 1.5           # reverse distance when undocking (m)
     undock_speed: 0.16             # reverse speed (m/s) — above kMinLinVel=0.15 host clamp
-    dock_approach_distance: 1.0    # distance to staging pose in front of dock
+    # Distance (m) to the staging pose behind the dock — the final
+    # straight-in approach runway. Injected as opennav_docking
+    # simple_charging_dock.staging_x_offset = -dock_approach_distance
+    # (navigation.launch.py). 1.5 m field-validated 2026-06 as a clean,
+    # calm approach; longer runways (2.5) felt needlessly fast and bought
+    # nothing once the dock pose is correctly pinned.
+    dock_approach_distance: 1.5
     # Overshoot (m) applied to dock_pose in the body forward direction
     # when configuring opennav_docking's home_dock target. The robot
     # then aims at (dock_pose + overshoot) instead of dock_pose itself;

--- a/ros2/src/mowgli_bringup/config/nav2_params.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params.yaml
@@ -798,6 +798,11 @@ docking_server:
     controller.v_linear_max: 0.25
     controller.v_angular_max: 0.75
     controller.slowdown_radius: 0.25
+    # Graceful smooth-control-law gains — upstream documented defaults.
+    # (Diagnosed 2026-06: the "15 cm right" seat was a mis-pinned dock pose,
+    # not a controller deficiency — the fused seated pose matched the target
+    # within ~1 cm at stock gains, so there's no reason to deviate from the
+    # documented k_phi 3.0 / k_delta 2.0.)
     controller.k_phi: 3.0
     controller.k_delta: 2.0
     # Named dock instances — BT uses dock_id="home_dock"

--- a/ros2/src/mowgli_bringup/config/nav2_params_no_lidar.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params_no_lidar.yaml
@@ -138,7 +138,7 @@ controller_server:
       rotate_to_heading_angular_vel: 0.75  # decisive pivot, clear of deadband — see nav2_params.yaml
       max_angular_accel: 2.5
       simulate_ahead_time: 1.0
-      rotate_to_goal_heading: false        # let RPP handle final heading
+      rotate_to_goal_heading: true         # terminal pivot to match goal heading — needed for the opennav_docking NavigateToPose→staging handoff (see nav2_params.yaml)
       closed_loop: true                    # use wheel odom feedback for pivot completion
 
       # --- RegulatedPurePursuitController (primary) params ---
@@ -456,6 +456,9 @@ docking_server:
     controller.v_linear_max: 0.25
     controller.v_angular_max: 0.75
     controller.slowdown_radius: 0.25
+    # Graceful smooth-control-law gains — upstream documented defaults
+    # (match nav2_params.yaml; the "15 cm" seat was a mis-pinned dock, not
+    # a controller issue — stock gains converge within ~1 cm).
     controller.k_phi: 3.0
     controller.k_delta: 2.0
     dock_plugins: ["simple_charging_dock"]

--- a/ros2/src/mowgli_bringup/launch/mowgli.launch.py
+++ b/ros2/src/mowgli_bringup/launch/mowgli.launch.py
@@ -222,6 +222,7 @@ def generate_launch_description() -> LaunchDescription:
             ("~/imu/data_raw", "/imu/data"),
             ("~/imu/mag_raw", "/imu/mag_raw"),
             ("~/wheel_odom", "/wheel_odom"),
+            ("~/wheel_ticks", "/wheel_ticks"),
             ("~/emergency", "/hardware_bridge/emergency"),
             ("~/power", "/hardware_bridge/power"),
             ("~/status", "/hardware_bridge/status"),

--- a/ros2/src/mowgli_bringup/launch/mowgli.launch.py
+++ b/ros2/src/mowgli_bringup/launch/mowgli.launch.py
@@ -215,6 +215,16 @@ def generate_launch_description() -> LaunchDescription:
             {"lift_recovery_mode": bool(robot_params.get("lift_recovery_mode", False))},
             {"lift_blade_resume_delay_sec": float(robot_params.get(
                 "lift_blade_resume_delay_sec", 1.0))},
+            # Gyro angular-rate loop — now operator-tunable via the GUI config
+            # (was only in hardware_bridge.yaml / the node default). Set
+            # angular_rate_loop_enabled:false in mowgli_robot.yaml for plain wz
+            # passthrough (the firmware per-wheel velocity PID then owns wheel
+            # control) when the loop oscillates in yaw. Default keeps the prior
+            # behaviour (enabled) so sim / other configs are unchanged.
+            {"angular_rate_loop_enabled": bool(robot_params.get(
+                "angular_rate_loop_enabled", True))},
+            {"angular_rate_kp": float(robot_params.get("angular_rate_kp", 0.4))},
+            {"angular_rate_ki": float(robot_params.get("angular_rate_ki", 2.0))},
         ],
         # The node publishes on ~/topic (e.g. /hardware_bridge/wheel_odom).
         # behavior_tree_node subscribes to /hardware_bridge/status etc.

--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -323,11 +323,11 @@ def generate_launch_description() -> LaunchDescription:
     chassis_safety_inset = None
     # Dock approach distance: how far behind the dock the opennav_docking
     # staging pose sits. Edited as `dock_approach_distance` in the GUI
-    # (positive metres), injected here as the negative-X
-    # `home_dock.staging_x_offset` consumed by docking_server. The yaml
-    # value was orphan before this — editing the slider produced no
-    # operational change because docking_server kept its hardcoded
-    # -1.5 m default. See issue #192.
+    # (positive metres), injected below as the negative-X
+    # `simple_charging_dock.staging_x_offset` consumed by the dock plugin.
+    # (Until 2026-06 it was injected into `home_dock.staging_x_offset`,
+    # the dock-instance namespace the plugin never reads, so the slider was
+    # orphan and the static -1.5 m governed. See issue #192.)
     dock_approach_distance = 1.5
     # SimpleChargingDock charging-current threshold (amps). 0.3 is the
     # production default (see nav2_params.yaml for the "0.1 stops too
@@ -463,15 +463,6 @@ def generate_launch_description() -> LaunchDescription:
             dock_pose_y + dock_approach_overshoot * _sin_yaw,
             dock_pose_yaw,
         ]
-        # Staging pose offset along the dock's X axis (negative = behind
-        # the dock, the side the robot approaches from). yaml exposes
-        # dock_approach_distance as a positive metres knob in the GUI;
-        # opennav_docking expects the same value negative. Wiring the
-        # two replaces the previously-orphan dock_approach_distance —
-        # the GUI slider now drives the actual staging point. See
-        # issue #192.
-        home_dock["staging_x_offset"] = -float(dock_approach_distance)
-
         # SimpleChargingDock plugin params — charging-current threshold
         # is operator-tunable so the static nav2_params.yaml value can be
         # overridden per-site from mowgli_robot.yaml + GUI.
@@ -479,6 +470,16 @@ def generate_launch_description() -> LaunchDescription:
                   .setdefault("ros__parameters", {})
                   .setdefault("simple_charging_dock", {}))
         scd["charging_threshold"] = dock_charging_threshold
+        # Staging pose offset along the dock's X axis (negative = behind
+        # the dock, the side the robot approaches from). yaml exposes
+        # dock_approach_distance as a positive metres knob in the GUI;
+        # opennav_docking expects the same value negative. This MUST live
+        # under the simple_charging_dock plugin namespace — the plugin reads
+        # `<plugin_name>.staging_x_offset`; writing it under `home_dock`
+        # (the dock-instance namespace, which only carries type/frame/pose)
+        # was silently ignored, leaving the static nav2_params.yaml value
+        # to govern and orphaning the GUI knob. See issue #192.
+        scd["staging_x_offset"] = -float(dock_approach_distance)
 
         # FollowPath (transit controller = RPP via RotationShim).
         fp = (doc.setdefault("controller_server", {})

--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -81,6 +81,7 @@ def generate_launch_description() -> LaunchDescription:
     # ------------------------------------------------------------------
     _runtime_cfg_path = "/ros2_ws/config/mowgli_robot.yaml"
     _early_use_lidar = "true"
+    _lidar_from_yaml = False
     _early_use_magnetometer = "false"
     _early_use_scan_matching = "false"
     _early_use_loop_closure = "false"
@@ -95,6 +96,7 @@ def generate_launch_description() -> LaunchDescription:
             # don't break.
             if "lidar_enabled" in _rp:
                 _early_use_lidar = "true" if bool(_rp["lidar_enabled"]) else "false"
+                _lidar_from_yaml = True
             _early_use_magnetometer = "true" if bool(
                 _rp.get("use_magnetometer", False)) else "false"
             _early_use_scan_matching = "true" if bool(
@@ -104,15 +106,15 @@ def generate_launch_description() -> LaunchDescription:
         except yaml.YAMLError:
             pass
 
-    # LIDAR_ENABLED env var overrides the yaml (back-compat with the
-    # installer's .env workflow). Recognised values for "off": false,
-    # 0, no. Anything else (including unset) keeps the yaml-derived
-    # default.
-    _env_lidar = os.environ.get("LIDAR_ENABLED", "").strip().lower()
-    if _env_lidar in ("false", "0", "no"):
-        _early_use_lidar = "false"
-    elif _env_lidar in ("true", "1", "yes"):
-        _early_use_lidar = "true"
+    # LIDAR_ENABLED env var is a FALLBACK ONLY — it applies only when the yaml
+    # does NOT set lidar_enabled. The GUI-managed yaml is authoritative when
+    # present (a stale installer .env must never override the user's config).
+    if not _lidar_from_yaml:
+        _env_lidar = os.environ.get("LIDAR_ENABLED", "").strip().lower()
+        if _env_lidar in ("false", "0", "no"):
+            _early_use_lidar = "false"
+        elif _env_lidar in ("true", "1", "yes"):
+            _early_use_lidar = "true"
 
     # ------------------------------------------------------------------
     # Loop-closure gating

--- a/ros2/src/mowgli_coverage/src/coverage_server.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_server.cpp
@@ -62,9 +62,11 @@ nav2_util::CallbackReturn CoverageServer::on_configure(
                                  "DISCONTINUOUS");
   declare_parameter<bool>("coordinates_in_cartesian_frame", true);
 
-  // Action server with default-ish timeouts (matches upstream).
-  double action_server_result_timeout = 10.0;
-  declare_parameter<double>("action_server_result_timeout", 10.0);
+  // Action server result timeout. Keep this >= the BT client's per-piece wait
+  // (PlanCoverageArea, 12 s): if the server expires the result first the
+  // client's goal handle is invalidated underneath it. 15 s clears the client.
+  double action_server_result_timeout = 15.0;
+  declare_parameter<double>("action_server_result_timeout", 15.0);
   get_parameter("action_server_result_timeout", action_server_result_timeout);
   rcl_action_server_options_t server_options =
       rcl_action_server_get_default_options();

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -123,6 +123,15 @@ private:
     baud_rate_ = declare_parameter<int>("baud_rate", 115200);
     heartbeat_rate_ = declare_parameter<double>("heartbeat_rate", 4.0);
     publish_rate_ = declare_parameter<double>("publish_rate", 100.0);
+    // Serial-link watchdog: if no bytes arrive for this long while the port is
+    // open, treat the link as dead and reopen it. The STM32 streams status
+    // (~4 Hz) + odom (~20 Hz) + IMU (~50-100 Hz) continuously whenever it is
+    // running, so a multi-second RX gap means the USB endpoint went away —
+    // e.g. a firmware flash or board reboot re-enumerated the CDC device. The
+    // OS leaves the stale fd "open" (reads just return nothing), so without
+    // this the bridge would sit forever writing into a dead fd. Reopening
+    // re-resolves /dev/mowgli to the new ttyACM.
+    serial_rx_timeout_s_ = declare_parameter<double>("serial_rx_timeout_s", 2.0);
     high_level_rate_ = declare_parameter<double>("high_level_rate", 2.0);
     dock_x_ = declare_parameter<double>("dock_pose_x", 0.0);
     dock_y_ = declare_parameter<double>("dock_pose_y", 0.0);
@@ -311,6 +320,9 @@ private:
                   serial_port_path_.c_str(),
                   baud_rate_);
     }
+    // Seed the RX watchdog so a freshly-(re)opened port gets a full grace
+    // window before the no-data check can fire.
+    last_serial_rx_time_ = now();
   }
 
   void create_timers()
@@ -355,14 +367,16 @@ private:
 
   void read_serial_tick()
   {
-    // If the port was never opened or was closed due to an error, attempt to
-    // (re)open it.
+    // If the port was never opened or was closed due to an error / dead-link
+    // watchdog, attempt to (re)open it. open() re-resolves the device path, so
+    // this picks up a new ttyACM after a USB re-enumeration.
     if (!serial_->is_open())
     {
       if (!serial_->open())
       {
         return;  // Still not open; will retry next tick.
       }
+      last_serial_rx_time_ = now();
       RCLCPP_INFO(get_logger(), "Serial port re-opened successfully.");
     }
 
@@ -373,11 +387,37 @@ private:
     while (true)
     {
       const ssize_t n = serial_->read(buf, kReadBufSize);
-      if (n <= 0)
+      if (n < 0)
       {
-        break;
+        // Hard read error (e.g. the USB CDC device was removed/re-enumerated by
+        // a firmware flash or board reboot): the fd is dead. Close now so the
+        // next tick reopens and re-resolves /dev/mowgli to the live device.
+        RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
+                             "Serial read error — closing port to reconnect.");
+        serial_->close();
+        return;
+      }
+      if (n == 0)
+      {
+        break;  // No more data available this tick.
       }
       packet_handler_.feed(buf, static_cast<std::size_t>(n));
+      last_serial_rx_time_ = now();
+    }
+
+    // Dead-link watchdog: the STM32 streams continuously whenever it is up, so
+    // a multi-second RX gap on an "open" port means the endpoint vanished (a
+    // re-enumeration that left the fd nominally open but mute). Close it so the
+    // next tick reopens and reconnects — this is what makes a firmware flash or
+    // board reboot self-heal instead of wedging the bridge.
+    if (serial_rx_timeout_s_ > 0.0 &&
+        (now() - last_serial_rx_time_).seconds() > serial_rx_timeout_s_)
+    {
+      RCLCPP_WARN(get_logger(),
+                  "No serial data for %.1f s — reopening %s to reconnect to the STM32.",
+                  serial_rx_timeout_s_,
+                  serial_port_path_.c_str());
+      serial_->close();
     }
   }
 
@@ -1527,6 +1567,9 @@ private:
   int baud_rate_{115200};
   double heartbeat_rate_{4.0};
   double publish_rate_{100.0};
+  // Serial-link RX watchdog (auto-reconnect on flash / board reboot / unplug).
+  double serial_rx_timeout_s_{2.0};
+  rclcpp::Time last_serial_rx_time_{0, 0, RCL_ROS_TIME};
   double high_level_rate_{2.0};
 
   std::unique_ptr<SerialPort> serial_;

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -398,7 +398,9 @@ private:
         // Hard read error (e.g. the USB CDC device was removed/re-enumerated by
         // a firmware flash or board reboot): the fd is dead. Close now so the
         // next tick reopens and re-resolves /dev/mowgli to the live device.
-        RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
+        RCLCPP_WARN_THROTTLE(get_logger(),
+                             *get_clock(),
+                             2000,
                              "Serial read error — closing port to reconnect.");
         serial_->close();
         return;

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -963,8 +963,9 @@ private:
     latest_gyro_z_ = gz;
 
     // Magnetometer data is ignored — uncalibrated on metal robot chassis,
-    // gives ~229° error vs real heading. dock_pose_yaw is set from config
-    // (user measures with phone compass).
+    // gives ~229° error vs real heading. dock_pose_yaw is a map-frame ENU
+    // yaw, set by the GUI "Set Docking Point" calibration or the undock
+    // GPS-trajectory fit (NOT a phone-compass heading).
 
     // Write resolved dock pose to file for SLAM initialization.
     // On fresh map start, navigation.launch.py reads this file to set
@@ -1065,8 +1066,14 @@ private:
     // (remapped to /gnss/heading in launch). dock_yaw_to_set_pose
     // consumes it and seeds both EKFs via their set_pose services.
     // The orientation quaternion is heading in ENU.
-    // dock_yaw_ is compass heading; convert to ENU: yaw_enu = pi/2 - compass
-    const double enu_yaw = M_PI / 2.0 - dock_yaw_;
+    // dock_yaw_ (= dock_pose_yaw) is ALREADY a map-frame ENU yaw: it is
+    // written that way by the GUI set_docking_point service
+    // (area_manager.cpp) and the undock GPS-trajectory calibration
+    // (calibration_nodes.cpp), and consumed as ENU directly by
+    // opennav_docking's home_dock pose. Use it verbatim — the old
+    // `pi/2 - dock_yaw_` compass→ENU conversion was wrong (it double-
+    // rotated this seed relative to every other consumer/writer).
+    const double enu_yaw = dock_yaw_;
 
     // During the anchor window after a charging transition, publish with
     // σ=π so dock_yaw_to_set_pose accepts the first heading update as a

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -77,6 +77,7 @@ static constexpr uint8_t HL_MODE_MANUAL_MOWING = 4u;  ///< Manual teleop with bl
 #include "mowgli_interfaces/msg/high_level_status.hpp"
 #include "mowgli_interfaces/msg/power.hpp"
 #include "mowgli_interfaces/msg/status.hpp"
+#include "mowgli_interfaces/msg/wheel_tick.hpp"
 #include "mowgli_interfaces/srv/emergency_stop.hpp"
 #include "mowgli_interfaces/srv/mower_control.hpp"
 #include "nav_msgs/msg/odometry.hpp"
@@ -227,6 +228,11 @@ private:
     pub_mag_raw_ =
         create_publisher<sensor_msgs::msg::MagneticField>("~/imu/mag_raw", rclcpp::QoS(10));
     pub_wheel_odom_ = create_publisher<nav_msgs::msg::Odometry>("~/wheel_odom", rclcpp::QoS(10));
+    // Per-wheel encoder ticks (diagnostics — GUI "Per-Wheel Encoders" panel).
+    // 2-wheel diff-drive maps to RL/RR only. Remapped to /wheel_ticks in the
+    // launch file (the GUI bridge subscribes to /wheel_ticks).
+    pub_wheel_ticks_ =
+        create_publisher<mowgli_interfaces::msg::WheelTick>("~/wheel_ticks", rclcpp::QoS(10));
     pub_battery_state_ =
         create_publisher<sensor_msgs::msg::BatteryState>("/battery_state", rclcpp::QoS(10));
     // Dock heading: publish dock_yaw at 1 Hz while charging so
@@ -1224,6 +1230,36 @@ private:
       d_right = 0;
     }
 
+    // ----- Per-wheel WheelTick (diagnostics: GUI "Per-Wheel Encoders") -----
+    // Published every firmware packet (~47 Hz). The mower is 2-wheel diff-drive,
+    // so only the Rear-Left / Rear-Right slots are valid (left→RL, right→RR,
+    // matching the wheel_odometry_node convention); Front-L/R stay invalid.
+    // WheelTick wants MONOTONIC-up magnitude counts plus a direction byte
+    // (consumers do (cur-prev)*sign(direction)), whereas the firmware sends
+    // signed cumulative ticks — so accumulate |delta| and derive the direction
+    // from the delta sign (holding the last direction through a zero delta).
+    wheel_ticks_mag_left_ += static_cast<uint32_t>(std::abs(d_left));
+    wheel_ticks_mag_right_ += static_cast<uint32_t>(std::abs(d_right));
+    if (d_left > 0)
+      wheel_dir_left_ = 1u;
+    else if (d_left < 0)
+      wheel_dir_left_ = 0u;
+    if (d_right > 0)
+      wheel_dir_right_ = 1u;
+    else if (d_right < 0)
+      wheel_dir_right_ = 0u;
+
+    mowgli_interfaces::msg::WheelTick wt{};
+    wt.stamp = now();
+    wt.wheel_tick_factor = static_cast<uint32_t>(std::lround(ticks_per_meter_));
+    wt.valid_wheels = mowgli_interfaces::msg::WheelTick::WHEEL_VALID_RL |
+                      mowgli_interfaces::msg::WheelTick::WHEEL_VALID_RR;
+    wt.wheel_direction_rl = wheel_dir_left_;
+    wt.wheel_ticks_rl = wheel_ticks_mag_left_;
+    wt.wheel_direction_rr = wheel_dir_right_;
+    wt.wheel_ticks_rr = wheel_ticks_mag_right_;
+    pub_wheel_ticks_->publish(wt);
+
     // ----- Aggregate firmware packets into ~10 Hz wheel_odom publishes -----
     // Firmware packets arrive at ~47 Hz (every ~21 ms). At slow speeds this
     // gives only 0-3 ticks per window, so single-tick encoder noise (1 tick
@@ -1544,6 +1580,13 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub_imu_;
   rclcpp::Publisher<sensor_msgs::msg::MagneticField>::SharedPtr pub_mag_raw_;
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_wheel_odom_;
+  rclcpp::Publisher<mowgli_interfaces::msg::WheelTick>::SharedPtr pub_wheel_ticks_;
+  // Per-wheel cumulative-magnitude tick counters + last direction (for WheelTick;
+  // see handle_odometry). Magnitude is monotonic-up; direction is 1=fwd/0=rev.
+  uint32_t wheel_ticks_mag_left_{0};
+  uint32_t wheel_ticks_mag_right_{0};
+  uint8_t wheel_dir_left_{1};
+  uint8_t wheel_dir_right_{1};
   rclcpp::Publisher<sensor_msgs::msg::BatteryState>::SharedPtr pub_battery_state_;
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub_dock_heading_;
 

--- a/ros2/src/mowgli_localization/include/mowgli_localization/localization_monitor_node.hpp
+++ b/ros2/src/mowgli_localization/include/mowgli_localization/localization_monitor_node.hpp
@@ -118,6 +118,12 @@ private:
   double gps_timeout_{2.0};
   double pose_timeout_{0.5};
   double publish_rate_{10.0};
+  /// Hysteresis: a changed localization mode must persist at least this long
+  /// before it is committed/published. Filters the spurious per-epoch RTK
+  /// Fixed<->Float flicker (the receiver's carrSoln can toggle every epoch
+  /// during motion while the position stays sub-cm), which otherwise flaps
+  /// the published mode. 0 disables the debounce.
+  double mode_debounce_sec_{1.0};
 
   // ---------------------------------------------------------------------------
   // Source state
@@ -129,6 +135,14 @@ private:
   bool gps_rtk_active_{false};
   /// True when fixed (vs. float).
   bool gps_rtk_fixed_{false};
+
+  // ---------------------------------------------------------------------------
+  // Debounce state (committed mode published; a differing instantaneous mode
+  // must persist >= mode_debounce_sec_ before it is committed).
+  // ---------------------------------------------------------------------------
+  LocalizationMode stable_mode_{LocalizationMode::DEAD_RECKONING};
+  LocalizationMode pending_mode_{LocalizationMode::DEAD_RECKONING};
+  rclcpp::Time pending_since_{0, 0, RCL_ROS_TIME};
 
   // ---------------------------------------------------------------------------
   // ROS handles

--- a/ros2/src/mowgli_localization/src/cog_to_imu_node.cpp
+++ b/ros2/src/mowgli_localization/src/cog_to_imu_node.cpp
@@ -517,7 +517,12 @@ private:
     anchor_wheel_sign_ = wheel_sign;
     abs_dtheta_since_anchor_ = 0.0;  // next baseline starts fresh
 
-    publish_imu(now(), yaw, yaw_var);
+    // Stamp the heading with the GPS fix time, not wall-clock now(). The COG
+    // yaw is derived from this fix's position; stamping it with arrival time
+    // bakes in the GPS pipeline latency (~100-200 ms), which misassociates the
+    // measurement with a later graph node during turns. msg.header.stamp is the
+    // fix epoch.
+    publish_imu(rclcpp::Time(msg.header.stamp), yaw, yaw_var);
 
     const double mono_now = static_cast<double>(get_clock()->now().nanoseconds()) * 1e-9;
     latched_yaw_ = LatchedYaw{mono_now, yaw, yaw_var};

--- a/ros2/src/mowgli_localization/src/gnss_runtime_state_builder.cpp
+++ b/ros2/src/mowgli_localization/src/gnss_runtime_state_builder.cpp
@@ -430,8 +430,21 @@ void ApplyUbloxDiagnostics(GnssRuntimeState& state, const GnssDiagnosticSnapshot
   {
     state.correction_age_s = *corr_age;
   }
-  if (const auto corrections_active = CorrectionsActiveFromTransport(corr_age, msgs_per_sec);
-      corrections_active.has_value())
+  // corrections_active should answer "is the solution being RTK-corrected right
+  // now", not "did an RTCM byte arrive in the last transport tick". The carrier
+  // solution is the authoritative answer: an F9P cannot report Fixed/Float
+  // without corrections actually being applied. The raw transport metric
+  // (age_of_last_corr_s / msgs_per_sec) is bursty per-epoch and read false on
+  // ~29/33 samples while the receiver was solidly Fixed at ~4 mm — using it
+  // alone made corrections_active (and the GUI/diagnostics that key off it)
+  // flap. So treat a Fixed/Float carrier solution as corrections-active, and
+  // fall back to the transport freshness only when the solution is not RTK.
+  if (state.rtk_mode == GnssRtkMode::kFixed || state.rtk_mode == GnssRtkMode::kFloat)
+  {
+    state.corrections_active = true;
+  }
+  else if (const auto corrections_active = CorrectionsActiveFromTransport(corr_age, msgs_per_sec);
+           corrections_active.has_value())
   {
     state.corrections_active = *corrections_active;
   }

--- a/ros2/src/mowgli_localization/src/localization_monitor_node.cpp
+++ b/ros2/src/mowgli_localization/src/localization_monitor_node.cpp
@@ -73,6 +73,7 @@ void LocalizationMonitorNode::declare_parameters()
   gps_timeout_ = declare_parameter<double>("gps_timeout", 2.0);
   pose_timeout_ = declare_parameter<double>("pose_timeout", 0.5);
   publish_rate_ = declare_parameter<double>("publish_rate", 10.0);
+  mode_debounce_sec_ = declare_parameter<double>("mode_debounce_sec", 1.0);
 }
 
 void LocalizationMonitorNode::create_publishers()
@@ -145,25 +146,42 @@ void LocalizationMonitorNode::on_absolute_pose(
 
 void LocalizationMonitorNode::on_publish_timer()
 {
-  static LocalizationMode prev_mode = LocalizationMode::DEAD_RECKONING;
+  const LocalizationMode instant = evaluate_mode();
 
-  const LocalizationMode mode = evaluate_mode();
-
-  if (mode != prev_mode)
+  // Hysteresis (mode_debounce_sec_): only commit a changed mode once the new
+  // value has persisted continuously for the debounce window. This filters the
+  // spurious per-epoch RTK Fixed<->Float flicker (the receiver's carrSoln can
+  // toggle every epoch during motion while position σ stays sub-cm) so the
+  // published localization mode — and anything gating on it — does not flap.
+  // mode_debounce_sec_ <= 0 disables the hysteresis (commit immediately).
+  const rclcpp::Time now = this->now();
+  if (instant == stable_mode_)
   {
+    // Back to the committed mode — cancel any pending change.
+    pending_mode_ = stable_mode_;
+  }
+  else if (instant != pending_mode_)
+  {
+    // New candidate — start its dwell timer.
+    pending_mode_ = instant;
+    pending_since_ = now;
+  }
+  else if (mode_debounce_sec_ <= 0.0 || (now - pending_since_).seconds() >= mode_debounce_sec_)
+  {
+    // Candidate has dwelled long enough — commit it.
     RCLCPP_INFO(get_logger(),
                 "Localization mode change: %s → %s",
-                mode_to_string(prev_mode).c_str(),
-                mode_to_string(mode).c_str());
-    prev_mode = mode;
+                mode_to_string(stable_mode_).c_str(),
+                mode_to_string(instant).c_str());
+    stable_mode_ = instant;
   }
 
   std_msgs::msg::String mode_msg;
-  mode_msg.data = mode_to_string(mode);
+  mode_msg.data = mode_to_string(stable_mode_);
   mode_pub_->publish(mode_msg);
 
   std_msgs::msg::Int32 id_msg;
-  id_msg.data = static_cast<int32_t>(mode);
+  id_msg.data = static_cast<int32_t>(stable_mode_);
   mode_id_pub_->publish(id_msg);
 }
 

--- a/ros2/src/mowgli_localization/src/navsat_to_absolute_pose_node.cpp
+++ b/ros2/src/mowgli_localization/src/navsat_to_absolute_pose_node.cpp
@@ -96,6 +96,10 @@ void NavSatToAbsolutePoseNode::declare_parameters()
   datum_lat_ = declare_parameter<double>("datum_lat", 0.0);
   datum_lon_ = declare_parameter<double>("datum_lon", 0.0);
 
+  // Heading-from-COG yaw uncertainty (rad). Was a hardcoded member documented
+  // as tunable; now actually a declared parameter (default 3° = 0.0524 rad).
+  lever_arm_yaw_sigma_ = declare_parameter<double>("lever_arm_yaw_sigma", 0.0524);
+
   // Defensive guards on /gps/pose_cov — see header for rationale.
   pos_accuracy_inflation_threshold_m_ =
       declare_parameter<double>("pos_accuracy_inflation_threshold_m", 0.025);
@@ -229,9 +233,14 @@ void NavSatToAbsolutePoseNode::on_navsat_fix(sensor_msgs::msg::NavSatFix::ConstS
   double north = 0.0;
   wgs84_to_enu(msg->latitude, msg->longitude, east, north);
 
-  // Build AbsolutePose.
+  // Build AbsolutePose. Stamp with the GPS fix time, not wall-clock now(), so
+  // the pose isn't tagged with the GPS pipeline latency (which misassociates it
+  // in time downstream). Fall back to now() only if the driver left the stamp
+  // unset (sec==0 && nanosec==0).
   AbsPose out;
-  out.header.stamp = now();
+  out.header.stamp = (msg->header.stamp.sec != 0 || msg->header.stamp.nanosec != 0)
+                         ? rclcpp::Time(msg->header.stamp)
+                         : now();
   out.header.frame_id = "map";
   out.source = AbsPose::SOURCE_GPS;
 

--- a/ros2/src/mowgli_localization/test/test_gnss_runtime_state_builder.cpp
+++ b/ros2/src/mowgli_localization/test/test_gnss_runtime_state_builder.cpp
@@ -141,6 +141,52 @@ TEST(GnssRuntimeStateBuilderTest, EnrichesUbloxStateFromStructuredDiagnostics)
   EXPECT_FLOAT_EQ(*state.correction_age_s, 0.4f);
 }
 
+TEST(GnssRuntimeStateBuilderTest,
+     UbloxFixedCarrierSolutionKeepsCorrectionsActiveDespiteStaleTransport)
+{
+  // Real-robot regression: while the F9P is solidly RTK-Fixed at ~4 mm, the
+  // transport-side RTCM metric (msgs_per_sec / age_of_last_corr_s) is bursty
+  // per-epoch and frequently reads "no recent byte" even though corrections are
+  // clearly being applied (you cannot be Fixed without them). corrections_active
+  // must follow the carrier solution, not the bursty transport flag, or the GUI
+  // and diagnostics flap Fixed<->no-corrections every second.
+  sensor_msgs::msg::NavSatFix fix;
+  fix.header.stamp = MakeRosStamp(12);
+  fix.status.status = sensor_msgs::msg::NavSatStatus::STATUS_FIX;
+
+  auto state = BuildGnssRuntimeStateFromFix(fix, GnssBackendKind::kUblox);
+  const auto snapshot = BuildGnssDiagnosticSnapshot(MakeArray({
+      MakeDiag("GPS: fix", {{"gps_fix_ok", "True"}, {"carr_soln", "fixed"}}),
+      MakeDiag("GPS: NTRIP/RTCM", {{"msgs_per_sec", "0.0"}, {"age_of_last_corr_s", "8.0"}}),
+  }));
+
+  EnrichGnssRuntimeStateFromDiagnostics(state, GnssBackendKind::kUblox, snapshot, 5.0);
+  ASSERT_TRUE(state.rtk_mode.has_value());
+  EXPECT_EQ(*state.rtk_mode, GnssRtkMode::kFixed);
+  ASSERT_TRUE(state.corrections_active.has_value());
+  EXPECT_TRUE(*state.corrections_active);
+}
+
+TEST(GnssRuntimeStateBuilderTest, UbloxNonRtkStillUsesTransportFreshnessForCorrectionsActive)
+{
+  // When the carrier solution is not RTK (carr_soln "none"), corrections_active
+  // must fall back to the transport metric — a stale transport then correctly
+  // reports corrections inactive.
+  sensor_msgs::msg::NavSatFix fix;
+  fix.header.stamp = MakeRosStamp(12);
+  fix.status.status = sensor_msgs::msg::NavSatStatus::STATUS_FIX;
+
+  auto state = BuildGnssRuntimeStateFromFix(fix, GnssBackendKind::kUblox);
+  const auto snapshot = BuildGnssDiagnosticSnapshot(MakeArray({
+      MakeDiag("GPS: fix", {{"gps_fix_ok", "True"}, {"carr_soln", "none"}}),
+      MakeDiag("GPS: NTRIP/RTCM", {{"msgs_per_sec", "0.0"}, {"age_of_last_corr_s", "8.0"}}),
+  }));
+
+  EnrichGnssRuntimeStateFromDiagnostics(state, GnssBackendKind::kUblox, snapshot, 5.0);
+  ASSERT_TRUE(state.corrections_active.has_value());
+  EXPECT_FALSE(*state.corrections_active);
+}
+
 TEST(GnssRuntimeStateBuilderTest, RejectsDiagnosticsThatAreNewerThanFixOrTooStale)
 {
   sensor_msgs::msg::NavSatFix fix;

--- a/ros2/src/mowgli_map/src/area_manager.cpp
+++ b/ros2/src/mowgli_map/src/area_manager.cpp
@@ -590,6 +590,12 @@ void MapServerNode::on_add_area(const mowgli_interfaces::srv::AddMowingArea::Req
     areas_.push_back(std::move(entry));
   }
   resize_map_to_areas();
+  // resize_map_to_areas() reallocates the grid and resets every layer
+  // (CLASSIFICATION → UNKNOWN), discarding the LAWN/NO_GO cells stamped above.
+  // Re-stamp from the full area list — exactly as on_load_areas does — or a
+  // freshly recorded area reads 0 LAWN cells, which breaks completion gating,
+  // the GUI coverage overlay, and the cell-based strip fallback.
+  apply_area_classifications();
   masks_dirty_ = true;
 
   RCLCPP_INFO(get_logger(),


### PR DESCRIPTION
Brings the `feat/host-wheel-pi` work to `dev` for validation before `main`. The branch name is historical — the velocity loop ended up **back in firmware** (the host-over-USB loop was abandoned, see below); the host side is a clean feedforward/PID passthrough again.

## What's in here (10 commits)

### Motor control — ⚠️ SAFETY-RELEVANT (flag in review)
- **`feat(firmware): replace hand-rolled wheel PI with vendored PX4 PID`** — per-wheel velocity loop in the STM32 (`pid.hpp`, PX4 `PID`, BSD-3, header-only). Reproduces the old integral math (P=30/I=5000/D=0, integral clamp ±100) + open-loop feedforward (`target*PWM_PER_MPS`) deadband bridge, sign/stop/hard-stop reset, stopped-wheel zero, plus a **direction-aware conditional-integration anti-windup** (only freezes the integrator in the direction that worsens an already-railed ±255 output; always allows unwinding). Firmware retains sole blade/emergency/watchdog authority — none bypassed. **Validated on-robot**: linear speed tracked 0.85→1.03 across a full mow, RTK-Fixed throughout.
- **`feat(hardware_bridge): publish WheelTick`** for the GUI per-wheel encoder panel.
- **`fix(hardware_bridge): auto-reconnect serial`** on flash / board reboot / re-enumeration.

### Localization / launch / docking
- **`fix(localization): stop RTK Fixed/Float flicker flapping the mode and corrections flag`** (this PR's newest commit) — debounce the published localization mode (`mode_debounce_sec`, default 1.0 s) and make `corrections_active` follow the carrier solution rather than the bursty per-epoch transport metric. +2 regression tests. Fixes the "GPS switches Fixed/Float every second" symptom (position σ was rock-solid ~4 mm throughout — pure classification flicker).
- **`fix(launch): yaml lidar_enabled is authoritative`** — the `LIDAR_ENABLED` env var is now fallback-only; also exposes the gyro angular-rate loop (`angular_rate_loop_enabled/kp/ki`) to GUI config. (The gyro rate loop is disabled in the live config — it was the source of the yaw "rotation overshoot" wobble.)
- **`fix: localizer/autonomy safety fixes from review`** (extracted, no PID coupling).
- **`fix(docking): staging-offset namespace, dock_pose_yaw ENU seed, no-lidar terminal pivot`** — re-docking validated end-to-end ("Robot is charging!").

### CI / GUI
- **`ci(firmware): build-check feature branches`** (GUI flashes firmware from branch source).
- **`fix(gui): firmware flash restarts on tab change / focus loss`**.
- `style: clang-format` fixups.

## Verification
- CI builds the `feat-host-wheel-pi` image (ros2-docker + firmware-ci + ros2-ci).
- Firmware PX4-PID speed loop validated on-robot; gyro yaw wobble fixed; LiDAR kept (perf profiling under mowing load still open); docking re-validated.
- Merge to `dev` for a soak, then `dev → main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)