### PR TITLE
tune: ship validated transit/mowing speeds as template defaults

### DIFF
--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
@@ -156,6 +156,15 @@ struct BTContext
   /// Current navigation mode: "precise" or "degraded"
   std::string current_nav_mode{"precise"};
 
+  /// Operator-configured drive speeds (m/s), sourced from mowgli_robot.yaml
+  /// by behavior_tree_node and applied to the live controllers by SetNavMode:
+  /// transit_speed → FollowPath.desired_linear_vel (RPP transit), mowing_speed
+  /// → FollowCoveragePath.speed_fast (FTC coverage). Defaults match the shipped
+  /// template; SetNavMode halves them in "degraded" mode (floored at the host
+  /// min-drive clamp).
+  double transit_speed{0.25};
+  double mowing_speed{0.2};
+
   /// True if it was raining when the current mowing session started.
   /// Set by WasRainingAtStart, checked by IsNewRain.
   bool raining_at_mow_start{false};

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -432,6 +432,15 @@ private:
     const double undock_speed = declare_parameter<double>("undock_speed", 0.15);
     blackboard_->set("undock_speed", undock_speed);
 
+    // Transit / mowing speeds, sourced from mowgli_robot.yaml and applied to
+    // the live controllers by SetNavMode (FollowPath.desired_linear_vel for the
+    // RPP transit controller, FollowCoveragePath.speed_fast for FTC coverage).
+    // Stored on the shared BTContext so SetNavMode's tick is a pure read.
+    // Previously SetNavMode hardcoded 0.5 (precise) / 0.25 (degraded), which
+    // stomped the launch-injected values — the configured speeds never applied.
+    context_->transit_speed = declare_parameter<double>("transit_speed", 0.25);
+    context_->mowing_speed = declare_parameter<double>("mowing_speed", 0.2);
+
     // Rain delay: parameter in minutes, blackboard in seconds.
     const double rain_delay_minutes = declare_parameter<double>("rain_delay_minutes", 30.0);
     blackboard_->set("rain_delay_sec", rain_delay_minutes * 60.0);

--- a/ros2/src/mowgli_behavior/src/navigation_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/navigation_nodes.cpp
@@ -15,6 +15,7 @@
 
 #include "mowgli_behavior/navigation_nodes.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <sstream>
 #include <stdexcept>
@@ -847,27 +848,35 @@ BT::NodeStatus SetNavMode::tick()
     return BT::NodeStatus::SUCCESS;
   }
 
-  std::vector<rclcpp::Parameter> params;
-  if (mode == "precise")
-  {
-    params = {
-        rclcpp::Parameter("FollowCoveragePath.desired_linear_vel", 0.5),
-        rclcpp::Parameter("FollowPath.desired_linear_vel", 0.5),
-    };
-  }
-  else
-  {
-    // degraded: half speed
-    params = {
-        rclcpp::Parameter("FollowCoveragePath.desired_linear_vel", 0.25),
-        rclcpp::Parameter("FollowPath.desired_linear_vel", 0.25),
-    };
-  }
+  // Apply the operator-configured speeds (from mowgli_robot.yaml via
+  // behavior_tree_node → BTContext), NOT hardcoded magic numbers. We set the
+  // knob each controller actually reads: FollowPath is RPP (via RotationShim),
+  // whose speed knob is desired_linear_vel; FollowCoveragePath is FTC, whose
+  // knob is speed_fast (it ignores desired_linear_vel — setting that was a
+  // long-standing no-op that left coverage speed unconfigurable here).
+  //
+  // "degraded" (Float-quality GPS) runs at half the configured speed, floored
+  // at the host min-drive clamp: hardware_bridge zeroes |vx| < kMinLinVel
+  // (0.15 m/s), so a half-speed below that would stall the robot entirely.
+  constexpr double kMinDriveSpeed = 0.15;
+  const double transit =
+      (mode == "precise") ? ctx->transit_speed : std::max(0.5 * ctx->transit_speed, kMinDriveSpeed);
+  const double mowing =
+      (mode == "precise") ? ctx->mowing_speed : std::max(0.5 * ctx->mowing_speed, kMinDriveSpeed);
+
+  const std::vector<rclcpp::Parameter> params = {
+      rclcpp::Parameter("FollowPath.desired_linear_vel", transit),
+      rclcpp::Parameter("FollowCoveragePath.speed_fast", mowing),
+  };
 
   param_client->set_parameters(params);
   ctx->current_nav_mode = mode;
 
