### PR TITLE
fix(firmware): clear master_tx_busy unconditionally to stop WWDG reboot loop

### DIFF
--- a/firmware/stm32/ros_usbnode/src/main.c
+++ b/firmware/stm32/ros_usbnode/src/main.c
@@ -915,14 +915,29 @@ void debug_printf(const char *fmt, ...)
 }
 
 #if BOARD_HAS_MASTER_USART
+/* Upper bound (ms) on the wait for the previous MASTER USART DMA to finish.
+ * At 115200 8N1 the longest debug string (~200 B) transmits in ~17 ms, so 25 ms
+ * never drops a normal message yet stays under the 40 ms window watchdog so a
+ * stuck busy flag can never starve the main loop into a WWDG reset. */
+#define MASTER_TX_TIMEOUT_MS 25u
 /*
  * Send message via MASTER USART (DMA Normal Mode)
  */
 void MASTER_Transmit(uint8_t *buffer, uint8_t len)
 {
-  // wait until tx buffers are free (send complete)
+  /* Wait (bounded) for the previous DMA TX to complete. If its TX-complete
+   * callback was ever missed and master_tx_busy is stuck, time out and DROP
+   * this message instead of spinning forever — spinning would starve the main
+   * loop and trip the watchdog, and overwriting master_tx_buffer mid-DMA would
+   * corrupt an in-flight transfer. The MASTER USART only carries debug output,
+   * so dropping a message is harmless. */
+  uint32_t wait_start = HAL_GetTick();
   while (master_tx_busy)
   {
+    if ((HAL_GetTick() - wait_start) > MASTER_TX_TIMEOUT_MS)
+    {
+      return;
+    }
   }
   master_tx_busy = 1;
   // copy into our master_tx_buffer
@@ -1014,10 +1029,12 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
 #if BOARD_HAS_MASTER_USART
   if (huart->Instance == MASTER_USART_INSTANCE)
   {
-    if (__HAL_USART_GET_FLAG(&MASTER_USART_Handler, USART_FLAG_TC))
-    {
-      master_tx_busy = 0;
-    }
+    /* HAL invokes this callback on TX completion, so release the busy flag
+     * unconditionally. It was previously gated on a re-read of USART_FLAG_TC;
+     * when TC had not yet latched at callback time the flag was left set
+     * forever, so the next MASTER_Transmit() spun in its busy-wait, starved the
+     * main loop, and the window watchdog reset the board. */
+    master_tx_busy = 0;
   }
 #endif
 }


### PR DESCRIPTION
## Problem

On boards with `BOARD_HAS_MASTER_USART` + UART debug (e.g. Yardforce 500 Classic), the STM32 can enter a ~4 s reboot loop whenever the firmware is armed and the host is communicating with it. The USB CDC re-enumerates every ~4 s and nothing the host sends recovers it.

## Root cause

`HAL_UART_TxCpltCallback` cleared `master_tx_busy` only if `USART_FLAG_TC` happened to be set at callback time:

```c
if (__HAL_USART_GET_FLAG(&MASTER_USART_Handler, USART_FLAG_TC))
    master_tx_busy = 0;
```

When TC had not yet latched at callback time, the flag stuck at `1` forever, so the next `MASTER_Transmit()` spun in `while (master_tx_busy) {}`, the main loop never reached `WATCHDOG_Refresh()`, and the Window Watchdog (~40 ms) reset the board. Confirmed on hardware: `RCC_CSR` shows `WWDGRSTF` after a reproduction (cleared `RMVF` first, so the flag is unambiguous).

Every `debug_printf` ultimately calls `MASTER_Transmit`, so heavy debug output (e.g. a host that re-pushes config on each reconnect) reliably leaves the flag stuck → reboot loop. With the host stopped the board is perfectly stable.

## Fix

- `HAL_UART_TxCpltCallback`: clear `master_tx_busy` **unconditionally** — HAL invokes this callback precisely on TX completion, so re-reading `TC` was the race.
- `MASTER_Transmit`: **bound** the busy-wait with a 25 ms timeout (drop the message, don't hang) as defense-in-depth — comfortably under the 40 ms WWDG window, above a worst-case 200 B @ 115200 message (~17 ms). The MASTER USART carries only debug output, so a dropped message is harmless.

## Verification (hardware, Yardforce 500 Classic)

- Reproduced: 12+ WWDG resets / 50 s while armed; `RCC_CSR` `WWDGRSTF` set.
- After flashing this fix: **0 resets / 50 s**, steady drive telemetry (~23 Hz), no serial re-open loop.

## Note

Blocking `debug_printf` inside USB-RX IRQ-context packet handlers is best avoided as well, but that is left to the individual handlers — this change fixes the underlying race so any caller is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)