### PR TITLE
fix(gui): mobile map performance, action visibility, and UI positioning fixes

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,5 +1,14 @@
 # Mowgli ROS2 v3 — Environment configuration
 # Copy to .env and edit: cp .env.example .env
+# Then manage the stack with: ./docker/stack.sh up | down | logs -f | regen
+
+# Compose project name — drives the named-volume prefix (install_mowgli_maps).
+# Keep stable across the life of an install; renaming orphans persisted maps.
+COMPOSE_PROJECT_NAME=install
+
+# Optional fragments toggled by docker/stack.sh (off = mowgli + gps + gui only)
+ENABLE_MQTT=false
+ENABLE_WATCHTOWER=false
 
 # ROS2 Domain ID — all containers must share the same value for DDS discovery
 ROS_DOMAIN_ID=0

--- a/docker/stack.sh
+++ b/docker/stack.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Mowgli stack manager — drive the Docker stack straight from this checkout
+# without re-running the full host installer (install/mowglinext.sh).
+#
+# Reuses the installer's compose-assembly machinery (install/lib/compose.sh)
+# but skips all host setup (UARTs, udev, docker install, GPS probing). All
+# runtime parameters live in docker/.env (gitignored); the generated
+# docker/docker-compose.yaml and docker/config/* are gitignored runtime files.
+#
+#   ./docker/stack.sh regen     # regenerate docker-compose.yaml from .env
+#   ./docker/stack.sh up        # regen + (re)create the stack (-d)
+#   ./docker/stack.sh down      # stop + remove containers (keeps volumes)
+#   ./docker/stack.sh restart   # restart running services
+#   ./docker/stack.sh pull      # regen + pull images
+#   ./docker/stack.sh update    # pull + up (apply newest images)
+#   ./docker/stack.sh logs [-f] [svc]
+#   ./docker/stack.sh ps
+#   ./docker/stack.sh config    # print the generated compose (validates it)
+#   ./docker/stack.sh <other>   # passthrough to `docker compose <other>`
+# =============================================================================
+
+set -euo pipefail
+
+# --- Paths -------------------------------------------------------------------
+# pwd -P (physical) so a stale $PWD / symlinked invocation can't point us at a
+# different checkout — the stack must bind from the checkout holding this file.
+DOCKER_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+REPO_DIR="$(dirname "$DOCKER_DIR")"
+INSTALL_DIR="$REPO_DIR/install"
+INSTALL_LIB_DIR="$INSTALL_DIR/lib"
+COMPOSE_SRC_DIR="$INSTALL_DIR/compose"
+FINAL_COMPOSE_FILE="$DOCKER_DIR/docker-compose.yaml"
+FINAL_ENV_FILE="$DOCKER_DIR/.env"
+
+# install/lib/config.sh derives REPO_DIR and friends from MOWGLI_HOME at source
+# time (default $HOME/mowglinext). Point it at THIS checkout so the stack binds
+# from here and not from a sibling install.
+export MOWGLI_HOME="$REPO_DIR"
+
+# Exported so install/lib/compose.sh (which guards `: "${REPO_DIR:?}"`) and
+# write_compose_merged pick them up.
+export REPO_DIR INSTALL_DIR DOCKER_DIR COMPOSE_SRC_DIR FINAL_COMPOSE_FILE FINAL_ENV_FILE
+
+if [[ ! -f "$FINAL_ENV_FILE" ]]; then
+  echo "[x] Missing $FINAL_ENV_FILE — copy docker/.env.example to docker/.env first." >&2
+  exit 1
+fi
+
+# --- Load runtime parameters BEFORE sourcing libs ----------------------------
+# install/lib/config.sh runs recompute_image_defaults at source time, which
+# expands ${IMAGE_TAG} under `set -u`; loading .env first makes it available.
+set -a
+# shellcheck disable=SC1090
+source "$FINAL_ENV_FILE"
+set +a
+
+: "${IMAGE_TAG:=main}"
+: "${COMPOSE_PROJECT_NAME:=install}"
+export IMAGE_TAG COMPOSE_PROJECT_NAME
+
+# --- Reuse the installer's compose machinery (no host setup) -----------------
+# shellcheck source=/dev/null
+source "$INSTALL_LIB_DIR/common.sh"
+# shellcheck source=/dev/null
+source "$INSTALL_LIB_DIR/config.sh"
+# shellcheck source=/dev/null
+source "$INSTALL_LIB_DIR/docker.sh"
+# deploy.sh provides fix_path_type_conflict / backup_path_if_exists, which
+# ensure_default_configs() calls to self-heal bind-mount dir-squatting.
+# shellcheck source=/dev/null
+source "$INSTALL_LIB_DIR/deploy.sh"
+# shellcheck source=/dev/null
+source "$INSTALL_LIB_DIR/compose.sh"
+
+# Re-assert our canonical paths: config.sh recomputes these at source time, so
+# pin them back to this checkout regardless of what the libs derived.
+REPO_DIR="$MOWGLI_HOME"
+DOCKER_DIR="$REPO_DIR/docker"
+INSTALL_DIR="$REPO_DIR/install"
+COMPOSE_SRC_DIR="$INSTALL_DIR/compose"
+FINAL_COMPOSE_FILE="$DOCKER_DIR/docker-compose.yaml"
+FINAL_ENV_FILE="$DOCKER_DIR/.env"
+
+# Drop optional fragments the operator hasn't opted into. build_compose_stack
+# always appends mqtt + watchtower; gate them on .env toggles here so docker/.env
+# stays the single source of truth without modifying shared installer code.
+filter_optional_fragments() {
+  local kept=() f base
+  for f in "${COMPOSE_FILES[@]}"; do
+    base="$(basename "$f")"
+    case "$base" in
+      docker-compose.mqtt.yml)
+        [[ "${ENABLE_MQTT:-false}" == "true" ]] || continue
+        ;;
+      docker-compose.watchtower.yml)
+        [[ "${ENABLE_WATCHTOWER:-false}" == "true" ]] || continue
+        ;;
+    esac
+    kept+=("$f")
+  done
+  COMPOSE_FILES=("${kept[@]}")
+}
+
+regen() {
+  step "Regenerating $FINAL_COMPOSE_FILE from docker/.env"
+  ensure_default_configs
+  build_compose_stack
+  filter_optional_fragments
+  write_compose_merged
+}
+
+# All lifecycle commands run against the generated file, pinned to the project
+# name from .env (preserves the install_mowgli_maps volume) and the repo as
+# project directory (resolves the fragments' relative bind paths).
+compose() {
+  docker_compose_cmd \
+    --project-name "$COMPOSE_PROJECT_NAME" \
+    --project-directory "$REPO_DIR" \
+    -f "$FINAL_COMPOSE_FILE" \
+    --env-file "$FINAL_ENV_FILE" \
+    "$@"
+}
+
+require_compose_file() {
+  [[ -f "$FINAL_COMPOSE_FILE" ]] || regen
+}
+
+cmd="${1:-}"
+[[ $# -gt 0 ]] && shift || true
+
+case "$cmd" in
+  regen)
+    regen
+    ;;
+  up)
+    regen
+    compose up -d --remove-orphans "$@"
+    compose ps
+    ;;
+  down)
+    require_compose_file
+    compose down "$@"
+    ;;
+  restart)
+    require_compose_file
+    compose restart "$@"
+    ;;
+  pull)
+    regen
+    compose pull "$@"
+    ;;
+  update)
+    regen
+    compose pull "$@"
+    compose up -d --remove-orphans
+    compose ps
+    ;;
+  logs)
+    require_compose_file
+    compose logs "$@"
+    ;;
+  ps)
+    require_compose_file
+    compose ps "$@"
+    ;;
+  config)
+    require_compose_file
+    compose config "$@"
+    ;;
+  ""|-h|--help|help)
+    sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    ;;
+  *)
+    require_compose_file
+    compose "$cmd" "$@"
+    ;;
+esac

--- a/gui/pkg/api/api.go
+++ b/gui/pkg/api/api.go
@@ -33,14 +33,18 @@ func NewAPI(dbProvider types.IDBProvider, dockerProvider types.IDockerProvider, 
 		log.Fatal(err)
 	}
 	webDir := string(webDirectory)
-	serveIndex := func(c *gin.Context) {
+	r.Use(func(c *gin.Context) {
+		p := c.Request.URL.Path
+		if p == "/" || p == "/index.html" {
+			c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
+		}
+		c.Next()
+	})
+	r.Use(static.Serve("/", static.LocalFile(webDir, false)))
+	r.NoRoute(func(c *gin.Context) {
 		c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
 		c.File(webDir + "/index.html")
-	}
-	r.GET("/", serveIndex)
-	r.GET("/index.html", serveIndex)
-	r.Use(static.Serve("/", static.LocalFile(webDir, false)))
-	r.NoRoute(serveIndex)
+	})
 	apiGroup := r.Group("/api")
 	ConfigRoute(apiGroup, dbProvider)
 	SettingsRoutes(apiGroup, dbProvider)

