### PR TITLE
fix(behavior): wire undock_distance param to BT blackboard

### DIFF
--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -421,16 +421,17 @@ private:
     blackboard_->set("dock_pose", dock_pose);
     blackboard_->set("undock_pose", undock_pose);
 
-    // Undock reverse speed, sourced from mowgli_robot.yaml.undock_speed
-    // and consumed by the BackUp BT instances in main_tree.xml via the
-    // {undock_speed} blackboard reference. Previously the speed was
-    // hardcoded as a string attribute in three undock-flow BackUps,
-    // which kept the yaml value orphan — editing the GUI slider did
-    // nothing. Recovery-side BackUps (e.g. OBSTACLE_BACKOFF) intentionally
-    // stay hardcoded; they are not "undocking" so they should not move
-    // when the operator tunes undock speed. See issue #191.
+    // Undock reverse speed and distance, sourced from mowgli_robot.yaml and
+    // consumed by the BackUp BT instances in main_tree.xml via the
+    // {undock_speed} / {undock_distance} blackboard references. Previously
+    // both were hardcoded in the BT XML, so editing the YAML had no effect.
+    // Recovery-side BackUps (e.g. OBSTACLE_BACKOFF) intentionally stay
+    // hardcoded; they are not undocking and must not shift when the operator
+    // tunes undock distance. See issue #191.
     const double undock_speed = declare_parameter<double>("undock_speed", 0.15);
     blackboard_->set("undock_speed", undock_speed);
+    const double undock_distance = declare_parameter<double>("undock_distance", 1.0);
+    blackboard_->set("undock_distance", undock_distance);
 
     // Transit / mowing speeds, sourced from mowgli_robot.yaml and applied to
     // the live controllers by SetNavMode (FollowPath.desired_linear_vel for the

--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -266,17 +266,17 @@
                    a geometric distance to the dock pose that is fragile
                    when RTK drifts briefly near the metal canopy. BackUp is
                    deterministic — reverse at the given speed for the
-                   given distance. 1 m gives RTK ~5 s × 0.2 m/s of clean
-                   displacement for CalibrateHeadingFromUndock to resolve
-                   the initial heading accurately. -->
-              <BackUp backup_dist="1.0" backup_speed="{undock_speed}"/>
+                   given distance. undock_distance must be > 0.5 m so
+                   CalibrateHeadingFromUndock has enough GPS displacement
+                   to resolve the initial heading accurately. -->
+              <BackUp backup_dist="{undock_distance}" backup_speed="{undock_speed}"/>
               <!-- Wait for RTK Fixed after undock. The dock often has a
                    metal canopy that attenuates GPS; once the robot is 2 m
                    out the F9P should re-acquire quickly. Timeout proceeds
                    anyway at degraded precision rather than freeze. -->
               <WaitForGpsFix timeout_sec="20.0" min_fix_type="4"/>
-              <!-- Refine the EKF yaw from the 1 m of GPS-verified backward
-                   motion: heading = atan2(-dy, -dx). Sync, no extra motion.
+              <!-- Refine the EKF yaw from GPS-verified backward motion:
+                   heading = atan2(-dy, -dx). Sync, no extra motion.
                    Fails UndockSequence if GPS barely moved (robot stuck on
                    dock) so the BT retries the whole undock. -->
               <PublishHighLevelStatus state="2" state_name="CALIBRATING_HEADING"/>
@@ -369,7 +369,7 @@
                        uses geometric distance to dock pose which fails with
                        RTK drift near the dock canopy. BackUp reliably reverses
                        off the dock via Nav2 behavior_server. -->
-                        <BackUp backup_dist="1.5" backup_speed="{undock_speed}"/>
+                        <BackUp backup_dist="{undock_distance}" backup_speed="{undock_speed}"/>
                         <Sequence>
                           <RecordResumeUndockFailure/>
                           <ClearCommand/>
@@ -419,7 +419,7 @@
                    uses geometric distance to dock pose which fails with
                    RTK drift near the dock canopy. BackUp reliably reverses
                    off the dock via Nav2 behavior_server. -->
