### PR TITLE
fix(localization): invalidate stale COG latch after in-place pivot

### DIFF
--- a/ros2/scripts/mow_session_monitor.py
+++ b/ros2/scripts/mow_session_monitor.py
@@ -81,6 +81,20 @@ def _wrap_pi(a: float) -> float:
     return a
 
 
+def _safe_float(v: str) -> Optional[float]:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(v: str) -> Optional[int]:
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
 # -----------------------------------------------------------------------------
 # QoS profiles
 # -----------------------------------------------------------------------------
@@ -176,6 +190,21 @@ class LatestState:
     # --- Dock heading (when charging) ---
     gnss_heading_yaw_rad: Optional[float] = None
 
+    # --- Yaw-source attribution (diagnose 180° flip / lever-arm jumps) ---
+    # COG yaw = GPS course-over-ground (cog_to_imu_node) — the physical
+    # travel direction. fg_yaw = fusion_graph's own published yaw. The
+    # gap between cog_yaw, fg_yaw, and fusion_yaw_rad localises a yaw
+    # corruption to the COG unary vs gyro integration vs the publish path.
+    cog_yaw_rad: Optional[float] = None
+    cog_yaw_var: Optional[float] = None
+    fg_yaw_rad: Optional[float] = None
+    # fusion_graph diagnostics: yaw marginal cov, online gyro bias, and the
+    # cumulative wrong-fix reject counter (diffed across samples for a rate).
+    fg_cov_yawyaw: Optional[float] = None
+    fg_gyro_bias_z: Optional[float] = None
+    fg_gps_rejects_wrongfix: Optional[int] = None
+    fg_cog_flip_recoveries: Optional[int] = None
+
     # --- BT / status ---
     bt_state: Optional[int] = None
     bt_state_name: Optional[str] = None
@@ -247,6 +276,7 @@ class MowSessionMonitor(Node):
         self.start_fusion_xy: Optional[tuple[float, float]] = None
         self.peak_fusion_gps_err = 0.0
         self.peak_wheel_gyro_yaw_drift = 0.0
+        self.peak_cog_fusion_yaw_gap = 0.0
 
         # --- RTK covariance-drop check state ---
         # See the comment block above RTK_FIXED_GPS_COV_THRESHOLD for why this
@@ -284,6 +314,17 @@ class MowSessionMonitor(Node):
         sub("/gps/fix", NavSatFix, self._gps_fix_cb, QOS_SENSOR)
         sub("/gps/absolute_pose", PoseWithCovarianceStamped, self._gps_abs_cb, QOS_RELIABLE)
         sub("/gnss/heading", Imu, self._gnss_heading_cb, QOS_RELIABLE)
+
+        # Yaw-source attribution: COG (GPS travel direction), fusion_graph's
+        # own yaw, and its diagnostics. cog_to_imu / fusion publish these
+        # BEST_EFFORT, so subscribe with sensor QoS.
+        sub("/imu/cog_heading", Imu, self._cog_heading_cb, QOS_SENSOR)
+        sub("/imu/fg_yaw", Imu, self._fg_yaw_cb, QOS_SENSOR)
+        try:
+            from diagnostic_msgs.msg import DiagnosticArray  # type: ignore
+            sub("/fusion_graph/diagnostics", DiagnosticArray, self._fg_diag_cb, QOS_RELIABLE)
+        except ImportError as exc:
+            self.get_logger().warn(f"diagnostic_msgs not available: {exc} — fg diagnostics will be missing.")
 
         # BT + hardware state — imported lazily so we only require the
         # mowgli_interfaces package when those topics are available
@@ -452,6 +493,35 @@ class MowSessionMonitor(Node):
                 msg.orientation.z, msg.orientation.w
             )
 
