### PR TITLE
feat: idle Nav2 lifecycle suspend (opt-in, default off)

### DIFF
--- a/install/config/mowgli/mowgli_robot.yaml
+++ b/install/config/mowgli/mowgli_robot.yaml
@@ -15,6 +15,13 @@ mowgli:
         automatic_mode: 0
         mowing_enabled: true
         lidar_enabled: true
+        # idle_nav2_suspend (default false): when true, the behaviour tree
+        # PAUSEs the entire Nav2 lifecycle stack while the robot is parked on
+        # the dock, so the costmaps stop looping and the Pi's idle thermal
+        # load drops sharply. Nav2 is RESUMEd (collision_monitor back up)
+        # before any motion. Opt-in per site; leave false until validated on
+        # your hardware.
+        idle_nav2_suspend: false
 
         # Localizer backend — when LiDAR is present we want the
         # GTSAM factor-graph localizer with scan-matching + loop

--- a/ros2/src/mowgli_behavior/CMakeLists.txt
+++ b/ros2/src/mowgli_behavior/CMakeLists.txt
@@ -155,6 +155,37 @@ if(BUILD_TESTING)
     tf2_geometry_msgs
   )
 
+  # ---- test_set_nav2_lifecycle ----
+  # Exercises the SetNav2Lifecycle action node's idle-suspend gating
+  # (disabled = no-op, PAUSE refused off-dock, idempotent transitions) and,
+  # with a fake manage_nodes service, the actual PAUSE/RESUME transition.
+  ament_add_gtest(test_set_nav2_lifecycle
+    test/test_set_nav2_lifecycle.cpp
+    src/navigation_nodes.cpp
+  )
+
+  target_include_directories(test_set_nav2_lifecycle PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+
+  ament_target_dependencies(test_set_nav2_lifecycle
+    rclcpp
+    rclcpp_action
+    behaviortree_cpp
+    mowgli_interfaces
+    nav2_msgs
+    nav_msgs
+    geometry_msgs
+    std_msgs
+    std_srvs
+    tf2
+    tf2_ros
+    tf2_geometry_msgs
+    rcl_interfaces
+    action_msgs
+  )
+
 endif()
 
 ament_package()

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
@@ -174,6 +174,15 @@ struct BTContext
   /// Current navigation mode: "precise" or "degraded"
   std::string current_nav_mode{"precise"};
 
+  /// Whether SetNav2Lifecycle has suspended (PAUSEd) the Nav2 lifecycle
+  /// stack to save CPU/thermal budget while idle on the dock. Tracked here
+  /// (rather than re-querying lifecycle_manager every tick) so the
+  /// SetNav2Lifecycle RESUME/PAUSE nodes only issue a manage_nodes service
+  /// call on an actual state transition — the BT is the sole pause/resume
+  /// authority. Only meaningful when the idle_nav2_suspend feature flag is
+  /// enabled; stays false otherwise. Protected by context_mutex.
+  bool nav2_suspended{false};
+
   /// Operator-configured drive speeds (m/s), sourced from mowgli_robot.yaml
   /// by behavior_tree_node and applied to the live controllers by SetNavMode:
   /// transit_speed → FollowPath.desired_linear_vel (RPP transit), mowing_speed

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/navigation_nodes.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/navigation_nodes.hpp
@@ -29,6 +29,7 @@
 #include "nav2_msgs/action/back_up.hpp"
 #include "nav2_msgs/action/navigate_to_pose.hpp"
 #include "nav2_msgs/srv/clear_entire_costmap.hpp"
+#include "nav2_msgs/srv/manage_lifecycle_nodes.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "std_srvs/srv/empty.hpp"
@@ -102,6 +103,56 @@ public:
 private:
   rclcpp::Client<nav2_msgs::srv::ClearEntireCostmap>::SharedPtr global_client_;
   rclcpp::Client<nav2_msgs::srv::ClearEntireCostmap>::SharedPtr local_client_;
+};
+
+// ---------------------------------------------------------------------------
+// SetNav2Lifecycle
+// ---------------------------------------------------------------------------
+
+/// PAUSEs or RESUMEs the Nav2 lifecycle stack via
+/// /lifecycle_manager_navigation/manage_nodes, to drop idle CPU/thermal
+/// load while the robot sits docked. The whole Nav2 navigation group
+/// (controller/planner/smoother/behaviors/bt_navigator/waypoint/docking/
+/// coverage/collision_monitor) is otherwise kept fully active and looping
+/// its costmaps even while parked — on the Pi 4 that is the dominant idle
+/// thermal cost (triaged 2026-06-16).
+///
+/// SAFETY: pausing the navigation group also deactivates collision_monitor,
+/// so PAUSE is gated on charger_enabled — it only fires when the robot is
+/// physically on the dock, where it cannot move (motors coast at zero, no
+/// cmd_vel is issued in IDLE) and the firmware remains the sole safety
+/// authority. RESUME is wired as a root guard that runs before any motion
+/// branch, and the existing Nav2ReadyPoll in MowingSequence blocks all
+/// motion until lifecycle_manager reports active — so collision_monitor is
+/// always active again before the robot can drive.
+///
+/// Behaviour is gated behind the idle_nav2_suspend blackboard flag
+/// (default false): when disabled this node is a pure no-op (a single
+/// blackboard read, no service call). The node tracks ctx->nav2_suspended
+/// so a manage_nodes request is only sent on an actual transition — RESUME
+/// when already active, or a redundant PAUSE, costs nothing.
+///
+/// Input ports:
+///   - command: "PAUSE" or "RESUME"
+class SetNav2Lifecycle : public BT::SyncActionNode
+{
+public:
+  SetNav2Lifecycle(const std::string& name, const BT::NodeConfig& config)
+      : BT::SyncActionNode(name, config)
+  {
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    return {
+        BT::InputPort<std::string>("command", "PAUSE or RESUME"),
+    };
+  }
+
+  BT::NodeStatus tick() override;
+
+private:
+  rclcpp::Client<nav2_msgs::srv::ManageLifecycleNodes>::SharedPtr client_;
 };
 
 // ---------------------------------------------------------------------------

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -463,6 +463,15 @@ private:
     const double undock_distance = declare_parameter<double>("undock_distance", 1.0);
     blackboard_->set("undock_distance", undock_distance);
 