-  RCLCPP_INFO(ctx->node->get_logger(), "SetNavMode: mode set to '%s'", mode.c_str());
+  RCLCPP_INFO(ctx->node->get_logger(),
+              "SetNavMode: mode '%s' — transit %.2f m/s, mowing %.2f m/s",
+              mode.c_str(),
+              transit,
+              mowing);
   return BT::NodeStatus::SUCCESS;
 }
 

--- a/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
+++ b/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
@@ -167,8 +167,8 @@ mowgli:
     # Mowing
     # -----------------------------------------------------------------
     mowing_enabled: true           # enable blade motor during mowing
-    mowing_speed: 0.5              # m/s during coverage paths
-    transit_speed: 0.5             # m/s during point-to-point navigation
+    mowing_speed: 0.2              # m/s during coverage paths (field-validated comfortable cut speed)
+    transit_speed: 0.25            # m/s during point-to-point navigation (→ RPP desired_linear_vel)
     outline_passes: 1              # perimeter passes before fill
     outline_overlap: 0.0           # overlap between outline and fill (m)
     outline_offset: 0.05           # inward offset from boundary (m)

--- a/ros2/src/mowgli_bringup/launch/full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/full_system.launch.py
@@ -211,6 +211,13 @@ def generate_launch_description() -> LaunchDescription:
             # the {undock_speed} blackboard reference in main_tree.xml.
             # See issue #191.
             {"undock_speed": float(robot_params.get("undock_speed", 0.15))},
+            # transit_speed / mowing_speed flow into SetNavMode, which sets
+            # them on the live controllers (FollowPath.desired_linear_vel for
+            # the RPP transit controller, FollowCoveragePath.speed_fast for the
+            # FTC coverage controller) per nav mode. Without these the BT used
+            # hardcoded 0.5/0.25 and the configured speeds never took effect.
+            {"transit_speed": float(robot_params.get("transit_speed", 0.25))},
+            {"mowing_speed": float(robot_params.get("mowing_speed", 0.2))},
         ],
     )
 


### PR DESCRIPTION
Promotes the field-validated drive speeds from the per-robot GUI config into the repo template `mowgli_robot.yaml`, so they ship as defaults rather than living only in an untracked per-robot file.

| key | before | after |
|---|---|---|
| `mowing_speed` (→ FTC `FollowCoveragePath.speed_fast`) | 0.5 | **0.2** |
| `transit_speed` (→ RPP `FollowPath.desired_linear_vel`) | 0.5 | **0.25** |

### Not changed (already in the repo)
- **RPP rotate-to-heading angular tuning** — `rotate_to_heading_angular_vel: 0.75`, `max_angular_accel: 2.5` (commit `22895931`, already on dev+main).
- **Docking controller speed** — `controller.v_linear_max: 0.25` / `v_linear_min: 0.16` in `nav2_params.yaml`.

### Deliberately left at 0.16
- `undock_speed` stays `0.16`. It must be **≥ the `kMinLinVel = 0.15` host clamp** (`hardware_bridge` zeroes `|vx| < 0.15`) — a lower value (e.g. 0.10) would be zeroed before the wheels move *and* sits below the brushed-DC PWM-40 deadband, so the robot wouldn't undock.

Config-only change under `ros2/**`; CI build/format will run.