+    def _cog_heading_cb(self, msg: Imu) -> None:
+        with self.state_lock:
+            self.state.cog_yaw_rad = _quat_to_yaw(
+                msg.orientation.z, msg.orientation.w
+            )
+            var = msg.orientation_covariance[8]
+            self.state.cog_yaw_var = float(var) if var and var > 0.0 else None
+
+    def _fg_yaw_cb(self, msg: Imu) -> None:
+        with self.state_lock:
+            self.state.fg_yaw_rad = _quat_to_yaw(
+                msg.orientation.z, msg.orientation.w
+            )
+
+    def _fg_diag_cb(self, msg) -> None:
+        # DiagnosticArray with key/value pairs published by fusion_graph_node
+        # (cov_yawyaw, cog_flip_recoveries, gps_rejects_wrongfix, ...).
+        with self.state_lock:
+            for status in msg.status:
+                for kv in status.values:
+                    if kv.key == "cov_yawyaw":
+                        self.state.fg_cov_yawyaw = _safe_float(kv.value)
+                    elif kv.key == "gyro_bias_z_rad_per_s":
+                        self.state.fg_gyro_bias_z = _safe_float(kv.value)
+                    elif kv.key == "gps_rejects_wrongfix":
+                        self.state.fg_gps_rejects_wrongfix = _safe_int(kv.value)
+                    elif kv.key == "cog_flip_recoveries":
+                        self.state.fg_cog_flip_recoveries = _safe_int(kv.value)
+
     def _bt_cb(self, msg) -> None:
         with self.state_lock:
             self.state.bt_state = int(msg.state)
@@ -577,6 +647,24 @@ class MowSessionMonitor(Node):
                     self.peak_wheel_gyro_yaw_drift, abs(wheel_gyro_drift)
                 )
 