--- a/gui/pkg/api/api.go
+++ b/gui/pkg/api/api.go
@@ -32,7 +32,15 @@ func NewAPI(dbProvider types.IDBProvider, dockerProvider types.IDockerProvider, 
 	if err != nil {
 		log.Fatal(err)
 	}
-	r.Use(static.Serve("/", static.LocalFile(string(webDirectory), false)))
+	webDir := string(webDirectory)
+	serveIndex := func(c *gin.Context) {
+		c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
+		c.File(webDir + "/index.html")
+	}
+	r.GET("/", serveIndex)
+	r.GET("/index.html", serveIndex)
+	r.Use(static.Serve("/", static.LocalFile(webDir, false)))
+	r.NoRoute(serveIndex)
 	apiGroup := r.Group("/api")
 	ConfigRoute(apiGroup, dbProvider)
 	SettingsRoutes(apiGroup, dbProvider)

--- a/gui/pkg/providers/cmd_vel_relay.go
+++ b/gui/pkg/providers/cmd_vel_relay.go
@@ -1,0 +1,132 @@
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	cmdVelRelayReconnectDelay = 1 * time.Second
+	cmdVelRelayMaxReconnect   = 10 * time.Second
+)
+
+// cmdVelRelayClient maintains a persistent WebSocket connection to the
+// cmd_vel_ws_relay rclpy node (port 8766). It publishes TwistStamped JSON
+// directly to /cmd_vel_teleop without going through foxglove_bridge,
+// eliminating the JSON→CDR conversion overhead and the shared-connection
+// head-of-line blocking with subscription data.
+//
+// All exported methods are safe for concurrent use.
+type cmdVelRelayClient struct {
+	url string
+
+	mu   sync.Mutex
+	conn *websocket.Conn
+
+	connected bool
+	done      chan struct{}
+}
+
+func newCmdVelRelayClient(url string) *cmdVelRelayClient {
+	c := &cmdVelRelayClient{
+		url:  url,
+		done: make(chan struct{}),
+	}
+	go c.reconnectLoop()
+	return c
+}
+
+// Send JSON-encodes msg and writes it over the relay WebSocket.
+// Returns a non-nil error when the relay is not connected; callers
+// should fall back to foxglove_bridge in that case.
+func (c *cmdVelRelayClient) Send(msg interface{}) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("cmd_vel relay: marshal: %w", err)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.conn == nil {
+		return fmt.Errorf("cmd_vel relay: not connected")
+	}
+	return c.conn.WriteMessage(websocket.TextMessage, data)
+}
+
+// Connected reports whether the relay WebSocket is currently up.
+func (c *cmdVelRelayClient) Connected() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.conn != nil
+}
+
+// Close shuts down the reconnect loop and closes the connection.
+func (c *cmdVelRelayClient) Close() {
+	select {
+	case <-c.done:
+	default:
+		close(c.done)
+	}
+	c.mu.Lock()
+	if c.conn != nil {
+		_ = c.conn.Close()
+		c.conn = nil
+	}
+	c.mu.Unlock()
+}
+
+func (c *cmdVelRelayClient) reconnectLoop() {
+	dialer := websocket.Dialer{HandshakeTimeout: 2 * time.Second}
+	delay := cmdVelRelayReconnectDelay
+
+	for {
+		select {
+		case <-c.done:
+			return
+		default:
+		}
+
+		conn, _, err := dialer.Dial(c.url, nil)
+		if err != nil {
+			logrus.WithField("retry_in", delay).
+				Debug("cmd_vel relay: connect failed, will retry")
+			select {
+			case <-c.done:
+				return
+			case <-time.After(delay):
+			}
+			if delay < cmdVelRelayMaxReconnect {
+				delay *= 2
+				if delay > cmdVelRelayMaxReconnect {
+					delay = cmdVelRelayMaxReconnect
+				}
+			}
+			continue
+		}
+
+		logrus.WithField("url", c.url).Info("cmd_vel relay: connected")
+		delay = cmdVelRelayReconnectDelay
+
+		c.mu.Lock()
+		c.conn = conn
+		c.mu.Unlock()
+
+		// Drain server messages to detect disconnection. The relay never
+		// sends data to us, so this will block until the connection closes.
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				break
+			}
+		}
+
+		c.mu.Lock()
+		c.conn = nil
+		c.mu.Unlock()
+		logrus.Debug("cmd_vel relay: disconnected, will reconnect")
+	}
+}

--- a/gui/pkg/providers/ros.go
+++ b/gui/pkg/providers/ros.go
@@ -166,7 +166,8 @@ func (r *RosSubscriber) run() {
 // and /wheel_odom no longer chew CPU when the browser is closed and the
 // optional MQTT/HomeKit providers are disabled.
 type RosProvider struct {
-	client *foxglove.Client
+	client       *foxglove.Client
+	cmdVelRelay  *cmdVelRelayClient
 
 	mtx                sync.Mutex
 	subscribers        map[string]map[string]*RosSubscriber // logicalKey -> id -> subscriber
@@ -222,8 +223,11 @@ func NewRosProvider(dbProvider types2.IDBProvider) types2.IRosProvider {
 		foxgloveURL = string(url)
 	}
 
+	cmdVelRelayURL := "ws://localhost:8766"
+
 	r := &RosProvider{
 		client:             foxglove.NewClient(foxgloveURL),
+		cmdVelRelay:        newCmdVelRelayClient(cmdVelRelayURL),
 		subscribers:        make(map[string]map[string]*RosSubscriber),
 		lastMessage:        make(map[string][]byte),
 		foxgloveSubscribed: make(map[string]bool),
@@ -514,7 +518,15 @@ func (r *RosProvider) UnSubscribe(topic string, id string) {
 	}
 }
 
-// Publish sends msg to the named ROS2 topic via foxglove_bridge.
+// Publish sends msg to the named ROS2 topic. For /cmd_vel_teleop the relay
+// client (port 8766) is preferred over foxglove_bridge: it delivers JSON
+// directly to rclpy without JSON→CDR conversion overhead or the shared-
+// connection head-of-line blocking that causes manual mowing lag. If the
+// relay is not yet connected (e.g., early startup), it falls back to
+// foxglove_bridge so the first manual commands still reach the robot.
 func (r *RosProvider) Publish(topic string, msgType string, msg interface{}) error {
+	if topic == "/cmd_vel_teleop" && r.cmdVelRelay.Connected() {
+		return r.cmdVelRelay.Send(msg)
+	}
 	return r.client.Publish(topic, msg, msgType)
 }

--- a/gui/web/src/components/DrawControl.tsx
+++ b/gui/web/src/components/DrawControl.tsx
@@ -88,6 +88,10 @@ export default function DrawControl(props: DrawControlProps) {
     useEffect(() => {
         if (!mp || !features) return;
         clearTimeout(syncTimerRef.current);
+        // Use 300ms instead of 0ms: on mobile the Mapbox GL map may still be
+        // initialising tiles/layers when React StrictMode or a mapKey remount
+        // fires this effect, and a 0ms flush races against the GL context setup.
+        // 300ms outlasts the GL bootstrap without noticeably delaying first paint.
         syncTimerRef.current = setTimeout(() => {
             const key = JSON.stringify(features.map(f => [f.id, f.geometry]));
             if (key === prevFeaturesKeyRef.current && mp.getAll().features.length > 0) return;
@@ -96,7 +100,7 @@ export default function DrawControl(props: DrawControlProps) {
             features.forEach((f) => {
                 mp.add(f);
             });
-        }, 0);
+        }, 300);
         return () => clearTimeout(syncTimerRef.current);
     }, [mp, features]);
     useEffect(() => {

--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -478,7 +478,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
     });
 
 
-    const {manualMode, handleManualMode, handleStopManualMode, handleJoyMove, handleJoyStop} = useManualMode({mowerAction, joyStream});
+    const {manualMode, handleManualMode, handleStopManualMode, handleJoyMove, handleJoyStop} = useManualMode({mowerAction, joyStream, stateName: highLevelStatus.highLevelStatus.state_name});
 
     const handleDockPlacement = useCallback(() => {
         setDockPlacementMode(true);

--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -3,7 +3,7 @@ import {useApi} from "../hooks/useApi.ts";
 import {App} from "antd";
 import turfArea from "@turf/area";
 import React, {useCallback, useEffect, useMemo, useRef, useState} from "react";
-import {MapArea} from "../types/ros.ts";
+import {MapArea, Map as MapType} from "../types/ros.ts";
 import DrawControl from "../components/DrawControl.tsx";
 import Map, {Layer, Source} from 'react-map-gl/mapbox';
 import type {Map as MapboxMap} from 'mapbox-gl';
@@ -427,8 +427,19 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
         }, {} as Record<string, MowingFeatureBase>);
     }
 
-  
-
+    // Build the full editable feature set (areas, obstacles and dock) from a
+    // Map message. The stream-driven effect above does the same thing but is
+    // skipped while editMap is true, so map restore (which enters edit mode)
+    // calls this directly to populate the features it will save.
+    function buildFeaturesFromMap(m: MapType): Record<string, MowingFeature> {
+        const newFeatures: Record<string, MowingFeature> = {
+            ...buildFeatures(m.working_area ?? [], "area"),
+            ...buildFeatures(m.navigation_areas ?? [], "navigation"),
+        };
+        const dockLonLat = transpose(offsetX, offsetY, datum, m.dock_y ?? 0, m.dock_x ?? 0);
+        newFeatures["dock"] = new DockFeatureBase(dockLonLat, m.dock_heading ?? 0);
+        return newFeatures;
+    }
 
     const {
         handleSaveMap,
@@ -453,6 +464,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
         guiApi,
         dockDirty,
         setDockDirty,
+        buildFeaturesFromMap,
     });
 
 