+    // idle_nav2_suspend (default false): when true, the BT PAUSEs the Nav2
+    // lifecycle stack (via SetNav2Lifecycle) while parked on the dock to cut
+    // the idle CPU/thermal load of the always-looping costmaps, and RESUMEs
+    // it (root Nav2ResumeGuard) before any motion. Default-off so enabling
+    // it is a deliberate, per-site operator decision. Read by the
+    // SetNav2Lifecycle nodes from the blackboard.
+    const bool idle_nav2_suspend = declare_parameter<bool>("idle_nav2_suspend", false);
+    blackboard_->set("idle_nav2_suspend", idle_nav2_suspend);
+
     // Transit / mowing speeds, sourced from mowgli_robot.yaml and applied to
     // the live controllers by SetNavMode (FollowPath.desired_linear_vel for the
     // RPP transit controller, FollowCoveragePath.vx_max for MPPI coverage).

--- a/ros2/src/mowgli_behavior/src/navigation_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/navigation_nodes.cpp
@@ -168,6 +168,94 @@ BT::NodeStatus ClearCostmap::tick()
 }
 
 // ---------------------------------------------------------------------------
+// SetNav2Lifecycle
+// ---------------------------------------------------------------------------
+
+BT::NodeStatus SetNav2Lifecycle::tick()
+{
+  // Feature flag (default false): when disabled, this node is a pure no-op.
+  // No service client is created and no manage_nodes request is ever sent,
+  // so behaviour is identical to a build without idle suspend.
+  bool enabled = false;
+  config().blackboard->get<bool>("idle_nav2_suspend", enabled);
+  if (!enabled)
+  {
+    return BT::NodeStatus::SUCCESS;
+  }
+
+  std::string command;
+  if (!getInput<std::string>("command", command))
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+  const bool want_pause = (command == "PAUSE");
+  if (!want_pause && command != "RESUME")
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+
+  auto ctx = config().blackboard->get<std::shared_ptr<BTContext>>("context");
+
+  // Decide whether a transition is actually needed. ctx->nav2_suspended is
+  // our single source of truth (the BT is the only pause/resume authority),
+  // so we issue a manage_nodes call only on a real transition — no per-tick
+  // service spam while mowing or while parked.
+  {
+    std::lock_guard<std::mutex> lock(ctx->context_mutex);
+    if (want_pause)
+    {
+      if (ctx->nav2_suspended)
+      {
+        return BT::NodeStatus::SUCCESS;  // already paused
+      }
+      // SAFETY: only suspend (which deactivates collision_monitor) when the
+      // robot is physically on the dock. Off-dock idle keeps Nav2 active.
+      if (!ctx->latest_power.charger_enabled)
+      {
+        return BT::NodeStatus::SUCCESS;
+      }
+    }
+    else if (!ctx->nav2_suspended)
+    {
+      return BT::NodeStatus::SUCCESS;  // already active, nothing to resume
+    }
+  }
+
+  if (!client_)
+  {
+    client_ = ctx->helper_node->create_client<nav2_msgs::srv::ManageLifecycleNodes>(
+        "/lifecycle_manager_navigation/manage_nodes");
+  }
+  if (!client_->service_is_ready())
+  {
+    // lifecycle_manager not up yet — leave our tracked state unchanged so we
+    // retry on the next tick rather than desyncing.
+    RCLCPP_WARN_THROTTLE(ctx->node->get_logger(),
+                         *ctx->node->get_clock(),
+                         5000,
+                         "SetNav2Lifecycle: manage_nodes service not ready, skipping %s",
+                         command.c_str());
+    return BT::NodeStatus::SUCCESS;
+  }
+
+  auto req = std::make_shared<nav2_msgs::srv::ManageLifecycleNodes::Request>();
+  req->command = want_pause ? nav2_msgs::srv::ManageLifecycleNodes::Request::PAUSE
+                            : nav2_msgs::srv::ManageLifecycleNodes::Request::RESUME;
+  // Fire-and-forget: RESUME completion is gated downstream by Nav2ReadyPoll
+  // (Nav2Active) before any motion, so we don't block the tick on the
+  // transition. Mark our tracked state immediately.
+  client_->async_send_request(req);
+  {
+    std::lock_guard<std::mutex> lock(ctx->context_mutex);
+    ctx->nav2_suspended = want_pause;
+  }
+  RCLCPP_INFO(ctx->node->get_logger(),
+              "SetNav2Lifecycle: sent %s to lifecycle_manager_navigation",
+              command.c_str());
+  return BT::NodeStatus::SUCCESS;
+}
+
+// ---------------------------------------------------------------------------
 // NavigateToPose
 // ---------------------------------------------------------------------------
 