+            # --- Yaw-source disagreement (180° flip / lever-arm corruption) ---
+            # cog_minus_fusion ≈ ±180° is the signature of the East→turn fault:
+            # the fused yaw is flipped vs the GPS travel direction, so the
+            # gps_x lever-arm projects position to the wrong side.
+            cog_minus_fusion_deg = None
+            if s.cog_yaw_rad is not None and s.fusion_yaw_rad is not None:
+                cog_minus_fusion_deg = math.degrees(
+                    _wrap_pi(s.cog_yaw_rad - s.fusion_yaw_rad)
+                )
+                self.peak_cog_fusion_yaw_gap = max(
+                    self.peak_cog_fusion_yaw_gap, abs(cog_minus_fusion_deg)
+                )
+            fg_minus_fusion_deg = None
+            if s.fg_yaw_rad is not None and s.fusion_yaw_rad is not None:
+                fg_minus_fusion_deg = math.degrees(
+                    _wrap_pi(s.fg_yaw_rad - s.fusion_yaw_rad)
+                )
+
             # --- Distance to plan goal ---
             dist_to_goal = None
             if (
@@ -632,6 +720,19 @@ class MowSessionMonitor(Node):
                 },
                 "gps_absolute_pose": {
                     "x": s.gps_abs_x, "y": s.gps_abs_y,
+                },
+                "yaw_sources": {
+                    # COG = GPS travel direction (cog_to_imu); fg = fusion_graph's
+                    # published yaw; fusion = /odometry/filtered_map yaw.
+                    "cog_deg": math.degrees(s.cog_yaw_rad) if s.cog_yaw_rad is not None else None,
+                    "cog_var": s.cog_yaw_var,
+                    "fg_deg": math.degrees(s.fg_yaw_rad) if s.fg_yaw_rad is not None else None,
+                    "cog_minus_fusion_deg": cog_minus_fusion_deg,
+                    "fg_minus_fusion_deg": fg_minus_fusion_deg,
+                    "cov_yawyaw": s.fg_cov_yawyaw,
+                    "gyro_bias_z": s.fg_gyro_bias_z,
+                    "gps_rejects_wrongfix": s.fg_gps_rejects_wrongfix,
+                    "cog_flip_recoveries": s.fg_cog_flip_recoveries,
                 },
                 "slam": {
                     # /slam/pose_cov, already in GPS map frame
@@ -804,6 +905,7 @@ class MowSessionMonitor(Node):
                 "session_straight_line_displacement_m": fusion_xy_travel,
                 "peak_fusion_gps_error_m": self.peak_fusion_gps_err,
                 "peak_wheel_gyro_yaw_drift_deg": self.peak_wheel_gyro_yaw_drift,
+                "peak_cog_fusion_yaw_gap_deg": self.peak_cog_fusion_yaw_gap,
                 "rtk_cov_check": {
                     "rtk_fixed_arrivals": self.rtk_fixed_arrivals,
                     "ok": self.rtk_cov_checks_ok,

--- a/ros2/src/fusion_graph/src/fusion_graph_node_setup_comms.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_setup_comms.cpp
@@ -356,6 +356,10 @@ void FusionGraphNode::SetupCommunications(double node_period_s)
                           // to get a rate. A spike on any of these is
                           // worth surfacing — see PR notes.
                           add("gps_rejects_wrongfix", std::to_string(stats.gps_rejects_wrongfix));
+                          // 180° yaw-flip recoveries (OnCogHeading). A non-zero
+                          // count localises a yaw corruption to the COG-flip path
+                          // and timestamps when the snap-to-COG fired.
+                          add("cog_flip_recoveries", std::to_string(cog_flip_recoveries_));
                           add("icp_rejects_rmse", std::to_string(stats.icp_rejects_rmse));
                           add("icp_rejects_inliers", std::to_string(stats.icp_rejects_inliers));
                           add("icp_rejects_sanity", std::to_string(stats.icp_rejects_sanity));

--- a/ros2/src/mowgli_localization/include/mowgli_localization/cog_yaw_math.hpp
+++ b/ros2/src/mowgli_localization/include/mowgli_localization/cog_yaw_math.hpp
@@ -140,6 +140,30 @@ inline bool cog_sweep_dominates(double omega, double lever_radius, double vx,
   return sweep_speed > ratio * std::abs(vx);
 }
 
+// Deadbanded absolute-rotation increment for the stationary-latch staleness
+// gate.
+//
+// The stationary yaw latch holds the heading from the last forward-motion
+// segment and republishes it at 2 Hz while the robot is still. After an
+// in-place pivot that latch is stale by the pivot angle, yet the
+// instantaneous-omega republish gate passes again the moment the pivot stops.
+// To catch this we integrate rotation since the latch was set and drop the
+// latch past a threshold. The integral MUST be deadbanded: a plain integral of
+// |gyro_z| accumulates the gyro noise floor (~0.01-0.03 rad/s) over a
+// multi-second stationary dwell and would falsely invalidate a perfectly good
+// latch. Below `deadband` the sample is treated as noise and contributes
+// nothing; at or above it the true rotation |omega|*dt is accumulated. A real
+// pivot (|omega| well over the deadband) trips the threshold within a fraction
+// of a turn; a still robot never does.
+inline double cog_latch_rotation_increment(double omega, double dt, double deadband)
+{
+  if (dt <= 0.0 || std::abs(omega) <= deadband)
+  {
+    return 0.0;
+  }
+  return std::abs(omega) * dt;
+}
+
 }  // namespace mowgli_localization
 
 #endif  // MOWGLI_LOCALIZATION__COG_YAW_MATH_HPP_

--- a/ros2/src/mowgli_localization/src/cog_to_imu_node.cpp
+++ b/ros2/src/mowgli_localization/src/cog_to_imu_node.cpp
@@ -120,6 +120,23 @@ public:
     // going stale and must not be republished. 0.05 rad/s ≈ 3°/s.
     latch_republish_max_omega_ =
         declare_parameter<double>("latch_republish_max_omega_rps", 0.05);
+    // Cumulative-rotation staleness gate for the latch. The instantaneous
+    // latch_republish_max_omega_ gate above only suppresses republish *while*
+    // the robot is turning; once an in-place pivot ENDS and ω returns to ~0
+    // the gate passes again and the pre-pivot heading gets republished — but
+    // the latch only updates on forward translation, so after a 180° pivot it
+    // is stale by π and corrupts the fused yaw (field 2026-06-20: manual
+    // east→west flip teleported fusion yaw −6°→−131° while motionless, then
+    // dragged position around the gps_x lever-arm circle). Track absolute
+    // rotation accumulated since the latch was set and drop the latch once it
+    // exceeds this; a real pivot trips it immediately. We do NOT reuse
+    // abs_dtheta_since_anchor_ — that integrates |gyro_z| with no deadband and
+    // resets every GPS fix, so over a multi-second stationary dwell its noise
+    // floor would falsely invalidate a good latch. latch_rotation_deadband_rps
+    // is the per-sample floor below which |gyro_z| is treated as noise and not
+    // accumulated. 0.26 rad ≈ 15°.
+    latch_max_rotation_rad_ = declare_parameter<double>("latch_max_rotation_rad", 0.26);
+    latch_rotation_deadband_rps_ = declare_parameter<double>("latch_rotation_deadband_rps", 0.05);
     // Number of consecutive non-rotating GPS samples required before we
     // start accumulating a new baseline after a pivot ends. 2 samples
     // at 5 Hz GPS ≈ 400 ms of confirmed straight motion before COG
@@ -216,6 +233,22 @@ public:
             double cur = abs_dtheta_since_anchor_.load(std::memory_order_relaxed);
             while (!abs_dtheta_since_anchor_.compare_exchange_weak(cur, cur + inc))
             {
+            }
+            // Deadbanded rotation since the stationary latch was set. Unlike
+            // abs_dtheta_since_anchor_ this ignores sub-deadband samples, so a
+            // long stationary dwell doesn't accumulate gyro noise into a false
+            // staleness trip. Drives the latch-invalidation in
+            // republish_latched_when_stationary().
+            const double linc =
+                mowgli_localization::cog_latch_rotation_increment(msg->angular_velocity.z,
+                                                                  dt,
+                                                                  latch_rotation_deadband_rps_);
+            if (linc > 0.0)
+            {
+              double lcur = abs_dtheta_since_latch_.load(std::memory_order_relaxed);
+              while (!abs_dtheta_since_latch_.compare_exchange_weak(lcur, lcur + linc))
+              {
+              }
             }
           }
         });
