### PR TITLE
fix(fusion_graph): forward-stamp TF by 50ms on real hardware to fix stuck PRE_ROTATE

### DIFF
--- a/ros2/src/fusion_graph/config/fusion_graph.yaml
+++ b/ros2/src/fusion_graph/config/fusion_graph.yaml
@@ -210,8 +210,13 @@ fusion_graph_node:
     # sim_full_system.launch.py overrides to 0.1 because under
     # sim_time, Nav2 controller lookups would otherwise fall 1-3 ms
     # ahead of the latest publish and throw ExtrapolationException,
-    # freezing cmd_vel publication. On real hardware, 100 ms of lead
-    # costs ~5° of yaw error per pivot at 0.5 rad/s — visible in
-    # Foxglove and pushed into FTC's heading PID. Override key
+    # freezing cmd_vel publication. On real hardware the same race
+    # occurs during RotationShimController PRE_ROTATE: both the RSC
+    # and fusion_graph run at 10 Hz with no phase alignment, so the
+    # controller's clock regularly lands 10-50 ms ahead of the latest
+    # TF stamp and throws ExtrapolationException, collapsing cmd_vel
+    # throughput to ~2 Hz and stalling PRE_ROTATE indefinitely.
+    # 50 ms lead: max yaw artifact = 0.05 s × 0.75 rad/s ≈ 1.4°,
+    # well within FTC's heading PID correction range. Override key
     # (set by navigation.launch.py): fusion_graph_tf_lead_s.
-    tf_publish_lead_s: 0.0
+    tf_publish_lead_s: 0.05


### PR DESCRIPTION
## Problem

When `use_fusion_graph:=true`, transit gets permanently stuck in the RotationShimController's PRE_ROTATE phase — the robot rotates very slowly or not at all for the entire session, never progressing to coverage.

**Root cause:** RSC PRE_ROTATE calls `lookupTransform("map", "base_footprint", clock()->now())` at 10 Hz. With `tf_publish_lead_s: 0.0`, the `map→odom` TF is stamped at `t = publish_time`. Because fusion_graph and the controller both run at 10 Hz with no phase alignment, the controller's `now()` consistently lands a few ms *ahead* of the latest TF stamp. tf2 throws `ExtrapolationException`, the controller outputs zero `cmd_vel`, and PRE_ROTATE never converges.

The loop collapses from 10 Hz to ~2.7 Hz (each tick waits the full `transform_tolerance: 0.3 s` timeout before failing). Nav2 never aborts because tiny GPS drift oscillations satisfy the `progress_checker` angular-movement threshold over the 60 s window.

Observed on RPi4 (ARM) with RTK-Fixed GPS; heading error at transit start was ~51° which is just above the `angular_dist_threshold: 0.785 rad` (45°) gate that enables PRE_ROTATE.

## Fix

Set `tf_publish_lead_s: 0.05` for real hardware (was `0.0`).

The same mechanism was already used for sim (`tf_publish_lead_s: 0.1` via `sim_full_system.launch.py` override) — this extends it to hardware at half the value, which is sufficient to bracket the controller's clock at 10 Hz.

**Yaw artifact:** at peak PRE_ROTATE angular velocity (0.75 rad/s), 50 ms of forward stamp introduces at most `0.05 × 0.75 ≈ 1.4°` of apparent heading offset — well within FTC's heading PID correction range and not visible in GPS tracks.

## Test plan

- [ ] Transit from dock to coverage start with `use_fusion_graph:=true` — robot should rotate and drive to the first F2C waypoint within a few seconds of start
- [ ] Verify no ExtrapolationException in `docker logs mowgli-ros2` during PRE_ROTATE
- [ ] Verify mowing session completes normally (no stuck transit)
- [ ] `use_fusion_graph:=false` path unaffected (this parameter is ignored by `ekf_map_node`)