-              <BackUp backup_dist="1.5" backup_speed="{undock_speed}"/>
+              <BackUp backup_dist="{undock_distance}" backup_speed="{undock_speed}"/>
                     <Sequence>
                       <RecordResumeUndockFailure/>
                       <ClearCommand/>

--- a/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
+++ b/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
@@ -203,7 +203,7 @@ mowgli:
     # hand-entered phone-compass seed (239°) — NOT a valid ENU yaw;
     # recalibrate per-site before relying on docking.
     dock_pose_yaw: 4.17
-    undock_distance: 1.5           # reverse distance when undocking (m)
+    undock_distance: 1.0           # reverse distance when undocking (m); must be > 0.5 m for CalibrateHeadingFromUndock
     undock_speed: 0.16             # reverse speed (m/s) — above kMinLinVel=0.15 host clamp
     # Distance (m) to the staging pose behind the dock — the final
     # straight-in approach runway. Injected as opennav_docking

--- a/ros2/src/mowgli_bringup/launch/full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/full_system.launch.py
@@ -207,10 +207,11 @@ def generate_launch_description() -> LaunchDescription:
             # so they appear on the GUI Settings page.
             {"tick_rate": float(robot_params.get("tick_rate", 10.0))},
             {"bt_debug_logging": bool(robot_params.get("bt_debug_logging", False))},
-            # undock_speed is consumed by the BackUp BT instances via
-            # the {undock_speed} blackboard reference in main_tree.xml.
-            # See issue #191.
+            # undock_speed / undock_distance are consumed by the BackUp BT
+            # instances via {undock_speed} / {undock_distance} blackboard
+            # references in main_tree.xml. See issue #191.
             {"undock_speed": float(robot_params.get("undock_speed", 0.15))},
+            {"undock_distance": float(robot_params.get("undock_distance", 1.0))},
             # transit_speed / mowing_speed flow into SetNavMode, which sets
             # them on the live controllers (FollowPath.desired_linear_vel for
             # the RPP transit controller, FollowCoveragePath.speed_fast for the


### PR DESCRIPTION
## Problem

`undock_distance` in `mowgli_robot.yaml` was silently ignored. The three BackUp nodes in the undock flows (initial undock, rain-resume undock, battery-resume undock) all used hardcoded distances (1.0 m and 1.5 m respectively), so changing `undock_distance` in the YAML had no effect on robot behaviour.

`undock_speed` was already wired correctly (issue #191). `undock_distance` was the same pattern but never finished.

## Root cause

`undock_distance` was not declared as a ROS parameter in `behavior_tree_node.cpp` and not injected from `robot_params` in `full_system.launch.py`, so the BT blackboard never received it and the XML attributes `backup_dist="1.0"` / `"1.5"` were never parameterised.

## Fix

Exact same pattern as `undock_speed` (#191):

1. **`full_system.launch.py`** — inject `undock_distance` from `robot_params` alongside `undock_speed`
2. **`behavior_tree_node.cpp`** — `declare_parameter<double>("undock_distance", 1.0)` + `blackboard_->set("undock_distance", ...)`
3. **`main_tree.xml`** — replace `backup_dist="1.0"` / `"1.5"` with `backup_dist="{undock_distance}"` in the three undock-flow BackUp nodes; the obstacle-wedge recovery BackUp (`0.40 m`) stays hardcoded — it is not an undocking maneuver
4. **`mowgli_robot.yaml`** — default updated from 1.5 m → 1.0 m (the 1.5 m figure was the old resume-undock literal; 1.0 m is a more representative default); `CalibrateHeadingFromUndock` constraint (must be > 0.5 m) noted in the comment

## Test plan

- [ ] Set `undock_distance: 0.8` in `mowgli_robot.yaml`, start mowing — robot should reverse exactly 0.8 m on initial undock
- [ ] Same for rain-resume and battery-resume undock paths
- [ ] Obstacle-wedge recovery BackUp still reverses 0.40 m (unaffected)
- [ ] `CalibrateHeadingFromUndock` succeeds with `undock_distance` > 0.5 m; fails and retries as expected if set below 0.5 m