@@ -526,6 +559,8 @@ private:
 
     const double mono_now = static_cast<double>(get_clock()->now().nanoseconds()) * 1e-9;
     latched_yaw_ = LatchedYaw{mono_now, yaw, yaw_var};
+    // Fresh latch — start counting rotation away from this heading from zero.
+    abs_dtheta_since_latch_ = 0.0;
 
     // Online mag-cal sample collection — only fit against COG that
     // survives the inflated-σ test (positional + drift + lever).
@@ -577,6 +612,18 @@ private:
     {
       return;
     }
+    // Cumulative-rotation staleness: the instantaneous gate above only catches
+    // the moment of turning. If the robot has rotated past latch_max_rotation_rad_
+    // since the latch was set (e.g. an in-place pivot that has since stopped),
+    // the latched heading no longer describes where the robot points — drop it
+    // rather than republish a stale, tight-covariance yaw into the graph. A new
+    // latch is seeded by on_fix() once forward motion resumes.
+    if (abs_dtheta_since_latch_.load() > latch_max_rotation_rad_)
+    {
+      latched_yaw_.reset();
+      ++latch_invalidated_rotation_;
+      return;
+    }
     const double mono_now = static_cast<double>(get_clock()->now().nanoseconds()) * 1e-9;
     const double age = std::max(0.0, mono_now - latched_yaw_->stamp);
     if (age > stationary_max_age_s_)
