### PR TITLE
docs: firmware wheel-PI, RTK flicker, lidar_enabled authority

### DIFF
--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -309,7 +309,13 @@ ROS2 ecosystem
 **SerialPort (serial_port.cpp/.hpp)**
 - Low-level serial port abstraction
 - Non-blocking read/write
-- Automatic reconnection on error
+- Auto-reconnect on firmware flash / board reboot / USB re-enumeration: a
+  dead-link RX watchdog (`serial_rx_timeout_s`, default 2 s) closes a port that
+  is nominally open but no longer delivering bytes (or returns a hard read
+  error), so the next read tick reopens it and re-resolves `/dev/mowgli` to the
+  live `ttyACM`. The STM32 streams status/odom/IMU continuously, so a
+  multi-second RX gap unambiguously means the endpoint went away. Self-heals
+  without a manual container restart.
 - Configurable baud rate (115200 default)
 
 **PacketHandler (packet_handler.cpp/.hpp)**
@@ -325,6 +331,10 @@ ROS2 ecosystem
 - Timer-based read loop (100 Hz default)
 - Heartbeat transmission (4 Hz default)
 - High-level state updates (2 Hz default, GPS quality + mode)
+- Publishes `WheelTick` on `~/wheel_ticks` (→ `/wheel_ticks`), once per firmware
+  packet (~47 Hz), for the GUI "Per-Wheel Encoders" panel. The 2-wheel
+  diff-drive maps left→RL, right→RR (`valid_wheels = RL|RR`); Front L/R remain
+  invalid so the panel correctly shows "no encoder reading" for them.
 
 #### Wire Protocol: COBS + CRC-16
 
@@ -626,7 +636,15 @@ navsat_to_absolute_pose:
 
 **Outputs:**
 - `/localization/status` (diagnostic_msgs/DiagnosticStatus)
-- `/localization/mode` (std_msgs/String, for debug/logging)
+- `/mowgli/localization/mode` (std_msgs/String, latched, for debug/logging)
+- `/mowgli/localization/mode_id` (std_msgs/Int32, latched, numeric mode)
+
+**Mode debounce (`mode_debounce_sec`, default 1.0 s):** the published mode is
+hysteretic — a changed mode must persist continuously for the debounce window
+before it is committed and published. This filters the per-epoch RTK
+Fixed↔Float flicker (an F9P's `carrSoln` can toggle every epoch under motion
+while position σ stays sub-cm), so the mode — and anything gating on it — does
+not flap. Set `mode_debounce_sec: 0` to commit immediately.
 
 **Degradation Modes (5 levels):**
 
@@ -645,6 +663,7 @@ localization_monitor:
     odom_stale_timeout_sec: 2.0
     gps_timeout_sec: 10.0
     max_acceptable_fusion_variance: 0.25   # m² for position