@@ -406,7 +494,9 @@ BT::NodeStatus NavigateInsideBoundary::onRunning()
     RCLCPP_INFO(ctx->node->get_logger(),
                 "NavigateInsideBoundary: disabling global_costmap keepout_filter "
                 "(recovery target=(%.2f, %.2f), %.2fm outside)",
-                recovery_pose_.position.x, recovery_pose_.position.y, distance_outside_);
+                recovery_pose_.position.x,
+                recovery_pose_.position.y,
+                distance_outside_);
     return BT::NodeStatus::RUNNING;
   }
 
@@ -541,8 +631,7 @@ BT::NodeStatus NavigateInsideBoundary::onRunning()
       backup_result_requested_ = true;
     }
 
-    if (backup_result_future_.wait_for(std::chrono::milliseconds(0)) !=
-        std::future_status::ready)
+    if (backup_result_future_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready)
     {
       return BT::NodeStatus::RUNNING;
     }
@@ -617,7 +706,9 @@ BT::NodeStatus NavigateInsideBoundary::SendNav2Goal()
 
   RCLCPP_INFO(ctx->node->get_logger(),
               "NavigateInsideBoundary: nav2 goal sent (x=%.2f y=%.2f, %.2fm outside)",
-              recovery_pose_.position.x, recovery_pose_.position.y, distance_outside_);
+              recovery_pose_.position.x,
+              recovery_pose_.position.y,
+              distance_outside_);
   phase_ = Phase::WaitingForGoalHandle;
   return BT::NodeStatus::RUNNING;
 }