@@ -617,7 +664,8 @@ private:
     RCLCPP_INFO(get_logger(),
                 "cog_to_imu stats: published fwd=%d rev=%d seed=%d, "
                 "rejected fix=%d accuracy=%d stationary=%d rotating=%d sweep=%d "
-                "displacement=%d baseline_rot=%lu, mag_cal samples=%zu (writes=%d)",
+                "displacement=%d baseline_rot=%lu latch_invalid_rot=%lu, "
+                "mag_cal samples=%zu (writes=%d)",
                 published_fwd_,
                 published_rev_,
                 stationary_seeds_published_,
@@ -628,6 +676,7 @@ private:
                 rejected_sweep_,
                 rejected_displacement_,
                 static_cast<unsigned long>(rejected_baseline_rotation_),
+                static_cast<unsigned long>(latch_invalidated_rotation_),
                 mag_samples_.size(),
                 mag_fit_count_);
     published_fwd_ = 0;
@@ -878,6 +927,8 @@ private:
   double min_omega_for_anchor_{};
   double cog_sweep_dominance_ratio_{1.0};
   double latch_republish_max_omega_{0.05};
+  double latch_max_rotation_rad_{0.26};
+  double latch_rotation_deadband_rps_{0.05};
   double max_pos_accuracy_{};
   double min_dt_{}, max_dt_{};
   double max_yaw_var_{}, min_yaw_var_{};
@@ -943,6 +994,9 @@ private:
   // COG when this exceeds cog_max_baseline_rotation_rad_ (a straight baseline
   // is near zero). last_imu_t_ is the previous /imu/data stamp for dt.
   std::atomic<double> abs_dtheta_since_anchor_{0.0};
+  // Deadbanded absolute rotation accumulated since the stationary latch was
+  // set; drives latch invalidation in republish_latched_when_stationary().
+  std::atomic<double> abs_dtheta_since_latch_{0.0};
   std::atomic<double> last_imu_t_{0.0};
   double cog_max_baseline_rotation_rad_{0.20};
   uint64_t rejected_baseline_rotation_{0};
@@ -975,6 +1029,7 @@ private:
   int rejected_rotating_{0};
   int rejected_sweep_{0};
   int stationary_seeds_published_{0};
+  uint64_t latch_invalidated_rotation_{0};
 };
 
 }  // namespace mowgli_localization

--- a/ros2/src/mowgli_localization/test/test_cog_yaw_math.cpp
+++ b/ros2/src/mowgli_localization/test/test_cog_yaw_math.cpp
@@ -200,6 +200,66 @@ TEST(CogSweepGate, BoundaryAtRatio)
   EXPECT_TRUE(mowgli_localization::cog_sweep_dominates(0.11, 0.30, 0.03, 1.0));
 }
 
