### PR TITLE
fix(gui): populate features when restoring a map from file

### DIFF
--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -3,7 +3,7 @@ import {useApi} from "../hooks/useApi.ts";
 import {App} from "antd";
 import turfArea from "@turf/area";
 import React, {useCallback, useEffect, useMemo, useRef, useState} from "react";
-import {MapArea} from "../types/ros.ts";
+import {MapArea, Map as MapType} from "../types/ros.ts";
 import DrawControl from "../components/DrawControl.tsx";
 import Map, {Layer, Source} from 'react-map-gl/mapbox';
 import type {Map as MapboxMap} from 'mapbox-gl';
@@ -427,8 +427,19 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
         }, {} as Record<string, MowingFeatureBase>);
     }
 
-  
-
+    // Build the full editable feature set (areas, obstacles and dock) from a
+    // Map message. The stream-driven effect above does the same thing but is
+    // skipped while editMap is true, so map restore (which enters edit mode)
+    // calls this directly to populate the features it will save.
+    function buildFeaturesFromMap(m: MapType): Record<string, MowingFeature> {
+        const newFeatures: Record<string, MowingFeature> = {
+            ...buildFeatures(m.working_area ?? [], "area"),
+            ...buildFeatures(m.navigation_areas ?? [], "navigation"),
+        };
+        const dockLonLat = transpose(offsetX, offsetY, datum, m.dock_y ?? 0, m.dock_x ?? 0);
+        newFeatures["dock"] = new DockFeatureBase(dockLonLat, m.dock_heading ?? 0);
+        return newFeatures;
+    }
 
     const {
         handleSaveMap,
@@ -453,6 +464,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
         guiApi,
         dockDirty,
         setDockDirty,
+        buildFeaturesFromMap,
     });
 
 

--- a/gui/web/src/pages/map/hooks/useMapFiles.ts
+++ b/gui/web/src/pages/map/hooks/useMapFiles.ts
@@ -28,6 +28,10 @@ interface UseMapFilesOptions {
     guiApi: Api<unknown>;
     dockDirty: boolean;
     setDockDirty: (v: boolean) => void;
+    // Builds the editable feature set (areas, obstacles, dock) from a Map
+    // message. Needed by handleRestoreMap because the MapPage effect that
+    // normally does this is intentionally skipped while editMap is true.
+    buildFeaturesFromMap: (m: MapType) => Record<string, MowingFeature>;
 }
 
 export function useMapFiles({
@@ -44,6 +48,7 @@ export function useMapFiles({
     guiApi,
     dockDirty,
     setDockDirty,
+    buildFeaturesFromMap,
 }: UseMapFilesOptions) {
     async function handleSaveMap() {
         const areas: Record<string, MowgliMapArea[]> = {
@@ -209,6 +214,13 @@ export function useMapFiles({
                 const parts = content.split(",");
                 const newMap = JSON.parse(atob(parts[1])) as MapType;
                 setMap(newMap);
+                // The MapPage effect that turns a Map into editable features
+                // skips while editMap is true (set just above), so build them
+                // here — otherwise handleSaveMap would persist the stale
+                // features and the restored map would be silently discarded.
+                setFeatures(buildFeaturesFromMap(newMap));
+                setHasUnsavedChanges(true);
+                setDockDirty(true);
             });
             reader.readAsDataURL(file);
         });


### PR DESCRIPTION
## Problem

Restoring a map from a backup file silently discards the imported map and re-saves the previously displayed one.

`handleRestoreMap` sets `editMap = true` and then `setMap(newMap)`, but the `MapPage` effect that converts a `Map` message into editable `features` bails out early with `if (editMap) return`. So a restored map loads into `map` state but **never into `features`** — and `handleSaveMap` persists from `features`, re-saving the stale map.

## Fix

Build the editable feature set explicitly in `handleRestoreMap` via a new `buildFeaturesFromMap` helper (areas + navigation + dock), then mark unsaved changes and the dock dirty so Save persists the restored map and its dock pose.

The helper mirrors the stream-driven effect exactly (`buildFeatures(working_area)` + `buildFeatures(navigation_areas)` + `DockFeatureBase` from `dock_x/y/heading`); it exists only because that effect is intentionally skipped while `editMap` is true.

## Notes

- Rebased onto current `dev` (post GUI redesign); the restore flow and `if (editMap) return` short-circuit are unchanged upstream, so the fix still applies.
- `useMapFiles` gains a `buildFeaturesFromMap` prop and calls it in the restore load handler.