@@ -640,8 +731,8 @@ BT::NodeStatus NavigateInsideBoundary::BeginReEnableKeepout()
     keepout_disabled_ = false;
     return pending_nav_result_;
   }
-  set_param_future_ = keepout_params_client_->set_parameters(
-      {rclcpp::Parameter("keepout_filter.enabled", true)});
+  set_param_future_ =
+      keepout_params_client_->set_parameters({rclcpp::Parameter("keepout_filter.enabled", true)});
   phase_ = Phase::ReEnablingKeepout;
   return BT::NodeStatus::RUNNING;
 }
@@ -682,7 +773,8 @@ BT::NodeStatus NavigateInsideBoundary::BeginFallbackBackup()
 
   RCLCPP_INFO(ctx->node->get_logger(),
               "NavigateInsideBoundary: fallback backup goal sent (%.2f m @ %.2f m/s)",
-              kBackupDist, kBackupSpeed);
+              kBackupDist,
+              kBackupSpeed);
   return BT::NodeStatus::RUNNING;
 }
 
@@ -704,8 +796,7 @@ void NavigateInsideBoundary::onHalted()
   }
   if (keepout_disabled_)
   {
-    RCLCPP_INFO(ctx->node->get_logger(),
-                "NavigateInsideBoundary: halt — restoring keepout filter");
+    RCLCPP_INFO(ctx->node->get_logger(), "NavigateInsideBoundary: halt — restoring keepout filter");
     RequestKeepoutEnable(true);
     keepout_disabled_ = false;
   }

--- a/ros2/src/mowgli_behavior/src/register_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/register_nodes.cpp
@@ -53,6 +53,7 @@ void registerAllNodes(BT::BehaviorTreeFactory& factory)
   factory.registerNodeType<SetMowerEnabled>("SetMowerEnabled");
   factory.registerNodeType<StopMoving>("StopMoving");
   factory.registerNodeType<ClearCostmap>("ClearCostmap");
+  factory.registerNodeType<SetNav2Lifecycle>("SetNav2Lifecycle");
   factory.registerNodeType<PublishHighLevelStatus>("PublishHighLevelStatus");
   factory.registerNodeType<WaitForDuration>("WaitForDuration");
   factory.registerNodeType<WaitForGpsFix>("WaitForGpsFix");