+// ── Stationary-latch staleness accumulator ──────────────────────────────
+// cog_latch_rotation_increment() deadbands the per-sample rotation so a long
+// stationary dwell's gyro noise never accumulates into a false latch
+// invalidation, while a real in-place pivot trips the threshold quickly.
+// Field 2026-06-20: a stale post-pivot latch republished a heading 180° wrong
+// and teleported the fused yaw.
+
+TEST(CogLatchStaleness, NoiseBelowDeadbandDoesNotAccumulate)
+{
+  // 0.03 rad/s gyro noise, under a 0.05 deadband, integrated at 100 Hz for a
+  // full 10 minutes of standing still — must accumulate exactly zero.
+  double acc = 0.0;
+  const double deadband = 0.05;
+  const double dt = 0.01;
+  for (int i = 0; i < 100 * 600; ++i)
+  {
+    acc += mowgli_localization::cog_latch_rotation_increment(0.03, dt, deadband);
+  }
+  EXPECT_DOUBLE_EQ(acc, 0.0);
+}
+
+TEST(CogLatchStaleness, InPlacePivotTripsThreshold)
+{
+  // A 180° in-place pivot at 0.5 rad/s (well over deadband). By a quarter turn
+  // the accumulator is past the 0.26 rad staleness threshold, and by the end
+  // it has integrated ~the full half-turn magnitude.
+  double acc = 0.0;
+  const double deadband = 0.05;
+  const double threshold = 0.26;
+  const double omega = 0.5;
+  const double dt = 0.01;
+  const int n = static_cast<int>((M_PI / omega) / dt);  // samples for a half turn
+  bool tripped_before_quarter_turn = false;
+  for (int i = 0; i < n; ++i)
+  {
+    acc += mowgli_localization::cog_latch_rotation_increment(omega, dt, deadband);
+    if (i == n / 4 && acc > threshold)
+    {
+      tripped_before_quarter_turn = true;
+    }
+  }
+  EXPECT_TRUE(tripped_before_quarter_turn);
+  EXPECT_NEAR(acc, M_PI, 0.05);
+}
+
+TEST(CogLatchStaleness, NonPositiveDtContributesNothing)
+{
+  // Guards the out-of-order / first-sample dt path.
+  EXPECT_DOUBLE_EQ(mowgli_localization::cog_latch_rotation_increment(1.0, 0.0, 0.05), 0.0);
+  EXPECT_DOUBLE_EQ(mowgli_localization::cog_latch_rotation_increment(1.0, -0.1, 0.05), 0.0);
+}
+
+TEST(CogLatchStaleness, AtDeadbandIsNotAccumulated)
+{
+  // Strict > : a sample exactly at the deadband is treated as noise.
+  EXPECT_DOUBLE_EQ(mowgli_localization::cog_latch_rotation_increment(0.05, 0.01, 0.05), 0.0);
+  // Just above accumulates.
+  EXPECT_GT(mowgli_localization::cog_latch_rotation_increment(0.051, 0.01, 0.05), 0.0);
+}
+
 int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## Problem

A manual ~180° turn corrupts the factor-graph localizer: yaw flips ~180° and position jumps ~0.3 m, then slowly re-converges once the robot drives straight again.

## Root cause

`cog_to_imu_node` republishes the last forward-motion heading (the "stationary latch") at 2 Hz while the robot is still, gated **only on instantaneous ω**. After an in-place pivot that gate passes again the moment rotation stops — but the latch only updates on forward *translation*, so it republishes a heading stale by the pivot angle. `fusion_graph` fuses that tight-covariance yaw unary and drags the gyro-correct estimate off. With the 0.3 m GPS lever arm, the wrong yaw projects position onto the antenna circle → the visible position jump.

Diagnosed from session logs: with the robot dead-still (gyro≈0, cmd=0), fused yaw teleported −6°→−131° because the COG was latched at the pre-pivot heading.

## Fix

Track **deadbanded** rotation accumulated since the latch was set, and drop the latch once it exceeds `latch_max_rotation_rad` (0.26 rad ≈ 15°). The deadband matters: a plain `|gyro_z|` integral accumulates the gyro noise floor over a long stationary dwell and would falsely invalidate a good latch. A real pivot trips it immediately; a still robot never does.

New params (both overridable): `latch_max_rotation_rad` (0.26), `latch_rotation_deadband_rps` (0.05).

## Validation

Field-tested on hardware 2026-06-20, same east→west pivot maneuver:

| | Before | After |
|---|---|---|
| Injected yaw teleports | 8 | **0** |
| Post-pivot stationary yaw | teleported ~±125° | **rock-solid** |
| Position during hold | orbited ~0.3 m | **stable** |
| `latch_invalid_rot` | — | **3** (fired correctly) |

Fusion now tracks 180° pivots cleanly via gyro and holds yaw steady through the post-pivot stationary hold while the COG is stale.

## Also included

- `cog_latch_rotation_increment()` pure helper in `cog_yaw_math.hpp` + unit tests (noise→0, pivot trips, boundaries).
- `cog_flip_recoveries` diagnostic on `/fusion_graph/diagnostics`.
- Yaw-source instrumentation (`cog` / `fg_yaw` / `cov_yawyaw` / `cog_minus_fusion_deg`) in `mow_session_monitor.py`, used for the diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)