+    mode_debounce_sec: 1.0                 # hysteresis on published mode (0 = off)
 ```
 
 #### 3d. robot_localization Diagnostics Integration

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -25,6 +25,8 @@ config/
 
 There is **no** `slam_toolbox.yaml` or `kiss_icp.yaml`. robot_localization (the default dual-EKF localizer) is tuned through `robot_localization.yaml`. LiDAR scan-matching and loop-closure are handled by `fusion_graph` (opt-in — see [§5](#5-fusion_graph)).
 
+Whether the LiDAR-aware stack (`nav2_params.yaml`) or the GPS-only stack (`nav2_params_no_lidar.yaml`) is loaded is decided by the **`lidar_enabled`** key in `mowgli_robot.yaml`, which is **authoritative**. The `LIDAR_ENABLED` environment variable (set by the installer `.env`) is only a **fallback** — it applies solely when `lidar_enabled` is absent from the yaml, so a stale installer `.env` can never override the user's GUI-managed config. A CLI/compose `use_lidar:=` override still wins for one-off runs.
+
 The opt-in **fusion_graph** localizer (GTSAM iSAM2 — see [§7](#7-fusion_graph)) does **not** have a separate config file: its knobs are declared as ros2 parameters on `fusion_graph_node` and the high-level switches (`use_fusion_graph`, `use_scan_matching`, `use_loop_closure`, `use_magnetometer`) live in `mowgli_robot.yaml`. The Settings page exposes them under the *Localization* section.
 
 All YAML files use the ROS2 `ros__parameters` namespace convention. Parameters can be overridden via command-line:
@@ -211,6 +213,22 @@ hardware_bridge:
 - **Payload:** Current high-level mode (idle/mowing/docking/recording) and GPS RTK quality
 - **Purpose:** Firmware uses this for telemetry, sound notifications, LED feedback
 - **Tuning:** Lower rate OK (2 Hz sufficient for informational updates)
+
+#### `angular_rate_loop_enabled` / `angular_rate_kp` / `angular_rate_ki`
+
+- **Type:** bool / double / double
+- **Defaults:** `true` / `0.4` / `2.0` (node defaults; **sourced from
+  `mowgli_robot.yaml`** and injected at launch by `mowgli.launch.py`, so they
+  are operator-tunable from the GUI config without editing `hardware_bridge.yaml`)
+- **Description:** Host-side gyro angular-rate PI on `wz`. When enabled,
+  `hardware_bridge` closes a yaw-rate loop on the IMU gyro before forwarding the
+  twist to firmware. When disabled (`angular_rate_loop_enabled: false`), `wz`
+  passes through untouched and the firmware per-wheel velocity PID owns all wheel
+  control.
+- **Note:** The host loop can ring in yaw (rotation overshoot). On this robot it
+  is disabled (`angular_rate_loop_enabled: false`) — the firmware velocity loop
+  handles wheel tracking. The default keeps the prior (enabled) behaviour so sim
+  and other configs are unchanged.
 
 ### Typical Configurations
 

--- a/wiki/Firmware.md
+++ b/wiki/Firmware.md
@@ -24,6 +24,52 @@ This guide explains how to adapt the Mowgli STM32 firmware to communicate with t
 - **Simple:** No ROS message format dependencies on firmware side
 - **Portable:** Works with any serial port, no ROS middleware required
 
+> **Note on this guide:** The code below is a generic, pseudocode-level
+> migration walkthrough and does **not** match the symbol names or packet
+> layout of the live firmware (which uses COBS handler callbacks such as
+> `on_cmd_vel` / `motors_handler`, a `pkt_cmd_vel_t` carrying `vx`/`wz`, and a
+> 2-wheel encoder/status path — not a 4-wheel `LlStatus` / `handle_cmd_vel`
+> scheme). For the authoritative motor-control behaviour, read the
+> [Drive Motor Control](#drive-motor-control--per-wheel-velocity-pi) section
+> below, then the actual source in
+> `firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp`.
+
+## Drive Motor Control — Per-Wheel Velocity PI
+
+The host sends a single `CMD_VEL` packet (`vx`, `wz`); the **firmware** owns the
+diff-drive split and the per-wheel velocity loop. A host-side velocity loop over
+the USB round-trip was tried and abandoned — it was fragile across the USB
+dead-time — so the loop lives in firmware where local encoder feedback is fast.
+
+**Source:** `firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp`
+(`on_cmd_vel`, `motors_handler`, `init_ROS`) and the vendored PX4 PID core in
+`firmware/stm32/ros_usbnode/include/pid.hpp`.
+
+- **Inverse kinematics:** `on_cmd_vel` converts (`vx`, `wz`) to per-wheel target
+  speeds (`vx ± wz·WHEEL_BASE/2`), clamps them to `±MAX_MPS`, and hands them to
+  `motors_handler`.
+- **Loop:** `motors_handler` runs at `MOTORS_NBT_TIME_MS` = 20 ms (50 Hz). Per
+  wheel it derives the actual speed from the signed cumulative encoder count
+  (`left/right_ticks_signed`, 300 ticks/m) over the 20 ms period.
+- **Controller:** a vendored PX4 `PID` (BSD-3, header-only `pid.hpp`,
+  derivative-on-measurement, NaN/inf guards) runs as a **PI** loop: P =
+  `WHEEL_PI_KP` (30), I = `WHEEL_PI_KI` (5000), **D = 0**, integral clamp ±100,
+  output clamp ±255 PWM.
+- **Feedforward:** the PI trim is added on top of an open-loop feedforward
+  `target_mps × PWM_PER_MPS` (300). The integrator bridges the brushed-DC
+  static-friction deadband (~PWM 40) on sub-deadband commands, where open-loop
+  alone leaves the motor buzzing without moving.
+- **Anti-windup (direction-aware conditional integration):** the integrator is
+  frozen only in the direction that would worsen an already-railed ±255 output;
+  it is always allowed to unwind out of saturation (keyed on the error sign, not
+  just the saturation bit).
+- **Resets / safety:** the integrator is reset on target sign-flip, stop-to-go,
+  and hard-stop (emergency or cmd_vel watchdog); a stopped wheel is forced to PWM
+  0 to kill residual hum. Set `USE_WHEEL_PI 0` to fall back to open-loop
+  forwarding for bring-up.
+
+Field-validated on the robot: linear speed tracked ~0.85–1.03 of commanded.
+
 ## Files Overview
 
 ### Firmware Directory Structure

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -137,7 +137,10 @@ nano config/mowgli/mowgli_robot.yaml
 
 Key settings to change:
 - `datum_lat` / `datum_long` — your GPS reference point
-- `dock_pose_x` / `dock_pose_y` / `dock_pose_yaw` — dock position
+- `dock_pose_x` / `dock_pose_y` / `dock_pose_yaw` — dock position. `dock_pose_yaw`
+  is a **map-frame ENU heading in radians** (not a phone-compass bearing); it is
+  normally captured automatically by "Set Docking Point" / undock calibration
+  rather than hand-entered.
 - `ntrip_host` / `ntrip_user` / `ntrip_password` — RTK correction source
 
 ### 4. Launch

--- a/wiki/Sensors.md
+++ b/wiki/Sensors.md
@@ -19,6 +19,20 @@ The GPS container runs:
 - `ntrip_client` — RTK corrections from NTRIP caster
 - `rtcm_serial_bridge.py` — forwards RTCM to GPS serial
 
+**RTK Fixed/Float flicker:** under motion an F9P's reported carrier solution
+(`carrSoln`) can toggle Fixed↔Float every epoch even while position σ stays
+~4 mm — a pure classification flicker, not a position problem. Two pieces of
+the ROS2 stack absorb this so it doesn't propagate downstream:
+- `localization_monitor_node` debounces the published localization mode
+  (`mode_debounce_sec`, default 1.0 s) — see
+  [Architecture › localization_monitor_node](Architecture#3c-localization_monitor_node).
+- The ublox GNSS diagnostics path treats `corrections_active` as following the
+  carrier solution (a Fixed/Float solution implies corrections are active, since
+  the receiver can't solve RTK without them), only falling back to the bursty
+  transport RTCM freshness metric when the solution is not RTK. (The Unicore
+  path is unchanged — it already uses the receiver's authoritative correction
+  age.)
+
 ### LiDAR: LDRobot LD19
 
 | Property | Value |


### PR DESCRIPTION
Promotes the documentation-only updates from `dev` (PR #273) to `main`. The only delta between `dev` and `main` is the docs commit `0f9d1024` reflecting the already-merged `feat/host-wheel-pi` batch (#271/#272).

## Files changed
- **wiki/Firmware.md** — scope-note + accurate "Drive Motor Control — Per-Wheel Velocity PI" section (vendored PX4 PID, deadband bridge, direction-aware anti-windup).
- **wiki/Architecture.md** — `localization_monitor_node` mode debounce + `/mowgli/localization/mode(_id)` outputs; `SerialPort` dead-link RX watchdog auto-reconnect; `WheelTick` publication.
- **wiki/Configuration.md** — `lidar_enabled` (yaml) authoritative over `LIDAR_ENABLED` env; GUI-tunable host gyro angular-rate loop params.
- **wiki/Sensors.md** — RTK Fixed/Float flicker note (mode debounce + carrier-solution `corrections_active`).
- **wiki/Getting-Started.md** — `dock_pose_yaw` clarified as map-frame ENU radians.

Docs-only; no code/config/firmware/test changes.