--- a/ros2/src/mowgli_behavior/test/test_set_nav2_lifecycle.cpp
+++ b/ros2/src/mowgli_behavior/test/test_set_nav2_lifecycle.cpp
@@ -1,0 +1,243 @@
+// Copyright 2026 Mowgli Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * @file test_set_nav2_lifecycle.cpp
+ * @brief Unit tests for the SetNav2Lifecycle action node.
+ *
+ * Verifies the idle-Nav2-suspend gating logic that decides whether to issue a
+ * lifecycle_manager manage_nodes PAUSE/RESUME. The safety-critical guarantees
+ * are exercised without any real lifecycle_manager:
+ *   - disabled flag  → pure no-op (default field behaviour is unchanged)
+ *   - PAUSE off-dock → no-op (collision_monitor is never deactivated unless
+ *     the robot is physically charging on the dock)
+ *   - RESUME when already active / PAUSE when already paused → idempotent
+ * A separate test stands up a fake manage_nodes service to confirm the actual
+ * suspend/resume transition flips ctx->nav2_suspended and reaches the server.
+ */
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "behaviortree_cpp/bt_factory.h"
+#include "mowgli_behavior/bt_context.hpp"
+#include "mowgli_behavior/navigation_nodes.hpp"
+#include "nav2_msgs/srv/manage_lifecycle_nodes.hpp"
+#include <gtest/gtest.h>
+
+using mowgli_behavior::BTContext;
+using mowgli_behavior::SetNav2Lifecycle;
+using ManageLifecycleNodes = nav2_msgs::srv::ManageLifecycleNodes;
+
+// ---------------------------------------------------------------------------
+// Global ROS2 init/shutdown
+// ---------------------------------------------------------------------------
+
+class RclcppEnvironment : public ::testing::Environment
+{
+public:
+  void SetUp() override
+  {
+    if (!rclcpp::ok())
+    {
+      rclcpp::init(0, nullptr);
+    }
+  }
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+  }
+};
+
+::testing::Environment* const rclcpp_env =
+    ::testing::AddGlobalTestEnvironment(new RclcppEnvironment());
+
+// ---------------------------------------------------------------------------
+// Fixture — builds a BTContext + blackboard + a SetNav2Lifecycle tree
+// ---------------------------------------------------------------------------
+
+class SetNav2LifecycleTest : public ::testing::Test
+{
+protected:
+  std::shared_ptr<BTContext> ctx;
+  BT::Blackboard::Ptr blackboard;
+  BT::BehaviorTreeFactory factory;
+
+  void SetUp() override
+  {
+    ctx = std::make_shared<BTContext>();
+    ctx->node = rclcpp::Node::make_shared("test_set_nav2_lifecycle");
+    ctx->helper_node = rclcpp::Node::make_shared("test_set_nav2_lifecycle_helper");
+
+    blackboard = BT::Blackboard::create();
+    blackboard->set("context", ctx);
+
+    factory.registerNodeType<SetNav2Lifecycle>("SetNav2Lifecycle");
+  }
+
+  /// Build a one-node tree with the given command ("PAUSE" / "RESUME").
+  BT::Tree makeTree(const std::string& command)
+  {
+    const std::string xml =
+        "<root BTCPP_format=\"4\"><BehaviorTree ID=\"MainTree\">"
+        "<SetNav2Lifecycle command=\"" +
+        command +
+        "\"/>"
+        "</BehaviorTree></root>";
+    return factory.createTreeFromText(xml, blackboard);
+  }
+
+  void setEnabled(bool enabled)
+  {
+    blackboard->set("idle_nav2_suspend", enabled);
+  }
+  void setCharging(bool charging)
+  {
+    ctx->latest_power.charger_enabled = charging;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Gating logic (no service required — deterministic)
+// ---------------------------------------------------------------------------
+
+TEST_F(SetNav2LifecycleTest, DisabledFlagIsNoOp)
+{
+  // Feature off (the default): even PAUSE while charging must do nothing.
+  setEnabled(false);
+  setCharging(true);
+  auto tree = makeTree("PAUSE");
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
+  EXPECT_FALSE(ctx->nav2_suspended);
+}
+
+TEST_F(SetNav2LifecycleTest, MissingFlagIsNoOp)
+{
+  // Blackboard key never set → treated as disabled, no transition.
+  setCharging(true);
+  auto tree = makeTree("PAUSE");
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
+  EXPECT_FALSE(ctx->nav2_suspended);
+}
+
+TEST_F(SetNav2LifecycleTest, PauseOffDockIsRefused)
+{
+  // SAFETY: never PAUSE (which deactivates collision_monitor) unless the
+  // robot is physically on the dock charging.
+  setEnabled(true);
+  setCharging(false);
+  auto tree = makeTree("PAUSE");
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
+  EXPECT_FALSE(ctx->nav2_suspended);
+}
+
+TEST_F(SetNav2LifecycleTest, ResumeWhenAlreadyActiveIsNoOp)
+{
+  setEnabled(true);
+  ctx->nav2_suspended = false;  // already active
+  auto tree = makeTree("RESUME");
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
+  EXPECT_FALSE(ctx->nav2_suspended);
+}
+
+TEST_F(SetNav2LifecycleTest, PauseWhenAlreadyPausedIsIdempotent)
+{
+  setEnabled(true);
+  setCharging(true);
+  ctx->nav2_suspended = true;  // already paused
+  auto tree = makeTree("PAUSE");
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
+  EXPECT_TRUE(ctx->nav2_suspended);
+}
+
+TEST_F(SetNav2LifecycleTest, BadCommandFails)
+{
+  setEnabled(true);
+  auto tree = makeTree("NONSENSE");
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE);
+}
+
+// ---------------------------------------------------------------------------
+// Transition with a fake manage_nodes server
+// ---------------------------------------------------------------------------
+
+TEST_F(SetNav2LifecycleTest, PauseAndResumeTransitionReachesServer)
+{
+  uint8_t last_command = 255;
+  int call_count = 0;
+  auto server_node = rclcpp::Node::make_shared("fake_lifecycle_manager");
+  auto service = server_node->create_service<ManageLifecycleNodes>(
+      "/lifecycle_manager_navigation/manage_nodes",
+      [&](const std::shared_ptr<ManageLifecycleNodes::Request> req,
+          std::shared_ptr<ManageLifecycleNodes::Response> resp)
+      {
+        last_command = req->command;
+        ++call_count;
+        resp->success = true;
+      });
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(ctx->helper_node);
+  executor.add_node(server_node);
+
+  // Let discovery settle so the helper client sees the service.
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  // First tick creates the client (lazy); spin until it's discovered.
+  setEnabled(true);
+  setCharging(true);
+  auto pause_tree = makeTree("PAUSE");
+  bool ready = false;
+  while (std::chrono::steady_clock::now() < deadline)
+  {
+    executor.spin_some();
+    auto client = ctx->helper_node->create_client<ManageLifecycleNodes>(
+        "/lifecycle_manager_navigation/manage_nodes");
+    if (client->service_is_ready())
+    {
+      ready = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  ASSERT_TRUE(ready) << "fake manage_nodes service was never discovered";
+
+  // PAUSE: charging + enabled + not-yet-suspended → sends PAUSE, flips state.
+  EXPECT_EQ(pause_tree.tickOnce(), BT::NodeStatus::SUCCESS);
+  EXPECT_TRUE(ctx->nav2_suspended);
+  for (int i = 0; i < 50 && call_count < 1; ++i)
+  {
+    executor.spin_some();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  EXPECT_EQ(call_count, 1);
+  EXPECT_EQ(last_command, ManageLifecycleNodes::Request::PAUSE);
+
+  // RESUME: suspended → sends RESUME, clears state.
+  auto resume_tree = makeTree("RESUME");
+  EXPECT_EQ(resume_tree.tickOnce(), BT::NodeStatus::SUCCESS);
+  EXPECT_FALSE(ctx->nav2_suspended);
+  for (int i = 0; i < 50 && call_count < 2; ++i)
+  {
+    executor.spin_some();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  EXPECT_EQ(call_count, 2);
+  EXPECT_EQ(last_command, ManageLifecycleNodes::Request::RESUME);
+}

--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -146,6 +146,31 @@
       </Fallback>
 
       <!-- ================================================================
+           GUARD 4: Nav2 resume (reactive, idempotent)
+           If idle_nav2_suspend is enabled, the Nav2 lifecycle stack is
+           PAUSEd by IdleSequence while parked on the dock to save the
+           Pi's idle thermal budget (the costmaps otherwise loop flat-out
+           even docked). This guard RESUMEs it before any motion branch
+           runs: it does NOTHING while idle-on-dock (charging AND no
+           command pending) so it never fights IdleSequence's PAUSE, and
+           otherwise ensures the stack is active again. SetNav2Lifecycle
+           only issues a manage_nodes call on a real transition (it tracks
+           the suspend state on the shared context), and is a pure no-op
+           when idle_nav2_suspend is disabled — so this guard is free in
+           the default configuration. The downstream Nav2ReadyPoll in
+           MowingSequence still blocks motion until lifecycle_manager
+           reports active, guaranteeing collision_monitor is back up
+           before the robot drives. Always returns SUCCESS so the root
+           ReactiveSequence proceeds to MainLogic. -->
+      <Fallback name="Nav2ResumeGuard">
+        <Sequence name="StayIdleSuspended">
+          <IsCharging/>
+          <IsCommand command="0"/>
+        </Sequence>
+        <SetNav2Lifecycle command="RESUME"/>
+      </Fallback>
+
+      <!-- ================================================================
            MAIN LOGIC
            Priority: critical battery → mow → home → record → idle
            ================================================================ -->
@@ -783,6 +808,12 @@
           <SetMowerEnabled enabled="false"/>
           <StopMoving/>
           <PublishHighLevelStatus state="1" state_name="IDLE"/>
+          <!-- Suspend the Nav2 lifecycle stack to drop idle CPU/thermal load
+               (no-op unless idle_nav2_suspend is enabled; self-gated on
+               charging so it only fires when physically docked, where the
+               robot cannot move and the firmware is the safety authority).
+               RESUMEd by Nav2ResumeGuard before any motion branch runs. -->
+          <SetNav2Lifecycle command="PAUSE"/>
           <WaitForDuration duration_sec="0.5"/>
         </Sequence>
 

--- a/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
+++ b/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
@@ -56,6 +56,12 @@ mowgli:
     # Behavior tree tuning (consumed by behavior_tree_node)
     tick_rate: 10.0
     bt_debug_logging: false
+    # idle_nav2_suspend (default false): when true, the BT PAUSEs the Nav2
+    # lifecycle stack while parked on the dock so the costmaps stop looping and
+    # idle CPU/thermal load drops sharply. Nav2 is RESUMEd (collision_monitor
+    # back up) before any motion via the root Nav2ResumeGuard + Nav2ReadyPoll.
+    # Opt-in per site.
+    idle_nav2_suspend: false
     # IMU calibration (consumed by hardware_bridge_node — auto-triggered on dock)
     imu_cal_samples: 200
     imu_cal_persist_path: /ros2_ws/maps/imu_calibration.txt

--- a/ros2/src/mowgli_bringup/launch/full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/full_system.launch.py
@@ -226,6 +226,12 @@ def generate_launch_description() -> LaunchDescription:
             # references in main_tree.xml. See issue #191.
             {"undock_speed": float(robot_params.get("undock_speed", 0.15))},
             {"undock_distance": float(robot_params.get("undock_distance", 1.0))},
+            # idle_nav2_suspend: PAUSE the Nav2 lifecycle stack while parked on
+            # the dock to cut idle CPU/thermal load (costmaps stop looping).
+            # Default off — a deliberate per-site opt-in. RESUME is guaranteed
+            # before motion by the root Nav2ResumeGuard + Nav2ReadyPoll.
+            {"idle_nav2_suspend":
+                bool(robot_params.get("idle_nav2_suspend", False))},
             # transit_speed / mowing_speed flow into SetNavMode, which sets
             # them on the live controllers (FollowPath.desired_linear_vel for
             # the RPP transit controller, FollowCoveragePath.vx_max for the


### PR DESCRIPTION
## Problem
On the Pi 4 the Nav2 stack + costmaps run continuously even while the robot is docked and idle, which pins idle CPU high — field-measured ~83 °C docked-idle with active soft-temperature throttling.

## Change
A BT-driven, **opt-in (default off)** idle Nav2 lifecycle suspend:

- New BT action **`SetNav2Lifecycle`** PAUSE/RESUMEs the Nav2 group via `lifecycle_manager`.
- **`IdleSequence`** PAUSEs only while physically docked (gated on `charger_enabled`) — no `cmd_vel` is issued there, and firmware remains the sole safety authority.
- A root **`Nav2ResumeGuard`** RESUMEs before any motion branch, and the existing `Nav2ReadyPoll` blocks motion until lifecycle reports active — so `collision_monitor` is back up before the robot drives.
- Suspend state is tracked on `BTContext` so `manage_nodes` is only called on a transition; it's a pure no-op when `idle_nav2_suspend` is off.

## Result
Docked idle dropped from **~83 °C (throttling) → ~69 °C (no throttle)** on the Pi 4.

## Safety / scope
- **Default off.** Enabling is a per-site decision (`mowgli_robot.yaml: idle_nav2_suspend: true`).
- Only suspends while docked + charging; resume-guard + ready-poll guarantee Nav2 (incl. collision_monitor) is active before any motion.
- The earlier Part-1 sensor-derived costmap-rate change is intentionally **not** carried: dev restructured `nav2_params` (base/lidar/no_lidar) and already gates idle `map_server` CPU.
- Unit test: `test_set_nav2_lifecycle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)