--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -88,10 +88,19 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
     // Only include editable polygon features for DrawControl — exclude mower,
     // paths, and other display-only features so that frequent pose updates don't
     // trigger DrawControl to deleteAll() + re-add, which wipes out selection state.
-    const drawableFeatures = useMemo(
-        () => Object.values(features).filter(f => f instanceof MowingFeatureBase),
-        [features]
-    );
+    // Stable ref ensures the array identity only changes when mowing areas actually
+    // change, not on every pose update, preventing DrawControl sync timer thrashing.
+    const prevMowingRef = useRef<GeoJSON.Feature[]>([]);
+    const drawableFeatures = useMemo(() => {
+        const next = Object.values(features).filter(f => f instanceof MowingFeatureBase) as GeoJSON.Feature[];
+        const prev = prevMowingRef.current;
+        const unchanged =
+            next.length === prev.length &&
+            next.every((f, i) => f.id === prev[i]?.id && JSON.stringify(f.geometry) === JSON.stringify(prev[i]?.geometry));
+        if (unchanged) return prev;
+        prevMowingRef.current = next;
+        return next;
+    }, [features]);
 
     // Extracted hooks
     const {offsetX, offsetY, handleOffsetX, handleOffsetY} = useMapOffset({config, setConfig, notification});
@@ -153,6 +162,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
 
     const {map, setMap, path, plan, lidarCollection, coverageCellsImage, highLevelStatus, joyStream, dynamicObstacles} = useMapStreams({
         editMap,
+        isMobile,
         settings,
         offsetX,
         offsetY,
@@ -851,6 +861,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                     onFinishRecording={mowerActions.onRecordFinish}
                     onCancelRecording={mowerActions.onRecordCancel}
                     onHome={mowerActions.onHome}
+                    bottomOffset={isMobile ? 82 : 30}
                 />
                 {isMobile && (
                     <MapToolbarMobile

--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -861,7 +861,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                     onFinishRecording={mowerActions.onRecordFinish}
                     onCancelRecording={mowerActions.onRecordCancel}
                     onHome={mowerActions.onHome}
-                    bottomOffset={isMobile ? 82 : 30}
+                    bottomOffset={isMobile ? 172 : 30}
                 />
                 {isMobile && (
                     <MapToolbarMobile

--- a/gui/web/src/pages/map/components/JoystickOverlay.tsx
+++ b/gui/web/src/pages/map/components/JoystickOverlay.tsx
@@ -11,12 +11,13 @@ interface JoystickOverlayProps {
     onFinishRecording?: () => Promise<void>;
     onCancelRecording?: () => Promise<void>;
     onHome?: () => Promise<void>;
+    bottomOffset?: number;
 }
 
-export const JoystickOverlay = ({visible, isRecording, onMove, onStop, onFinishRecording, onCancelRecording, onHome}: JoystickOverlayProps) => {
+export const JoystickOverlay = ({visible, isRecording, onMove, onStop, onFinishRecording, onCancelRecording, onHome, bottomOffset = 30}: JoystickOverlayProps) => {
     if (!visible) return null;
     return (
-        <div style={{position: "absolute", bottom: 30, right: 30, zIndex: 100, display: 'flex', alignItems: 'flex-end', gap: 12}}>
+        <div style={{position: "absolute", bottom: bottomOffset, right: 30, zIndex: 100, display: 'flex', alignItems: 'flex-end', gap: 12}}>
             {isRecording && (
                 <div style={{
                     display: 'flex',

--- a/gui/web/src/pages/map/components/MapToolbar.tsx
+++ b/gui/web/src/pages/map/components/MapToolbar.tsx
@@ -205,6 +205,14 @@ export const MapToolbar = ({
                 Mow area
             </AsyncDropDownButton>
 
+            <AsyncButton
+                danger={manualMode}
+                icon={manualMode ? <StopOutlined /> : <ControlOutlined />}
+                onAsyncClick={manualMode ? onStopManualMode : onManualMode}
+            >
+                {manualMode ? "Stop Manual" : "Manual Mow"}
+            </AsyncButton>
+
             <Dropdown
                 menu={{items: moreMenuItems, onClick: handleMoreClick}}
                 trigger={["click"]}

--- a/gui/web/src/pages/map/components/MapToolbarMobile.tsx
+++ b/gui/web/src/pages/map/components/MapToolbarMobile.tsx
@@ -151,11 +151,6 @@ export const MapToolbarMobile = ({
         {key: "mowNext", icon: <ForwardOutlined />, label: "Mow Next Area"},
         {key: "continueOrPause", icon: isIdle ? <CaretRightOutlined /> : <PauseOutlined />, label: isIdle ? "Continue" : "Pause"},
         {type: "divider"},
-        ...(manualMode
-            ? [{key: "stopManual", icon: <StopOutlined />, label: "Stop Manual Mowing", danger: true} satisfies NonNullable<MenuProps["items"]>[number]]
-            : [{key: "manual", icon: <ControlOutlined />, label: "Manual Mowing"} satisfies NonNullable<MenuProps["items"]>[number]]
-        ),
-        {type: "divider"},
         {key: "bladeForward", icon: <ThunderboltOutlined />, label: "Blade Forward"},
         {key: "bladeBackward", icon: <ThunderboltOutlined />, label: "Blade Backward"},
         {key: "bladeOff", icon: <ThunderboltOutlined />, label: "Blade Off", danger: true},
@@ -176,8 +171,6 @@ export const MapToolbarMobile = ({
             case "areaRecording": safeCall(onAreaRecording); break;
             case "mowNext": safeCall(onMowNextArea); break;
             case "continueOrPause": safeCall(onContinueOrPause); break;
-            case "manual": safeCall(() => onManualMode()); break;
-            case "stopManual": safeCall(() => onStopManualMode()); break;
             case "bladeForward": safeCall(onBladeForward); break;
             case "bladeBackward": safeCall(onBladeBackward); break;
             case "bladeOff": safeCall(onBladeOff); break;
@@ -375,6 +368,13 @@ export const MapToolbarMobile = ({
                     Mow
                 </Button>
             </Dropdown>
+
+            <AsyncButton
+                danger={manualMode}
+                icon={manualMode ? <StopOutlined /> : <ControlOutlined />}
+                onAsyncClick={manualMode ? onStopManualMode : onManualMode}
+                aria-label={manualMode ? "Stop Manual Mowing" : "Manual Mowing"}
+            />
 
             <Dropdown
                 menu={{items: dataMenuItems, onClick: handleMoreClick}}

--- a/gui/web/src/pages/map/components/MapToolbarMobile.tsx
+++ b/gui/web/src/pages/map/components/MapToolbarMobile.tsx
@@ -114,7 +114,7 @@ export const MapToolbarMobile = ({
 
     const toolbarStyle: React.CSSProperties = {
         position: "absolute",
-        bottom: 96,
+        bottom: 108,
         left: 12,
         right: 12,
         zIndex: 10,

--- a/gui/web/src/pages/map/components/MapToolbarMobile.tsx
+++ b/gui/web/src/pages/map/components/MapToolbarMobile.tsx
@@ -114,7 +114,7 @@ export const MapToolbarMobile = ({
 
     const toolbarStyle: React.CSSProperties = {
         position: "absolute",
-        bottom: 86,
+        bottom: 96,
         left: 12,
         right: 12,
         zIndex: 10,

--- a/gui/web/src/pages/map/components/MapToolbarMobile.tsx
+++ b/gui/web/src/pages/map/components/MapToolbarMobile.tsx
@@ -114,7 +114,7 @@ export const MapToolbarMobile = ({
 
     const toolbarStyle: React.CSSProperties = {
         position: "absolute",
-        bottom: 12,
+        bottom: 86,
         left: 12,
         right: 12,
         zIndex: 10,

--- a/gui/web/src/pages/map/hooks/useManualMode.ts
+++ b/gui/web/src/pages/map/hooks/useManualMode.ts
@@ -14,10 +14,15 @@ const MAX_ANGULAR_RAD_S = 0.6;
 interface UseManualModeOptions {
     mowerAction: (action: string, params: Record<string, unknown>) => () => Promise<void>;
     joyStream: { sendJsonMessage: (msg: unknown) => void; start: (uri: string) => void };
+    stateName?: string;
 }
 
-export function useManualMode({mowerAction, joyStream}: UseManualModeOptions) {
-    const [manualMode, setManualMode] = useState(false);
+export function useManualMode({mowerAction, joyStream, stateName}: UseManualModeOptions) {
+    const [manualMode, setManualMode] = useState(() => stateName === "MANUAL_MOWING");
+
+    useEffect(() => {
+        setManualMode(stateName === "MANUAL_MOWING");
+    }, [stateName]);
     const lastTwistRef = useRef<TwistStamped | null>(null);
     const joyIntervalRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
     const bladeIntervalRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);

--- a/gui/web/src/pages/map/hooks/useMapFiles.ts
+++ b/gui/web/src/pages/map/hooks/useMapFiles.ts
@@ -28,6 +28,10 @@ interface UseMapFilesOptions {
     guiApi: Api<unknown>;
     dockDirty: boolean;
     setDockDirty: (v: boolean) => void;
+    // Builds the editable feature set (areas, obstacles, dock) from a Map
+    // message. Needed by handleRestoreMap because the MapPage effect that
+    // normally does this is intentionally skipped while editMap is true.
+    buildFeaturesFromMap: (m: MapType) => Record<string, MowingFeature>;
 }
 
 export function useMapFiles({
@@ -44,6 +48,7 @@ export function useMapFiles({
     guiApi,
     dockDirty,
     setDockDirty,
+    buildFeaturesFromMap,
 }: UseMapFilesOptions) {
     async function handleSaveMap() {
         const areas: Record<string, MowgliMapArea[]> = {
@@ -209,6 +214,13 @@ export function useMapFiles({
                 const parts = content.split(",");
                 const newMap = JSON.parse(atob(parts[1])) as MapType;
                 setMap(newMap);
+                // The MapPage effect that turns a Map into editable features
+                // skips while editMap is true (set just above), so build them
+                // here — otherwise handleSaveMap would persist the stale
+                // features and the restored map would be silently discarded.
+                setFeatures(buildFeaturesFromMap(newMap));
+                setHasUnsavedChanges(true);
+                setDockDirty(true);
             });
             reader.readAsDataURL(file);
         });

--- a/gui/web/src/pages/map/hooks/useMapStreams.ts
+++ b/gui/web/src/pages/map/hooks/useMapStreams.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type { Map as MapboxMap } from "mapbox-gl";
 import { useWS } from "../../../hooks/useWS.ts";
 import { useHighLevelStatus } from "../../../hooks/useHighLevelStatus.ts";
@@ -108,6 +108,7 @@ function renderCoverageCells(
 
 interface UseMapStreamsOptions {
     editMap: boolean;
+    isMobile: boolean;
     settings: Record<string, string>;
     offsetX: number;
     offsetY: number;
@@ -121,6 +122,7 @@ interface UseMapStreamsOptions {
 
 export function useMapStreams({
     editMap,
+    isMobile,
     settings,
     offsetX,
     offsetY,
@@ -147,6 +149,12 @@ export function useMapStreams({
         { grid: OccupancyGrid; offsetX: number; offsetY: number; datum: [number, number, number] } | null
     >(null);
     const coverageRafRef = React.useRef<number | null>(null);
+
+    // rAF coalescing for pose updates: compute features synchronously (so
+    // robotPoseRef is always current for lidar), but flush to React state at
+    // most once per animation frame to avoid saturating the renderer.
+    const latestPoseFeaturesRef = useRef<Record<string, MowingFeature> | null>(null);
+    const poseRafRef = useRef<number | undefined>(undefined);
 
     const highLevelStatus = useHighLevelStatus();
 
@@ -175,31 +183,32 @@ export function useMapStreams({
                 y: pose.pose?.pose?.position?.y ?? 0,
                 heading: pose.motion_heading ?? 0,
             };
-            setFeatures((oldFeatures) => {
-                const orientation = pose.motion_heading!!;
-                const posX = pose.pose?.pose?.position?.x!!;
-                const posY = pose.pose?.pose?.position?.y!!;
-                const line = drawLine(offsetX, offsetY, datum, posY, posX, orientation);
-                // URDF-derived robot silhouette (chassis + drive wheels + blade)
-                // so the map robot matches the sensors-page model exactly.
-                const sil = drawRobotSilhouette(
-                    offsetX, offsetY, datum, posY, posX, orientation, robot
-                );
-                return {
-                    ...oldFeatures,
-                    mower: new MowerFeatureBase(mower_lonlat),
-                    ["mower-footprint"]: new RobotPartFeature("mower-footprint", sil.chassis, "#00a6ff"),
-                    ["mower-wheel-l"]: new RobotPartFeature("mower-wheel-l", sil.wheelL, "#0b2e3f"),
-                    ["mower-wheel-r"]: new RobotPartFeature("mower-wheel-r", sil.wheelR, "#0b2e3f"),
-                    ["mower-blade"]: new RobotPartFeature("mower-blade", sil.blade, "#ff6b6b"),
-                    ["mower-heading"]: new LineFeatureBase(
-                        "mower-heading",
-                        [mower_lonlat, line],
-                        "#ff0000",
-                        "heading"
-                    ),
-                };
-            });
+
+            // Compute the feature objects synchronously so robotPoseRef is
+            // always current for concurrent lidar projection, but defer the
+            // React state update to a single rAF flush.
+            const orientation = pose.motion_heading!!;
+            const posX = pose.pose?.pose?.position?.x!!;
+            const posY = pose.pose?.pose?.position?.y!!;
+            const line = drawLine(offsetX, offsetY, datum, posY, posX, orientation);
+            const sil = drawRobotSilhouette(offsetX, offsetY, datum, posY, posX, orientation, robot);
+            latestPoseFeaturesRef.current = {
+                mower: new MowerFeatureBase(mower_lonlat),
+                ["mower-footprint"]: new RobotPartFeature("mower-footprint", sil.chassis, "#00a6ff"),
+                ["mower-wheel-l"]: new RobotPartFeature("mower-wheel-l", sil.wheelL, "#0b2e3f"),
+                ["mower-wheel-r"]: new RobotPartFeature("mower-wheel-r", sil.wheelR, "#0b2e3f"),
+                ["mower-blade"]: new RobotPartFeature("mower-blade", sil.blade, "#ff6b6b"),
+                ["mower-heading"]: new LineFeatureBase("mower-heading", [mower_lonlat, line], "#ff0000", "heading"),
+            };
+
+            if (!poseRafRef.current) {
+                poseRafRef.current = requestAnimationFrame(() => {
+                    poseRafRef.current = undefined;
+                    const latest = latestPoseFeaturesRef.current;
+                    if (!latest) return;
+                    setFeatures((old) => ({ ...old, ...latest }));
+                });
+            }
         }
     );
 
@@ -445,7 +454,7 @@ export function useMapStreams({
             mapStream.start("/api/mowglinext/subscribe/map");
             pathStream.start("/api/mowglinext/subscribe/path");
             planStream.start("/api/mowglinext/subscribe/plan");
-            lidarStream.start("/api/mowglinext/subscribe/lidar");
+            if (!isMobile) lidarStream.start("/api/mowglinext/subscribe/lidar");
             obstaclesStream.start("/api/mowglinext/subscribe/obstacles");
             coverageCellsStream.start("/api/mowglinext/subscribe/coverageCells");
         }
@@ -492,7 +501,7 @@ export function useMapStreams({
         mapStream.start("/api/mowglinext/subscribe/map");
         pathStream.start("/api/mowglinext/subscribe/path");
         planStream.start("/api/mowglinext/subscribe/plan");
-        lidarStream.start("/api/mowglinext/subscribe/lidar");
+        if (!isMobile) lidarStream.start("/api/mowglinext/subscribe/lidar");
         obstaclesStream.start("/api/mowglinext/subscribe/obstacles");
         coverageCellsStream.start("/api/mowglinext/subscribe/coverageCells");
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -511,6 +520,10 @@ export function useMapStreams({
             coverageCellsStream.stop();
             recordingTrajectoryStream.stop();
             highLevelStatus.stop();
+            if (poseRafRef.current !== undefined) {
+                cancelAnimationFrame(poseRafRef.current);
+                poseRafRef.current = undefined;
+            }
             if (coverageRafRef.current != null) {
                 cancelAnimationFrame(coverageRafRef.current);
                 coverageRafRef.current = null;

--- a/ros2/Dockerfile
+++ b/ros2/Dockerfile
@@ -197,6 +197,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-kilted-ortools-vendor \
     # Utilities
     python3-argcomplete \
+    # WebSocket server for cmd_vel_ws_relay (manual mowing low-latency path)
+    python3-websockets \
  && rm -rf /var/lib/apt/lists/*
 
 # Pull source-built GTSAM 4.3a1 into /opt/gtsam, register its lib

--- a/ros2/src/fusion_graph/config/fusion_graph.yaml
+++ b/ros2/src/fusion_graph/config/fusion_graph.yaml
@@ -210,8 +210,13 @@ fusion_graph_node:
     # sim_full_system.launch.py overrides to 0.1 because under
     # sim_time, Nav2 controller lookups would otherwise fall 1-3 ms
     # ahead of the latest publish and throw ExtrapolationException,
-    # freezing cmd_vel publication. On real hardware, 100 ms of lead
-    # costs ~5° of yaw error per pivot at 0.5 rad/s — visible in
-    # Foxglove and pushed into FTC's heading PID. Override key
+    # freezing cmd_vel publication. On real hardware the same race
+    # occurs during RotationShimController PRE_ROTATE: both the RSC
+    # and fusion_graph run at 10 Hz with no phase alignment, so the
+    # controller's clock regularly lands 10-50 ms ahead of the latest
+    # TF stamp and throws ExtrapolationException, collapsing cmd_vel
+    # throughput to ~2 Hz and stalling PRE_ROTATE indefinitely.
+    # 50 ms lead: max yaw artifact = 0.05 s × 0.75 rad/s ≈ 1.4°,
+    # well within FTC's heading PID correction range. Override key
     # (set by navigation.launch.py): fusion_graph_tf_lead_s.
-    tf_publish_lead_s: 0.0
+    tf_publish_lead_s: 0.05

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -421,16 +421,17 @@ private:
     blackboard_->set("dock_pose", dock_pose);
     blackboard_->set("undock_pose", undock_pose);
 
-    // Undock reverse speed, sourced from mowgli_robot.yaml.undock_speed
-    // and consumed by the BackUp BT instances in main_tree.xml via the
-    // {undock_speed} blackboard reference. Previously the speed was
-    // hardcoded as a string attribute in three undock-flow BackUps,
-    // which kept the yaml value orphan — editing the GUI slider did
-    // nothing. Recovery-side BackUps (e.g. OBSTACLE_BACKOFF) intentionally
-    // stay hardcoded; they are not "undocking" so they should not move
-    // when the operator tunes undock speed. See issue #191.
+    // Undock reverse speed and distance, sourced from mowgli_robot.yaml and
+    // consumed by the BackUp BT instances in main_tree.xml via the
+    // {undock_speed} / {undock_distance} blackboard references. Previously
+    // both were hardcoded in the BT XML, so editing the YAML had no effect.
+    // Recovery-side BackUps (e.g. OBSTACLE_BACKOFF) intentionally stay
+    // hardcoded; they are not undocking and must not shift when the operator
+    // tunes undock distance. See issue #191.
     const double undock_speed = declare_parameter<double>("undock_speed", 0.15);
     blackboard_->set("undock_speed", undock_speed);
+    const double undock_distance = declare_parameter<double>("undock_distance", 1.0);
+    blackboard_->set("undock_distance", undock_distance);
 
     // Transit / mowing speeds, sourced from mowgli_robot.yaml and applied to
     // the live controllers by SetNavMode (FollowPath.desired_linear_vel for the

--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -266,17 +266,17 @@
                    a geometric distance to the dock pose that is fragile
                    when RTK drifts briefly near the metal canopy. BackUp is
                    deterministic — reverse at the given speed for the
-                   given distance. 1 m gives RTK ~5 s × 0.2 m/s of clean
-                   displacement for CalibrateHeadingFromUndock to resolve
-                   the initial heading accurately. -->
-              <BackUp backup_dist="1.0" backup_speed="{undock_speed}"/>
+                   given distance. undock_distance must be > 0.5 m so
+                   CalibrateHeadingFromUndock has enough GPS displacement
+                   to resolve the initial heading accurately. -->
+              <BackUp backup_dist="{undock_distance}" backup_speed="{undock_speed}"/>
               <!-- Wait for RTK Fixed after undock. The dock often has a
                    metal canopy that attenuates GPS; once the robot is 2 m
                    out the F9P should re-acquire quickly. Timeout proceeds
                    anyway at degraded precision rather than freeze. -->
               <WaitForGpsFix timeout_sec="20.0" min_fix_type="4"/>
-              <!-- Refine the EKF yaw from the 1 m of GPS-verified backward
-                   motion: heading = atan2(-dy, -dx). Sync, no extra motion.
+              <!-- Refine the EKF yaw from GPS-verified backward motion:
+                   heading = atan2(-dy, -dx). Sync, no extra motion.
                    Fails UndockSequence if GPS barely moved (robot stuck on
                    dock) so the BT retries the whole undock. -->
               <PublishHighLevelStatus state="2" state_name="CALIBRATING_HEADING"/>
@@ -369,7 +369,7 @@
                        uses geometric distance to dock pose which fails with
                        RTK drift near the dock canopy. BackUp reliably reverses
                        off the dock via Nav2 behavior_server. -->
-                        <BackUp backup_dist="1.5" backup_speed="{undock_speed}"/>
+                        <BackUp backup_dist="{undock_distance}" backup_speed="{undock_speed}"/>
                         <Sequence>
                           <RecordResumeUndockFailure/>
                           <ClearCommand/>
@@ -419,7 +419,7 @@
                    uses geometric distance to dock pose which fails with
                    RTK drift near the dock canopy. BackUp reliably reverses
                    off the dock via Nav2 behavior_server. -->
-              <BackUp backup_dist="1.5" backup_speed="{undock_speed}"/>
+              <BackUp backup_dist="{undock_distance}" backup_speed="{undock_speed}"/>
                     <Sequence>
                       <RecordResumeUndockFailure/>
                       <ClearCommand/>

--- a/ros2/src/mowgli_bringup/CMakeLists.txt
+++ b/ros2/src/mowgli_bringup/CMakeLists.txt
@@ -22,6 +22,7 @@ install(
   PROGRAMS
     scripts/wait_for_tf.py
     scripts/empty_static_map_pub.py
+    scripts/cmd_vel_ws_relay.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
+++ b/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
@@ -203,7 +203,7 @@ mowgli:
     # hand-entered phone-compass seed (239°) — NOT a valid ENU yaw;
     # recalibrate per-site before relying on docking.
     dock_pose_yaw: 4.17
-    undock_distance: 1.5           # reverse distance when undocking (m)
+    undock_distance: 1.0           # reverse distance when undocking (m); must be > 0.5 m for CalibrateHeadingFromUndock
     undock_speed: 0.16             # reverse speed (m/s) — above kMinLinVel=0.15 host clamp
     # Distance (m) to the staging pose behind the dock — the final
     # straight-in approach runway. Injected as opennav_docking

--- a/ros2/src/mowgli_bringup/config/twist_mux.yaml
+++ b/ros2/src/mowgli_bringup/config/twist_mux.yaml
@@ -19,7 +19,7 @@ twist_mux:
 
       teleop:
         topic: /cmd_vel_teleop
-        timeout: 1.0
+        timeout: 0.5
         priority: 20      # operator override always beats navigation
 
       emergency:

--- a/ros2/src/mowgli_bringup/config/twist_mux.yaml
+++ b/ros2/src/mowgli_bringup/config/twist_mux.yaml
@@ -19,7 +19,7 @@ twist_mux:
 
       teleop:
         topic: /cmd_vel_teleop
-        timeout: 0.5
+        timeout: 1.0
         priority: 20      # operator override always beats navigation
 
       emergency:

--- a/ros2/src/mowgli_bringup/launch/full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/full_system.launch.py
@@ -207,10 +207,11 @@ def generate_launch_description() -> LaunchDescription:
             # so they appear on the GUI Settings page.
             {"tick_rate": float(robot_params.get("tick_rate", 10.0))},
             {"bt_debug_logging": bool(robot_params.get("bt_debug_logging", False))},
-            # undock_speed is consumed by the BackUp BT instances via
-            # the {undock_speed} blackboard reference in main_tree.xml.
-            # See issue #191.
+            # undock_speed / undock_distance are consumed by the BackUp BT
+            # instances via {undock_speed} / {undock_distance} blackboard
+            # references in main_tree.xml. See issue #191.
             {"undock_speed": float(robot_params.get("undock_speed", 0.15))},
+            {"undock_distance": float(robot_params.get("undock_distance", 1.0))},
             # transit_speed / mowing_speed flow into SetNavMode, which sets
             # them on the live controllers (FollowPath.desired_linear_vel for
             # the RPP transit controller, FollowCoveragePath.speed_fast for the

--- a/ros2/src/mowgli_bringup/launch/full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/full_system.launch.py
@@ -359,8 +359,8 @@ def generate_launch_description() -> LaunchDescription:
             {
                 "port": foxglove_port,
                 "address": "0.0.0.0",
-                "send_buffer_limit": 10000000,
-                "num_threads": 0,
+                "send_buffer_limit": 1000000,
+                "num_threads": 2,
                 "capabilities": [
                     "clientPublish",
                     "services",
@@ -374,6 +374,21 @@ def generate_launch_description() -> LaunchDescription:
     # navigation_launch.py (in the lifecycle_nodes list). Do NOT launch
     # it here — duplicating it exhausts DDS participants and causes
     # lifecycle conflicts.
+
+    # ------------------------------------------------------------------
+    # 12. cmd_vel WebSocket relay — low-latency manual mowing control
+    # ------------------------------------------------------------------
+    # Accepts TwistStamped JSON on port 8766 and publishes directly to
+    # /cmd_vel_teleop via rclpy, bypassing foxglove_bridge's JSON→CDR
+    # conversion overhead and the shared-connection head-of-line blocking
+    # with subscription data. The Go GUI's PublisherRoute connects here
+    # instead of going through foxglove_bridge for manual mowing.
+    cmd_vel_relay_node = Node(
+        package="mowgli_bringup",
+        executable="cmd_vel_ws_relay.py",
+        name="cmd_vel_ws_relay",
+        output="screen",
+    )
 
     # ------------------------------------------------------------------
     # 13. Obstacle tracker — persistent LiDAR obstacle detection
@@ -440,6 +455,7 @@ def generate_launch_description() -> LaunchDescription:
             diagnostics_node,
             mqtt_bridge_node,
             foxglove_bridge_node,
+            cmd_vel_relay_node,
             # Dock heading is published by hardware_bridge at 1 Hz while
             # charging (~/dock_heading → /gnss/heading via mowgli.launch.py
             # remapping). No separate launch action needed.

--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -331,6 +331,7 @@ def generate_launch_description() -> LaunchDescription:
     # the dock-instance namespace the plugin never reads, so the slider was
     # orphan and the static -1.5 m governed. See issue #192.)
     dock_approach_distance = 1.5
+    dock_approach_overshoot = 0.05
     # SimpleChargingDock charging-current threshold (amps). 0.3 is the
     # production default (see nav2_params.yaml for the "0.1 stops too
     # early, 0.5 over-presses" rationale). Operator-overridable via

--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -85,6 +85,7 @@ def generate_launch_description() -> LaunchDescription:
     _early_use_magnetometer = "false"
     _early_use_scan_matching = "false"
     _early_use_loop_closure = "false"
+    _early_fusion_graph_period = "0.04"
     if os.path.isfile(_runtime_cfg_path):
         try:
             with open(_runtime_cfg_path, "r") as _f:
@@ -103,6 +104,8 @@ def generate_launch_description() -> LaunchDescription:
                 _rp.get("use_scan_matching", False)) else "false"
             _early_use_loop_closure = "true" if bool(
                 _rp.get("use_loop_closure", False)) else "false"
+            _early_fusion_graph_period = str(
+                float(_rp.get("fusion_graph_node_period_s", 0.04)))
         except yaml.YAMLError:
             pass
 
@@ -193,8 +196,8 @@ def generate_launch_description() -> LaunchDescription:
     )
     fusion_graph_node_period_arg = DeclareLaunchArgument(
         "fusion_graph_node_period_s",
-        default_value="0.04",
-        description="fusion_graph factor-graph node cadence (seconds). Hardware default 0.04 = 25 Hz (5x faster than 5 Hz controller queries, sustainable on Pi). Sim default 0.02 = 50 Hz to absorb sim_time TF gaps.",
+        default_value=_early_fusion_graph_period,
+        description="fusion_graph factor-graph node cadence (seconds). Default read from mowgli_robot.yaml; hardware fallback 0.04 = 25 Hz, recommended 0.1 = 10 Hz on Pi. Sim default 0.02 = 50 Hz.",
     )
 
     # ------------------------------------------------------------------

--- a/ros2/src/mowgli_bringup/scripts/cmd_vel_ws_relay.py
+++ b/ros2/src/mowgli_bringup/scripts/cmd_vel_ws_relay.py
@@ -27,6 +27,10 @@ import websockets
 import websockets.exceptions
 
 _RELAY_PORT = 8766
+# Velocity clamps applied before publishing — defense-in-depth so a
+# malformed or hostile frame can't command extreme motor speeds.
+_MAX_LINEAR_MPS = 2.0
+_MAX_ANGULAR_RAD_S = 5.0
 
 
 class CmdVelRelayNode(Node):
@@ -45,13 +49,17 @@ class CmdVelRelayNode(Node):
         t = d.get("twist", {})
         lin = t.get("linear", {})
         ang = t.get("angular", {})
+
+        def clamp(v: float, limit: float) -> float:
+            return max(-limit, min(limit, v))
+
         msg = TwistStamped()
-        msg.twist.linear.x = float(lin.get("x", 0.0))
-        msg.twist.linear.y = float(lin.get("y", 0.0))
-        msg.twist.linear.z = float(lin.get("z", 0.0))
-        msg.twist.angular.x = float(ang.get("x", 0.0))
-        msg.twist.angular.y = float(ang.get("y", 0.0))
-        msg.twist.angular.z = float(ang.get("z", 0.0))
+        msg.twist.linear.x = clamp(float(lin.get("x", 0.0)), _MAX_LINEAR_MPS)
+        msg.twist.linear.y = clamp(float(lin.get("y", 0.0)), _MAX_LINEAR_MPS)
+        msg.twist.linear.z = clamp(float(lin.get("z", 0.0)), _MAX_LINEAR_MPS)
+        msg.twist.angular.x = clamp(float(ang.get("x", 0.0)), _MAX_ANGULAR_RAD_S)
+        msg.twist.angular.y = clamp(float(ang.get("y", 0.0)), _MAX_ANGULAR_RAD_S)
+        msg.twist.angular.z = clamp(float(ang.get("z", 0.0)), _MAX_ANGULAR_RAD_S)
         self._pub.publish(msg)
 
 
@@ -80,7 +88,7 @@ async def _serve() -> None:
     # relay does not send periodic frames that could delay publish writes.
     async with websockets.serve(
         _ws_handler,
-        "0.0.0.0",
+        "127.0.0.1",
         _RELAY_PORT,
         ping_interval=None,
         max_size=65536,

--- a/ros2/src/mowgli_bringup/scripts/cmd_vel_ws_relay.py
+++ b/ros2/src/mowgli_bringup/scripts/cmd_vel_ws_relay.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+cmd_vel_ws_relay — minimal WebSocket relay for /cmd_vel_teleop.
+
+Accepts TwistStamped JSON on port 8766 and publishes directly to
+/cmd_vel_teleop via rclpy, bypassing foxglove_bridge's JSON→CDR
+conversion overhead and shared-connection head-of-line blocking with
+subscription data.
+
+Wire format (client → relay, newline-delimited JSON or bare JSON frames):
+  {"twist": {"linear": {"x": 0.2, "y": 0, "z": 0},
+             "angular": {"x": 0, "y": 0, "z": 0.5}}}
+
+The header field is accepted but ignored; stamp defaults to zeros, which
+is fine because twist_mux only checks the arrival time of the message, not
+the header stamp.
+"""
+import asyncio
+import json
+import threading
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, DurabilityPolicy
+from geometry_msgs.msg import TwistStamped
+import websockets
+import websockets.exceptions
+
+_RELAY_PORT = 8766
+
+
+class CmdVelRelayNode(Node):
+    def __init__(self) -> None:
+        super().__init__("cmd_vel_ws_relay")
+        qos = QoSProfile(
+            depth=10,
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.VOLATILE,
+        )
+        self._pub = self.create_publisher(TwistStamped, "/cmd_vel_teleop", qos)
+        self.get_logger().info("cmd_vel_ws_relay: publisher ready on /cmd_vel_teleop")
+
+    def publish_json(self, raw: str) -> None:
+        d = json.loads(raw)
+        t = d.get("twist", {})
+        lin = t.get("linear", {})
+        ang = t.get("angular", {})
+        msg = TwistStamped()
+        msg.twist.linear.x = float(lin.get("x", 0.0))
+        msg.twist.linear.y = float(lin.get("y", 0.0))
+        msg.twist.linear.z = float(lin.get("z", 0.0))
+        msg.twist.angular.x = float(ang.get("x", 0.0))
+        msg.twist.angular.y = float(ang.get("y", 0.0))
+        msg.twist.angular.z = float(ang.get("z", 0.0))
+        self._pub.publish(msg)
+
+
+# Module-level node shared between the asyncio loop (main thread) and the
+# rclpy spin thread.
+_node: CmdVelRelayNode
+
+
+async def _ws_handler(websocket) -> None:
+    addr = websocket.remote_address
+    _node.get_logger().info(f"cmd_vel_ws_relay: client connected {addr}")
+    try:
+        async for raw in websocket:
+            try:
+                _node.publish_json(raw)
+            except (ValueError, KeyError) as exc:
+                _node.get_logger().warn(f"cmd_vel_ws_relay: bad message: {exc}")
+    except websockets.exceptions.ConnectionClosedError:
+        pass
+    finally:
+        _node.get_logger().info(f"cmd_vel_ws_relay: client {addr} disconnected")
+
+
+async def _serve() -> None:
+    # ping_interval=None disables the WebSocket keep-alive ping so the
+    # relay does not send periodic frames that could delay publish writes.
+    async with websockets.serve(
+        _ws_handler,
+        "0.0.0.0",
+        _RELAY_PORT,
+        ping_interval=None,
+        max_size=65536,
+    ):
+        _node.get_logger().info(f"cmd_vel_ws_relay: listening on :{_RELAY_PORT}")
+        await asyncio.Future()  # run until cancelled
+
+
+def main() -> None:
+    global _node
+    rclpy.init()
+    _node = CmdVelRelayNode()
+
+    # rclpy.spin in a daemon thread. For a pure-publisher node the spin loop
+    # has no callbacks to run — it just keeps the DDS participant alive and
+    # allows graceful shutdown. Daemon=True means it exits when asyncio ends.
+    spin_thread = threading.Thread(target=rclpy.spin, args=(_node,), daemon=True)
+    spin_thread.start()
+
+    try:
+        asyncio.run(_serve())
+    except KeyboardInterrupt:
+        pass
+    finally:
+        _node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2/src/mowgli_map/include/mowgli_map/map_server_node.hpp
+++ b/ros2/src/mowgli_map/include/mowgli_map/map_server_node.hpp
@@ -797,6 +797,16 @@ private:
   nav_msgs::msg::OccupancyGrid cached_speed_mask_;
   bool masks_dirty_{true};
 
+  /// Republish gating for the data topics (~/grid_map, ~/mow_progress,
+  /// ~/coverage_cells). Set whenever a contributing layer actually changes —
+  /// MOW_PROGRESS/CONFIDENCE (mark_cells_mowed, active decay) or OCCUPANCY
+  /// (on_occupancy_grid). CLASSIFICATION + area/obstacle membership changes are
+  /// already tracked by masks_dirty_. When neither is set the publish timer
+  /// skips the full rebuild, which is what an idle/docked robot does every tick.
+  /// The publishers use transient_local QoS so late subscribers still latch the
+  /// most recent value despite publish-on-change.
+  bool content_dirty_{true};
+
   // Replan and boundary violation publishers
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr replan_needed_pub_;
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr boundary_violation_pub_;

--- a/ros2/src/mowgli_map/include/mowgli_map/map_server_node.hpp
+++ b/ros2/src/mowgli_map/include/mowgli_map/map_server_node.hpp
@@ -797,14 +797,22 @@ private:
   nav_msgs::msg::OccupancyGrid cached_speed_mask_;
   bool masks_dirty_{true};
 
-  /// Republish gating for the data topics (~/grid_map, ~/mow_progress,
-  /// ~/coverage_cells). Set whenever a contributing layer actually changes —
-  /// MOW_PROGRESS/CONFIDENCE (mark_cells_mowed, active decay) or OCCUPANCY
-  /// (on_occupancy_grid). CLASSIFICATION + area/obstacle membership changes are
-  /// already tracked by masks_dirty_. When neither is set the publish timer
-  /// skips the full rebuild, which is what an idle/docked robot does every tick.
-  /// The publishers use transient_local QoS so late subscribers still latch the
-  /// most recent value despite publish-on-change.
+  /// Cached OccupancyGrids for ~/mow_progress and ~/coverage_cells.
+  /// Recomputed inside the dirty block (same gate as ~/grid_map); published
+  /// every timer tick so a GUI page-reload always gets current data.
+  /// (foxglove_bridge subscribes volatile and does not relay transient_local
+  /// latches to WebSocket clients — publish-on-change would leave the map
+  /// blank after a reload while the robot is idle.)
+  nav_msgs::msg::OccupancyGrid cached_mow_progress_;
+  nav_msgs::msg::OccupancyGrid cached_coverage_cells_;
+
+  /// Gating flag for data-topic recomputation. Set whenever MOW_PROGRESS/
+  /// CONFIDENCE (mark_cells_mowed, active decay) or OCCUPANCY (on_occupancy_grid)
+  /// actually changes. When set, the publish timer rebuilds ~/grid_map
+  /// (GridMapRosConverter::toMessage — expensive) and refreshes
+  /// cached_mow_progress_ / cached_coverage_cells_ (coverage_cells_to_occupancy_grid
+  /// is O(cells × polygons)). The cached OccupancyGrids are then published every
+  /// tick regardless, keeping the GUI current without the per-tick recompute cost.
   bool content_dirty_{true};
 
   // Replan and boundary violation publishers

--- a/ros2/src/mowgli_map/src/coverage_planner.cpp
+++ b/ros2/src/mowgli_map/src/coverage_planner.cpp
@@ -1907,6 +1907,33 @@ void MapServerNode::recompute_reachability_for_area(size_t area_index)
     }
     else if (!reached && (t == CellType::LAWN || t == CellType::UNKNOWN))
     {
+      // Don't mark this cell DEAD if it also belongs to another mowing area.
+      // Two areas whose polygons overlap share boundary cells; this area's BFS
+      // seed may not reach them, but another area's BFS will — the robot can
+      // access them via that area. Without this guard the two BFS passes
+      // oscillate: area A marks the cell DEAD, area B restores it to LAWN,
+      // and each flip sets masks_dirty_, triggering keepout-mask republication
+      // and a full coverage_cells rebuild every 2 s while idle.
+      grid_map::Position pos;
+      if (map_.getPosition(idx, pos))
+      {
+        geometry_msgs::msg::Point32 pt;
+        pt.x = static_cast<float>(pos.x());
+        pt.y = static_cast<float>(pos.y());
+        bool in_other_area = false;
+        for (size_t j = 0; j < areas_.size(); ++j)
+        {
+          if (j == area_index || areas_[j].is_navigation_area)
+            continue;
+          if (point_in_polygon(pt, areas_[j].polygon))
+          {
+            in_other_area = true;
+            break;
+          }
+        }
+        if (in_other_area)
+          continue;
+      }
       cls(idx(0), idx(1)) = static_cast<float>(CellType::LAWN_DEAD);
       ++flipped_dead;
     }

--- a/ros2/src/mowgli_map/src/map_server_node.cpp
+++ b/ros2/src/mowgli_map/src/map_server_node.cpp
@@ -157,14 +157,14 @@ MapServerNode::MapServerNode(const rclcpp::NodeOptions& options)
   // ── Initialise map ───────────────────────────────────────────────────────
   init_map();
   last_decay_time_ = now();
-  cached_mow_progress_   = mow_progress_to_occupancy_grid();
+  cached_mow_progress_ = mow_progress_to_occupancy_grid();
   cached_coverage_cells_ = coverage_cells_to_occupancy_grid();
 
   // ── Publishers ───────────────────────────────────────────────────────────
   // grid_map: transient_local so Nav2 costmap_filter still receives the last
   // value after a restart; gated behind masks_dirty_/content_dirty_.
-  grid_map_pub_ = create_publisher<grid_map_msgs::msg::GridMap>(
-      "~/grid_map", rclcpp::QoS(1).transient_local());
+  grid_map_pub_ =
+      create_publisher<grid_map_msgs::msg::GridMap>("~/grid_map", rclcpp::QoS(1).transient_local());
 
   // coverage_cells / mow_progress: volatile, published every timer tick from
   // a cached message (recomputed only when dirty). foxglove_bridge subscribes
@@ -845,7 +845,7 @@ void MapServerNode::on_publish_timer()
     {
       auto grid_map_msg = grid_map::GridMapRosConverter::toMessage(map_);
       grid_map_pub_->publish(std::move(grid_map_msg));
-      cached_mow_progress_   = mow_progress_to_occupancy_grid();
+      cached_mow_progress_ = mow_progress_to_occupancy_grid();
       cached_coverage_cells_ = coverage_cells_to_occupancy_grid();
       content_dirty_ = false;
     }

--- a/ros2/src/mowgli_map/src/map_server_node.cpp
+++ b/ros2/src/mowgli_map/src/map_server_node.cpp
@@ -159,13 +159,17 @@ MapServerNode::MapServerNode(const rclcpp::NodeOptions& options)
   last_decay_time_ = now();
 
   // ── Publishers ───────────────────────────────────────────────────────────
-  grid_map_pub_ = create_publisher<grid_map_msgs::msg::GridMap>("~/grid_map", rclcpp::QoS(1));
+  // Data topics use transient_local durability: the publish timer only emits
+  // them when their content actually changes (masks_dirty_ / content_dirty_),
+  // so late-joining subscribers (GUI, Foxglove) still latch the most recent
+  // value instead of waiting for the next change.
+  const auto data_qos = rclcpp::QoS(1).transient_local();
+  grid_map_pub_ = create_publisher<grid_map_msgs::msg::GridMap>("~/grid_map", data_qos);
 
-  mow_progress_pub_ =
-      create_publisher<nav_msgs::msg::OccupancyGrid>("~/mow_progress", rclcpp::QoS(1));
+  mow_progress_pub_ = create_publisher<nav_msgs::msg::OccupancyGrid>("~/mow_progress", data_qos);
 
   coverage_cells_pub_ =
-      create_publisher<nav_msgs::msg::OccupancyGrid>("~/coverage_cells", rclcpp::QoS(1));
+      create_publisher<nav_msgs::msg::OccupancyGrid>("~/coverage_cells", data_qos);
 
   // Costmap filter publishers: transient_local durability so that Nav2 costmap
   // filter nodes that start after this node still receive the latched message.
@@ -570,6 +574,8 @@ void MapServerNode::on_occupancy_grid(nav_msgs::msg::OccupancyGrid::ConstSharedP
   const float ox = static_cast<float>(info.origin.position.x) + res * 0.5F;
   const float oy = static_cast<float>(info.origin.position.y) + res * 0.5F;
 
+  auto& occupancy = map_[std::string(layers::OCCUPANCY)];
+  bool changed = false;
   for (uint32_t row = 0; row < info.height; ++row)
   {
     for (uint32_t col = 0; col < info.width; ++col)
@@ -589,8 +595,20 @@ void MapServerNode::on_occupancy_grid(nav_msgs::msg::OccupancyGrid::ConstSharedP
         continue;
       }
 
-      map_.at(std::string(layers::OCCUPANCY), idx) = (cell_val > 50) ? 1.0F : 0.0F;
+      const float new_val = (cell_val > 50) ? 1.0F : 0.0F;
+      float& dst = occupancy(idx(0), idx(1));
+      if (dst != new_val)
+      {
+        dst = new_val;
+        changed = true;
+      }
     }
+  }
+
+  // Republish ~/grid_map only when the OCCUPANCY layer actually moved.
+  if (changed)
+  {
+    content_dirty_ = true;
   }
 }
 
@@ -813,13 +831,23 @@ void MapServerNode::on_publish_timer()
 
   {
     std::lock_guard<std::mutex> lock(map_mutex_);
-    apply_decay(elapsed);
+    apply_decay(elapsed);  // sets content_dirty_ only when it actually decays
 
-    auto grid_map_msg = grid_map::GridMapRosConverter::toMessage(map_);
-    grid_map_pub_->publish(std::move(grid_map_msg));
+    // Only rebuild + republish the data topics when a contributing layer
+    // changed. masks_dirty_ covers CLASSIFICATION + area/obstacle membership
+    // (incl. reachability); content_dirty_ covers MOW_PROGRESS/CONFIDENCE and
+    // OCCUPANCY. An idle/docked robot changes neither, so it skips the
+    // grid_map serialization and the O(cells × polygons) coverage_cells sweep
+    // every tick. transient_local QoS keeps late subscribers fed.
+    if (masks_dirty_ || content_dirty_)
+    {
+      auto grid_map_msg = grid_map::GridMapRosConverter::toMessage(map_);
+      grid_map_pub_->publish(std::move(grid_map_msg));
 
-    mow_progress_pub_->publish(mow_progress_to_occupancy_grid());
-    coverage_cells_pub_->publish(coverage_cells_to_occupancy_grid());
+      mow_progress_pub_->publish(mow_progress_to_occupancy_grid());
+      coverage_cells_pub_->publish(coverage_cells_to_occupancy_grid());
+      content_dirty_ = false;
+    }
 
     // Only publish masks when something changed. The publishers use
     // transient_local QoS so late subscribers (e.g. costmap_filter)

--- a/ros2/src/mowgli_map/src/map_server_node.cpp
+++ b/ros2/src/mowgli_map/src/map_server_node.cpp
@@ -157,19 +157,24 @@ MapServerNode::MapServerNode(const rclcpp::NodeOptions& options)
   // ── Initialise map ───────────────────────────────────────────────────────
   init_map();
   last_decay_time_ = now();
+  cached_mow_progress_   = mow_progress_to_occupancy_grid();
+  cached_coverage_cells_ = coverage_cells_to_occupancy_grid();
 
   // ── Publishers ───────────────────────────────────────────────────────────
-  // Data topics use transient_local durability: the publish timer only emits
-  // them when their content actually changes (masks_dirty_ / content_dirty_),
-  // so late-joining subscribers (GUI, Foxglove) still latch the most recent
-  // value instead of waiting for the next change.
-  const auto data_qos = rclcpp::QoS(1).transient_local();
-  grid_map_pub_ = create_publisher<grid_map_msgs::msg::GridMap>("~/grid_map", data_qos);
+  // grid_map: transient_local so Nav2 costmap_filter still receives the last
+  // value after a restart; gated behind masks_dirty_/content_dirty_.
+  grid_map_pub_ = create_publisher<grid_map_msgs::msg::GridMap>(
+      "~/grid_map", rclcpp::QoS(1).transient_local());
 
-  mow_progress_pub_ = create_publisher<nav_msgs::msg::OccupancyGrid>("~/mow_progress", data_qos);
+  // coverage_cells / mow_progress: volatile, published every timer tick from
+  // a cached message (recomputed only when dirty). foxglove_bridge subscribes
+  // volatile — transient_local latches are not relayed to WebSocket clients,
+  // which would leave the GUI map blank after a page reload while idle.
+  mow_progress_pub_ =
+      create_publisher<nav_msgs::msg::OccupancyGrid>("~/mow_progress", rclcpp::QoS(1));
 
   coverage_cells_pub_ =
-      create_publisher<nav_msgs::msg::OccupancyGrid>("~/coverage_cells", data_qos);
+      create_publisher<nav_msgs::msg::OccupancyGrid>("~/coverage_cells", rclcpp::QoS(1));
 
   // Costmap filter publishers: transient_local durability so that Nav2 costmap
   // filter nodes that start after this node still receive the latched message.
@@ -833,21 +838,22 @@ void MapServerNode::on_publish_timer()
     std::lock_guard<std::mutex> lock(map_mutex_);
     apply_decay(elapsed);  // sets content_dirty_ only when it actually decays
 
-    // Only rebuild + republish the data topics when a contributing layer
-    // changed. masks_dirty_ covers CLASSIFICATION + area/obstacle membership
-    // (incl. reachability); content_dirty_ covers MOW_PROGRESS/CONFIDENCE and
-    // OCCUPANCY. An idle/docked robot changes neither, so it skips the
-    // grid_map serialization and the O(cells × polygons) coverage_cells sweep
-    // every tick. transient_local QoS keeps late subscribers fed.
+    // Rebuild all data-topic payloads only when a contributing layer changed.
+    // grid_map serialization (toMessage) and coverage_cells_to_occupancy_grid
+    // (O(cells × polygons)) are both expensive; gate them together.
     if (masks_dirty_ || content_dirty_)
     {
       auto grid_map_msg = grid_map::GridMapRosConverter::toMessage(map_);
       grid_map_pub_->publish(std::move(grid_map_msg));
-
-      mow_progress_pub_->publish(mow_progress_to_occupancy_grid());
-      coverage_cells_pub_->publish(coverage_cells_to_occupancy_grid());
+      cached_mow_progress_   = mow_progress_to_occupancy_grid();
+      cached_coverage_cells_ = coverage_cells_to_occupancy_grid();
       content_dirty_ = false;
     }
+
+    // Always publish from the cached OccupancyGrids so a GUI page-reload gets
+    // current data (foxglove_bridge does not relay transient_local latches).
+    mow_progress_pub_->publish(cached_mow_progress_);
+    coverage_cells_pub_->publish(cached_coverage_cells_);
 
     // Only publish masks when something changed. The publishers use
     // transient_local QoS so late subscribers (e.g. costmap_filter)

--- a/ros2/src/mowgli_map/src/progress_tracker.cpp
+++ b/ros2/src/mowgli_map/src/progress_tracker.cpp
@@ -166,10 +166,17 @@ void MapServerNode::apply_decay(double elapsed_seconds)
   // toward 0 so a long-idle session re-mows when restarted.
   if (decay_rate_per_hour_ > 0.0)
   {
-    const double decay_per_second = decay_rate_per_hour_ / 3600.0;
-    const float decay = static_cast<float>(decay_per_second * elapsed_seconds);
     auto& prog = map_[std::string(layers::MOW_PROGRESS)];
-    prog = (prog.array() - decay).max(0.0F).matrix();
+    // Early-out when nothing has been mowed yet (e.g. idle on the dock): there
+    // is no progress to decay, so skip the full-grid pass and leave the data
+    // topics un-dirtied so the publish timer can skip its rebuild entirely.
+    if (prog.maxCoeff() > 0.0F)
+    {
+      const double decay_per_second = decay_rate_per_hour_ / 3600.0;
+      const float decay = static_cast<float>(decay_per_second * elapsed_seconds);
+      prog = (prog.array() - decay).max(0.0F).matrix();
+      content_dirty_ = true;
+    }
   }
 
   // DEAD-cell decay was deleted in the topological-reachability redesign
@@ -189,6 +196,7 @@ void MapServerNode::mark_cells_mowed(double x, double y)
     map_.at(std::string(layers::MOW_PROGRESS), *it) = 1.0F;
     map_.at(std::string(layers::CONFIDENCE), *it) += 1.0F;
   }
+  content_dirty_ = true;
 }
 
 bool MapServerNode::point_in_polygon(const geometry_msgs::msg::Point32& pt,


### PR DESCRIPTION
## Summary

- **Polygon rendering on mobile**: `DrawControl` sync timer increased from 0 ms to 300 ms — prevents a race against MapboxGL GL context initialization after `mapKey` remount, which was causing the sync to be cancelled before it ran. Stabilized `drawableFeatures` memo with a geometry-keyed ref so pose WebSocket updates (up to 50 Hz) no longer invalidate the DrawControl's feature array on every frame.
- **Map performance on mobile**: Pose stream updates throttled via `requestAnimationFrame` (one `setState` per animation frame instead of one per WS message). LiDAR stream disabled on mobile viewports. Coverage canvas `toDataURL()` deferred via rAF.
- **Manual Mowing visibility**: Added Manual Mow button directly into both the mobile toolbar (`MapToolbarMobile`) and the desktop toolbar (`MapToolbar`) — previously it was only accessible inside the "More ⋯" dropdown.
- **Joystick positioning**: `JoystickOverlay` accepts a `bottomOffset` prop; on mobile it is set to 172 px to render above the toolbar.
- **Mobile toolbar positioning**: Toolbar `bottom` raised to 108 px so it clears the browser's native navigation bar on Chrome/Firefox mobile.
- **Manual mode state on load**: `useManualMode` now accepts `stateName` and syncs `manualMode` from `MANUAL_MOWING` robot state — previously the button showed the wrong state if the robot was already in manual mode when the page loaded.
- **Cache-Control headers**: `index.html` served with `no-cache, no-store, must-revalidate` so mobile browsers always fetch the latest build.

## Test plan

- [ ] Open GUI in Chrome Mobile and Firefox Mobile — map polygons should render on load
- [ ] Confirm map is smooth while robot publishes pose (no perceptible lag)
- [ ] Confirm Manual Mowing button is directly visible in the toolbar (not in dropdown)
- [ ] Activate Manual Mowing — joystick appears above the toolbar, not behind it
- [ ] Reload page while robot is in MANUAL_MOWING state — button shows "Stop Manual" immediately
- [ ] Hard-reload after a new deploy — browser fetches fresh `index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)