### PR TITLE
fix(nav2): real velocity feedback for MPPI/RPP (+ rotation telemetry, turn-in-place spike)

### DIFF
--- a/gui/pkg/api/openmower_import.go
+++ b/gui/pkg/api/openmower_import.go
@@ -76,11 +76,13 @@ type openMowerMap struct {
 //
 // Map: the verbatim contents of the user's OpenMower map.json. Required.
 //
-// OmDatumLat / OmDatumLon: optional. When provided AND different from
-// the configured MowgliNext datum (in mowgli_robot.yaml), the importer
-// applies a translation so OpenMower's local x/y land at the right
-// MowgliNext map-frame coordinates. When omitted, "same datum" is
-// assumed (identity transform). See docs/IMPORT_OPENMOWER_MAP.md §3.
+// OmDatumLat / OmDatumLon: optional. When provided, the importer
+// reprojects OpenMower's local x/y (relative to the OM datum) into the
+// MowgliNext map frame (relative to the MN datum from mowgli_robot.yaml)
+// via WGS84 lat/lon — correcting BOTH the datum offset AND the
+// cos(latitude) east-scale mismatch. When omitted, "same datum" is
+// assumed (identity copy) and a warning is surfaced. See
+// docs/IMPORT_OPENMOWER_MAP.md §3.
 //
 // Apply: when false (the default), the handler runs in **preview-only**
 // mode — parse + validate + summary, no writes. When true, the handler
@@ -193,13 +195,13 @@ func postImportOpenMower(rosProvider types.IRosProvider, dbProvider types.IDBPro
 			return
 		}
 
-		// Resolve MowgliNext datum from mowgli_robot.yaml. When the
-		// user passed an OpenMower datum, we'll compute the shift; when
-		// they didn't, we stay at zero shift and warn.
+		// Resolve MowgliNext datum from mowgli_robot.yaml. When the user
+		// passed an OpenMower datum we reproject geodetically; otherwise
+		// we fall back to an identity copy and warn.
 		mnLat, mnLon, datumErr := readMowgliNextDatum(dbProvider)
-		shiftE, shiftN, datumWarn := computeDatumShift(req.OmDatumLat, req.OmDatumLon, mnLat, mnLon, datumErr)
+		reproj, datumWarn := resolveReprojection(req.OmDatumLat, req.OmDatumLon, mnLat, mnLon, datumErr)
 
-		summary := buildImportSummary(omMap, shiftE, shiftN)
+		summary := buildImportSummary(omMap, reproj)
 		if datumWarn != "" {
 			summary.Warnings = append([]string{datumWarn}, summary.Warnings...)
 		}
@@ -207,7 +209,7 @@ func postImportOpenMower(rosProvider types.IRosProvider, dbProvider types.IDBPro
 		// Build (in memory) the MowgliNext-shaped payload that *would*
 		// be POSTed to /map_server_node/add_area, plus the dock pose.
 		// Currently logged + counted but not actually written.
-		replaceReq, dockReq := buildMowgliNextPayload(omMap, shiftE, shiftN)
+		replaceReq, dockReq := buildMowgliNextPayload(omMap, reproj)
 
 		if req.Apply {
 			if err := applyImport(c, rosProvider, replaceReq, dockReq); err != nil {
@@ -467,35 +469,85 @@ func readMowgliNextDatum(dbProvider types.IDBProvider) (float64, float64, error)
 	return lat, lon, nil
 }
 
-// computeDatumShift returns the (east, north) shift in metres that the
-// importer must add to every OpenMower polygon vertex to land it in
-// the MowgliNext map frame, plus a warning string when the inputs
-// don't allow a confident answer.
-func computeDatumShift(omLat, omLon *float64, mnLat, mnLon float64, mnDatumErr error) (float64, float64, string) {
+// datumReprojector maps a point expressed in OpenMower's local ENU frame
+// (metres relative to the OM datum) into MowgliNext's local ENU frame
+// (metres relative to the MN datum). When the two datums coincide it is
+// an exact identity; otherwise it round-trips through WGS84 lat/lon so
+// BOTH the constant offset (datum displacement) AND the cos(latitude)
+// east-scale mismatch between the two datums are corrected. The earlier
+// additive `shiftE/shiftN` approximation only matched the offset, leaving
+// a residual skew/rotation when the datums were far apart.
+type datumReprojector struct {
+	omLat, omLon float64
+	mnLat, mnLon float64
+}
+
+// project converts (eOM, nOM) — metres east/north of the OM datum — into
+// (eMN, nMN) — metres east/north of the MN datum. M is metersPerDegreeLat.
+//
+//	lat = om_lat + nOM / M
+//	lon = om_lon + eOM / (M · cos(om_lat))
+//	eMN = (lon − mn_lon) · M · cos(mn_lat)
+//	nMN = (lat − mn_lat) · M
+func (r datumReprojector) project(eOM, nOM float64) (float64, float64) {
+	lat := r.omLat + nOM/metersPerDegreeLat
+	lon := r.omLon + eOM/(metersPerDegreeLat*math.Cos(r.omLat*math.Pi/180.0))
+	eMN := (lon - r.mnLon) * metersPerDegreeLat * math.Cos(r.mnLat*math.Pi/180.0)
+	nMN := (lat - r.mnLat) * metersPerDegreeLat
+	return eMN, nMN
+}
+
+// resolveReprojection decides how OpenMower coordinates are mapped into
+// the MowgliNext map frame and returns the reprojector plus a warning
+// string when the inputs don't allow a confident, georeferenced answer.
+//
+// Cases:
+//   - OM datum provided + MN datum readable → full geodetic reprojection.
+//   - OM datum provided + MN datum UNSET (fresh install) → adopt the OM
+//     datum as the MN datum so the import is exact (identity), and tell
+//     the operator to set datum_lat/datum_lon to the OM datum. We do NOT
+//     write mowgli_robot.yaml here: the datum is owned by the GPS/settings
+//     write path and adopting it silently would change the live map frame
+//     for an already-running localizer. Surfacing it keeps the importer
+//     side-effect-free and matches how other settings are written.
+//   - OM datum NOT provided + MN datum set → identity copy with a
+//     prominent "import will be offset" warning.
+//   - OM datum NOT provided + MN datum unset → identity copy (nothing to
+//     reference against), gentle note.
+func resolveReprojection(omLat, omLon *float64, mnLat, mnLon float64, mnDatumErr error) (datumReprojector, string) {
 	if omLat == nil || omLon == nil {
-		return 0, 0, "OpenMower datum not provided — assuming same datum as MowgliNext (identity transform). If the source robot used a different OM_DATUM_LAT/OM_DATUM_LONG, supply om_datum_lat/om_datum_lon and re-import."
+		if mnDatumErr != nil {
+			return datumReprojector{}, "Datum OpenMower non fourni et datum MowgliNext absent — l'import est copié tel quel. Renseignez le datum OpenMower (OM_DATUM_LAT/LONG) pour un géoréférencement correct."
+		}
+		return datumReprojector{mnLat: mnLat, mnLon: mnLon, omLat: mnLat, omLon: mnLon},
+			"Datum OpenMower non fourni — l'import sera décalé. Renseignez le datum OpenMower (OM_DATUM_LAT/LONG) pour un géoréférencement correct."
 	}
 	if mnDatumErr != nil {
-		return 0, 0, fmt.Sprintf("OpenMower datum provided but MowgliNext datum unreadable (%v) — applying identity transform. Configure MowgliNext datum_lat/datum_lon first.", mnDatumErr)
+		// Fresh install: no MN datum yet. Adopt the OM datum so the import
+		// is exact; the operator must promote it to datum_lat/datum_lon.
+		return datumReprojector{omLat: *omLat, omLon: *omLon, mnLat: *omLat, mnLon: *omLon},
+			fmt.Sprintf("Datum MowgliNext absent — le datum OpenMower (%.8f, %.8f) a été adopté pour cet import. Réglez datum_lat/datum_lon sur ces valeurs pour que la carte soit correctement géoréférencée.", *omLat, *omLon)
 	}
-	cosLat := math.Cos(mnLat * math.Pi / 180.0)
-	shiftE := (*omLon - mnLon) * cosLat * metersPerDegreeLat
-	shiftN := (*omLat - mnLat) * metersPerDegreeLat
-	return shiftE, shiftN, ""
+	return datumReprojector{omLat: *omLat, omLon: *omLon, mnLat: mnLat, mnLon: mnLon}, ""
 }
 
 // ---------------------------------------------------------------------------
 // Summary + payload builders
 // ---------------------------------------------------------------------------
 
-// buildImportSummary walks the parsed OpenMower map, applies the datum
-// shift, validates each area, and produces the user-facing preview.
-func buildImportSummary(omMap openMowerMap, shiftE, shiftN float64) ImportOpenMowerSummary {
+// buildImportSummary walks the parsed OpenMower map, reprojects each
+// vertex into the MowgliNext frame, validates each area, and produces
+// the user-facing preview. DatumShift{East,North}M report where the OM
+// local origin (0, 0) lands in the MN frame — the constant displacement
+// between the two datums — so the GUI's "datum shift" alert still reads
+// meaningfully under full reprojection.
+func buildImportSummary(omMap openMowerMap, reproj datumReprojector) ImportOpenMowerSummary {
+	originE, originN := reproj.project(0, 0)
 	summary := ImportOpenMowerSummary{
 		Warnings:         []string{},
 		Areas:            []ImportedAreaBrief{},
-		DatumShiftEastM:  shiftE,
-		DatumShiftNorthM: shiftN,
+		DatumShiftEastM:  originE,
+		DatumShiftNorthM: originN,
 	}
 
 	mowAndNav := []openMowerArea{}
@@ -563,9 +615,10 @@ func buildImportSummary(omMap openMowerMap, shiftE, shiftN float64) ImportOpenMo
 	}
 	if len(activeDocks) >= 1 {
 		d := activeDocks[0]
+		dx, dy := reproj.project(d.Position.X, d.Position.Y)
 		summary.DockPose = &ImportDockPose{
-			X:      d.Position.X + shiftE,
-			Y:      d.Position.Y + shiftN,
+			X:      dx,
+			Y:      dy,
 			YawRad: d.Heading,
 		}
 	}
@@ -628,7 +681,7 @@ func matchObstaclesToParents(obstacles, parents []openMowerArea, summary *Import
 // buildMowgliNextPayload constructs the (unsent) ReplaceMapReq + dock
 // pose request that the apply path will eventually use. Produced even
 // in preview mode so logging shows exactly what would be written.
-func buildMowgliNextPayload(omMap openMowerMap, shiftE, shiftN float64) (*mowgli.ReplaceMapReq, *mowgli.SetDockingPointReq) {
+func buildMowgliNextPayload(omMap openMowerMap, reproj datumReprojector) (*mowgli.ReplaceMapReq, *mowgli.SetDockingPointReq) {
 	// Re-walk the validated areas (cheap; smaller than the duplication
 	// cost of returning more from buildImportSummary).
 	mowAndNav := []openMowerArea{}
@@ -668,11 +721,11 @@ func buildMowgliNextPayload(omMap openMowerMap, shiftE, shiftN float64) (*mowgli
 		isNav := strings.EqualFold(a.Properties.Type, "nav")
 		obs := []geometry.Polygon{}
 		for _, oi := range obstacleAssign[pi] {
-			obs = append(obs, geometry.Polygon{Points: outlineToPoint32s(obstacles[oi].Outline, shiftE, shiftN)})
+			obs = append(obs, geometry.Polygon{Points: outlineToPoint32s(obstacles[oi].Outline, reproj)})
 		}
 		mapArea := mowgli.MapArea{
 			Name:      a.Properties.Name,
-			Area:      geometry.Polygon{Points: outlineToPoint32s(a.Outline, shiftE, shiftN)},
+			Area:      geometry.Polygon{Points: outlineToPoint32s(a.Outline, reproj)},
 			Obstacles: obs,
 		}
 		replaceReq.Areas = append(replaceReq.Areas, mowgli.ReplaceMapArea{
@@ -686,9 +739,10 @@ func buildMowgliNextPayload(omMap openMowerMap, shiftE, shiftN float64) (*mowgli
 		if d.Properties.Active != nil && !*d.Properties.Active {
 			continue
 		}
+		dx, dy := reproj.project(d.Position.X, d.Position.Y)
 		dockReq = &mowgli.SetDockingPointReq{
 			DockingPose: geometry.Pose{
-				Position:    geometry.Point{X: d.Position.X + shiftE, Y: d.Position.Y + shiftN, Z: 0},
+				Position:    geometry.Point{X: dx, Y: dy, Z: 0},
 				Orientation: yawToQuaternion(d.Heading),
 			},
 		}
@@ -796,13 +850,15 @@ func dedupOutline(in []openMowerPoint) []openMowerPoint {
 }
 
 // outlineToPoint32s materialises an OpenMower outline as the geometry
-// _msgs/Polygon.Points list expected by mowgli.MapArea.
-func outlineToPoint32s(outline []openMowerPoint, shiftE, shiftN float64) []geometry.Point32 {
+// _msgs/Polygon.Points list expected by mowgli.MapArea, reprojecting each
+// vertex from the OM frame into the MowgliNext frame.
+func outlineToPoint32s(outline []openMowerPoint, reproj datumReprojector) []geometry.Point32 {
 	out := make([]geometry.Point32, 0, len(outline))
 	for _, p := range outline {
+		e, n := reproj.project(p.X, p.Y)
 		out = append(out, geometry.Point32{
-			X: float32(p.X + shiftE),
-			Y: float32(p.Y + shiftN),
+			X: float32(e),
+			Y: float32(n),
 			Z: 0,
 		})
 	}

--- a/gui/pkg/api/openmower_import_realmap_test.go
+++ b/gui/pkg/api/openmower_import_realmap_test.go
@@ -36,7 +36,7 @@ func loadRealLegacyMap(t *testing.T) openMowerMap {
 // on top of.
 func TestImportRealLegacyMap_FaithfulCounts(t *testing.T) {
 	om := loadRealLegacyMap(t)
-	summary := buildImportSummary(om, 0, 0)
+	summary := buildImportSummary(om, datumReprojector{})
 
 	assert.Equal(t, 8, summary.MowingAreas, "all 8 WorkingArea zones import as mow areas")
 	assert.Equal(t, 1, summary.NavigationAreas, "the single NavigationArea imports")
@@ -53,7 +53,7 @@ func TestImportRealLegacyMap_FaithfulCounts(t *testing.T) {
 	// duplicate, and mow-7/mow-8/nav-1 also lose a leading doubled vertex
 	// (which is exactly why those last two working areas failed to import
 	// before the dedup fix).
-	replace, _ := buildMowgliNextPayload(om, 0, 0)
+	replace, _ := buildMowgliNextPayload(om, datumReprojector{})
 	require.Len(t, replace.Areas, 9)
 	gotVerts := make([]int, 0, len(replace.Areas))
 	for _, ra := range replace.Areas {
@@ -83,7 +83,7 @@ func TestImportRealLegacyMap_FaithfulCounts(t *testing.T) {
 // duplicate, in outlineToPoint32s / the legacy adapter).
 func TestImportRealLegacyMap_NoDegenerateVertices(t *testing.T) {
 	om := loadRealLegacyMap(t)
-	replace, _ := buildMowgliNextPayload(om, 0, 0)
+	replace, _ := buildMowgliNextPayload(om, datumReprojector{})
 
 	degenerate := 0
 	for _, ra := range replace.Areas {

--- a/gui/pkg/api/openmower_import_test.go
+++ b/gui/pkg/api/openmower_import_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -119,7 +120,7 @@ func TestBuildImportSummary_Counts(t *testing.T) {
 	var omMap openMowerMap
 	require.NoError(t, json.Unmarshal([]byte(sampleOpenMowerMap), &omMap))
 
-	summary := buildImportSummary(omMap, 0, 0)
+	summary := buildImportSummary(omMap, datumReprojector{})
 
 	// 1 mow + 1 nav, 1 obstacle re-parented under the mow area, 1 orphan,
 	// the draft is skipped (warning), no inactive areas in the fixture.
@@ -155,7 +156,7 @@ func TestBuildImportSummary_ObstacleIsReparented(t *testing.T) {
 
 	// First area in the fixture is the mow area — confirm the obstacle
 	// got attached to it (Obstacles == 1) and not to the nav area.
-	summary := buildImportSummary(omMap, 0, 0)
+	summary := buildImportSummary(omMap, datumReprojector{})
 	require.Len(t, summary.Areas, 2)
 	mowBrief, navBrief := summary.Areas[0], summary.Areas[1]
 	assert.Equal(t, "Front lawn", mowBrief.Name)
@@ -168,7 +169,7 @@ func TestBuildImportSummary_AreaSqm(t *testing.T) {
 	var omMap openMowerMap
 	require.NoError(t, json.Unmarshal([]byte(sampleOpenMowerMap), &omMap))
 
-	summary := buildImportSummary(omMap, 0, 0)
+	summary := buildImportSummary(omMap, datumReprojector{})
 	require.Len(t, summary.Areas, 2)
 	// Front lawn is 10 × 6 = 60 m².
 	assert.InDelta(t, 60.0, summary.Areas[0].ApproxAreaSqm, 1e-6)
@@ -182,7 +183,7 @@ func TestBuildMowgliNextPayload_StructureMatchesReplaceMapReq(t *testing.T) {
 	var omMap openMowerMap
 	require.NoError(t, json.Unmarshal([]byte(sampleOpenMowerMap), &omMap))
 
-	replace, dock := buildMowgliNextPayload(omMap, 0, 0)
+	replace, dock := buildMowgliNextPayload(omMap, datumReprojector{})
 	require.NotNil(t, replace)
 	require.Len(t, replace.Areas, 2, "expected 1 mow + 1 nav, drafts and orphans excluded")
 
@@ -207,53 +208,125 @@ func TestBuildMowgliNextPayload_StructureMatchesReplaceMapReq(t *testing.T) {
 	assert.InDelta(t, math.Cos(math.Pi/4), dock.DockingPose.Orientation.W, 1e-9)
 }
 
-func TestBuildMowgliNextPayload_AppliesDatumShift(t *testing.T) {
+func TestBuildMowgliNextPayload_AppliesReprojection(t *testing.T) {
 	var omMap openMowerMap
 	require.NoError(t, json.Unmarshal([]byte(sampleOpenMowerMap), &omMap))
 
-	const dE, dN = 12.5, -7.0
-	replace, dock := buildMowgliNextPayload(omMap, dE, dN)
+	// OM datum offset from MN datum by ~100 m north and ~100 m east. At the
+	// OM origin (0, 0) the projection collapses to the constant offset
+	// between the two datums; cos(lat) differs negligibly over 100 m so the
+	// origin lands very close to (dE, dN) but the test pins the exact value
+	// the reprojector computes (not an additive shift).
+	mnLat, mnLon := 48.0, 11.0
+	reproj := datumReprojector{
+		omLat: mnLat + 100.0/metersPerDegreeLat,
+		omLon: mnLon + 100.0/(metersPerDegreeLat*math.Cos(mnLat*math.Pi/180.0)),
+		mnLat: mnLat,
+		mnLon: mnLon,
+	}
+	wantE0, wantN0 := reproj.project(0, 0)
+
+	replace, dock := buildMowgliNextPayload(omMap, reproj)
 	require.Len(t, replace.Areas, 2)
 
-	// Front lawn first vertex was (0, 0); should land at (dE, dN).
+	// Front lawn first vertex was (0, 0); should land at the reprojected
+	// origin (≈ (100, 100) but not exactly — that's the whole point).
 	first := replace.Areas[0]
 	require.NotEmpty(t, first.Area.Area.Points)
-	assert.InDelta(t, float32(dE), first.Area.Area.Points[0].X, 1e-5)
-	assert.InDelta(t, float32(dN), first.Area.Area.Points[0].Y, 1e-5)
+	assert.InDelta(t, float32(wantE0), first.Area.Area.Points[0].X, 1e-3)
+	assert.InDelta(t, float32(wantN0), first.Area.Area.Points[0].Y, 1e-3)
 
-	// Dock was at (-0.5, 0.2) → ( -0.5+dE, 0.2+dN ).
-	assert.InDelta(t, -0.5+dE, dock.DockingPose.Position.X, 1e-9)
-	assert.InDelta(t, 0.2+dN, dock.DockingPose.Position.Y, 1e-9)
+	// Dock was at (-0.5, 0.2) → reprojected.
+	wantDockE, wantDockN := reproj.project(-0.5, 0.2)
+	assert.InDelta(t, wantDockE, dock.DockingPose.Position.X, 1e-6)
+	assert.InDelta(t, wantDockN, dock.DockingPose.Position.Y, 1e-6)
 }
 
-// --- computeDatumShift ---------------------------------------------------
+// --- datumReprojector / resolveReprojection ------------------------------
 
-func TestComputeDatumShift_NoOmDatumIsIdentity(t *testing.T) {
-	e, n, warn := computeDatumShift(nil, nil, 48.0, 11.0, nil)
-	assert.Equal(t, 0.0, e)
-	assert.Equal(t, 0.0, n)
-	assert.NotEmpty(t, warn, "expected an identity-transform warning")
+// TestReproject_RoundTrip100m is the stand-in for a real field sample (none
+// is available — see the verification gap). It builds an OM polygon whose
+// datum is offset ~100 m north and ~100 m east of the MN datum, then asserts
+// the reprojected MN points match the expected ENU to within ~1 mm. The
+// expected value is derived independently of project() by going OM→lat/lon
+// →MN by hand, so a regression in the formula is caught.
+func TestReproject_RoundTrip100m(t *testing.T) {
+	const M = metersPerDegreeLat
+	mnLat, mnLon := 48.137154, 11.576124 // Munich-ish, arbitrary
+	// OM datum offset from MN datum.
+	dNorth, dEast := 100.0, 100.0
+	omLat := mnLat + dNorth/M
+	omLon := mnLon + dEast/(M*math.Cos(mnLat*math.Pi/180.0))
+
+	reproj := datumReprojector{omLat: omLat, omLon: omLon, mnLat: mnLat, mnLon: mnLon}
+
+	// A handful of OM-frame points. For each, compute the expected MN-frame
+	// point by hand (the same math project() should implement).
+	cases := [][2]float64{{0, 0}, {10, 0}, {0, 6}, {-3, 3}, {123.4, -56.7}}
+	for _, c := range cases {
+		eOM, nOM := c[0], c[1]
+		lat := omLat + nOM/M
+		lon := omLon + eOM/(M*math.Cos(omLat*math.Pi/180.0))
+		wantE := (lon - mnLon) * M * math.Cos(mnLat*math.Pi/180.0)
+		wantN := (lat - mnLat) * M
+
+		gotE, gotN := reproj.project(eOM, nOM)
+		assert.InDelta(t, wantE, gotE, 1e-3, "east mismatch for OM point %v", c)
+		assert.InDelta(t, wantN, gotN, 1e-3, "north mismatch for OM point %v", c)
+	}
+
+	// Sanity: the OM origin must land ≈100 m NE of the MN origin. cos(lat)
+	// varies by <2e-6 over 100 m so the residual is sub-mm, but the point is
+	// that this is computed, not assumed.
+	e0, n0 := reproj.project(0, 0)
+	assert.InDelta(t, dEast, e0, 1e-2)
+	assert.InDelta(t, dNorth, n0, 1e-2)
 }
 
-func TestComputeDatumShift_SameDatum(t *testing.T) {
-	lat := 48.5
-	lon := 11.5
-	e, n, warn := computeDatumShift(&lat, &lon, lat, lon, nil)
-	assert.InDelta(t, 0, e, 1e-9)
-	assert.InDelta(t, 0, n, 1e-9)
+func TestReproject_SameDatumIsIdentity(t *testing.T) {
+	// OM datum == MN datum → exact identity (matches the pre-fix additive
+	// behaviour for the "same datum" case).
+	lat, lon := 48.5, 11.5
+	r := datumReprojector{omLat: lat, omLon: lon, mnLat: lat, mnLon: lon}
+	for _, c := range [][2]float64{{0, 0}, {10, 6}, {-3, 3}, {-0.5, 0.2}} {
+		e, n := r.project(c[0], c[1])
+		assert.InDelta(t, c[0], e, 1e-9, "east not identity for %v", c)
+		assert.InDelta(t, c[1], n, 1e-9, "north not identity for %v", c)
+	}
+}
+
+func TestResolveReprojection_NoOmDatumWithMnSetIsIdentityPlusWarning(t *testing.T) {
+	r, warn := resolveReprojection(nil, nil, 48.0, 11.0, nil)
+	// Identity over the MN datum.
+	e, n := r.project(5, 7)
+	assert.InDelta(t, 5, e, 1e-9)
+	assert.InDelta(t, 7, n, 1e-9)
+	assert.Contains(t, warn, "Datum OpenMower non fourni")
+	assert.Contains(t, warn, "décalé")
+}
+
+func TestResolveReprojection_OmDatumWithMnUnsetAdoptsOmDatum(t *testing.T) {
+	// Fresh install: MN datum unreadable, OM datum provided → adopt OM as MN
+	// so the import is an exact identity, plus a "set datum_lat/lon" notice.
+	omLat, omLon := 49.123456, 8.654321
+	r, warn := resolveReprojection(&omLat, &omLon, 0, 0, errors.New("datum unset"))
+	for _, c := range [][2]float64{{0, 0}, {12.3, -4.5}} {
+		e, n := r.project(c[0], c[1])
+		assert.InDelta(t, c[0], e, 1e-9)
+		assert.InDelta(t, c[1], n, 1e-9)
+	}
+	assert.Contains(t, warn, "Datum MowgliNext absent")
+	assert.Contains(t, warn, "datum_lat/datum_lon")
+}
+
+func TestResolveReprojection_FullGeodeticNoWarning(t *testing.T) {
+	omLat, omLon := 49.0, 11.0
+	r, warn := resolveReprojection(&omLat, &omLon, 48.0, 11.0, nil)
 	assert.Empty(t, warn)
-}
-
-func TestComputeDatumShift_NorthernShift(t *testing.T) {
-	// OpenMower datum 1° north of MowgliNext at MN-lat 48° → ~111 km north.
-	mnLat := 48.0
-	mnLon := 11.0
-	omLat := 49.0
-	omLon := 11.0
-	e, n, warn := computeDatumShift(&omLat, &omLon, mnLat, mnLon, nil)
-	assert.Empty(t, warn)
-	assert.InDelta(t, 0, e, 1e-6)
-	assert.InDelta(t, metersPerDegreeLat, n, 1e-6)
+	// 1° north of the MN datum → the OM origin is ~111 km north.
+	e0, n0 := r.project(0, 0)
+	assert.InDelta(t, 0, e0, 1e-6)
+	assert.InDelta(t, metersPerDegreeLat, n0, 1e-6)
 }
 
 // --- HTTP handler --------------------------------------------------------

--- a/gui/web/src/i18n/locales/en.json
+++ b/gui/web/src/i18n/locales/en.json
@@ -1257,6 +1257,10 @@
   },
   "mapImportOpenMower": {
     "title": "Import OpenMower map",
+    "omDatumTitle": "OpenMower datum (optional)",
+    "omDatumHelp": "Enter the source robot's OM_DATUM_LAT / OM_DATUM_LONG so the map is reprojected into this robot's frame. Leave empty if both robots share the same datum — otherwise the import will be offset.",
+    "omDatumLat": "Latitude",
+    "omDatumLon": "Longitude",
     "applying": "Applying…",
     "applyReplaces": "Apply (replaces current map)",
     "cancel": "Cancel",

--- a/gui/web/src/i18n/locales/fr.json
+++ b/gui/web/src/i18n/locales/fr.json
@@ -1257,6 +1257,10 @@
   },
   "mapImportOpenMower": {
     "title": "Importer une carte OpenMower",
+    "omDatumTitle": "Datum OpenMower (optionnel)",
+    "omDatumHelp": "Saisissez le OM_DATUM_LAT / OM_DATUM_LONG du robot source pour que la carte soit reprojetée dans le repère de ce robot. Laissez vide si les deux robots partagent le même datum — sinon l'import sera décalé.",
+    "omDatumLat": "Latitude",
+    "omDatumLon": "Longitude",
     "applying": "Application…",
     "applyReplaces": "Appliquer (remplace la carte actuelle)",
     "cancel": "Annuler",

--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -470,6 +470,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
         handleDownloadGeoJSON,
         handleUploadGeoJSON,
         handleImportOpenMower,
+        handleReprojectOpenMowerPreview,
         handleApplyOpenMowerImport,
     } = useMapFiles({
         features,
@@ -996,11 +997,19 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
             </div>
             <ImportOpenMowerModal
                 preview={importPreview}
-                onApply={async () => {
+                onApply={async (omDatumLat, omDatumLon) => {
                     if (!importFileText) {
                         throw new Error("No imported map text in memory — re-select the file.");
                     }
-                    await handleApplyOpenMowerImport(importFileText);
+                    await handleApplyOpenMowerImport(importFileText, omDatumLat, omDatumLon);
+                }}
+                onReproject={async (omDatumLat, omDatumLon) => {
+                    if (!importFileText) {
+                        throw new Error("No imported map text in memory — re-select the file.");
+                    }
+                    const summary = await handleReprojectOpenMowerPreview(importFileText, omDatumLat, omDatumLon);
+                    setImportPreview(summary);
+                    return summary;
                 }}
                 onClose={() => {
                     setImportPreview(null);

--- a/gui/web/src/pages/map/components/ImportOpenMowerModal.tsx
+++ b/gui/web/src/pages/map/components/ImportOpenMowerModal.tsx
@@ -1,5 +1,5 @@
 import {useState} from "react";
-import {Alert, Modal, Statistic, Table, Tag, Typography} from "antd";
+import {Alert, InputNumber, Modal, Space, Statistic, Table, Tag, Typography} from "antd";
 import {useTranslation} from "react-i18next";
 import type {ImportOpenMowerSummary} from "../hooks/useMapFiles.ts";
 
@@ -7,12 +7,19 @@ interface ImportOpenMowerModalProps {
     preview: ImportOpenMowerSummary | null;
     /**
      * Apply confirmation. The hook re-POSTs the stashed file body with
-     * `apply: true`; this modal owns the loading + error UI but not the
-     * fetch itself. Returning a rejected promise here surfaces the error
-     * inline (we don't auto-close — the user can read the message and
-     * cancel).
+     * `apply: true` (and the OM datum, when set); this modal owns the
+     * loading + error UI but not the fetch itself. Returning a rejected
+     * promise here surfaces the error inline (we don't auto-close — the
+     * user can read the message and cancel).
      */
-    onApply: () => Promise<void>;
+    onApply: (omDatumLat?: number, omDatumLon?: number) => Promise<void>;
+    /**
+     * Re-run the preview with the OpenMower datum. The modal calls this
+     * after the user fills (or clears) both datum fields; the returned
+     * summary replaces the current preview so the datum-shift alert, dock
+     * pose, and warnings reflect the reprojected geometry.
+     */
+    onReproject: (omDatumLat?: number, omDatumLon?: number) => Promise<ImportOpenMowerSummary>;
     onClose: () => void;
 }
 
@@ -22,26 +29,62 @@ interface ImportOpenMowerModalProps {
  * user confirms, then runs the live write path on Apply via the
  * `onApply` callback wired from MapPage / useMapFiles.
  */
-export function ImportOpenMowerModal({preview, onApply, onClose}: ImportOpenMowerModalProps) {
+export function ImportOpenMowerModal({preview, onApply, onReproject, onClose}: ImportOpenMowerModalProps) {
     const {t} = useTranslation();
     const open = preview !== null;
     const summary = preview;
     const [applying, setApplying] = useState(false);
     const [applyError, setApplyError] = useState<string | null>(null);
+    // OpenMower datum (OM_DATUM_LAT/LONG) the source map was anchored at.
+    // Both must be filled for the server to reproject; either left empty
+    // ⇒ identity copy (offset import) + a warning from the backend.
+    const [omLat, setOmLat] = useState<number | null>(null);
+    const [omLon, setOmLon] = useState<number | null>(null);
+    const [reprojecting, setReprojecting] = useState(false);
+
+    const datumPair = (lat: number | null, lon: number | null): [number?, number?] =>
+        lat !== null && lon !== null ? [lat, lon] : [undefined, undefined];
 
     const handleOk = async () => {
         setApplying(true);
         setApplyError(null);
         try {
-            await onApply();
+            const [lat, lon] = datumPair(omLat, omLon);
+            await onApply(lat, lon);
             // Reset local state before the parent clears `preview`, so
             // the next import session starts clean.
             setApplying(false);
+            setOmLat(null);
+            setOmLon(null);
             onClose();
         } catch (e: any) {
             setApplyError(e?.message ?? String(e));
             setApplying(false);
         }
+    };
+
+    // Re-preview with the current datum fields. Wired to the inputs'
+    // onBlur / onPressEnter so the operator can tweak the datum and see
+    // the reprojected preview without an extra button.
+    const handleReproject = async () => {
+        setApplyError(null);
+        setReprojecting(true);
+        try {
+            const [lat, lon] = datumPair(omLat, omLon);
+            await onReproject(lat, lon);
+        } catch (e: any) {
+            setApplyError(e?.message ?? String(e));
+        } finally {
+            setReprojecting(false);
+        }
+    };
+
+    const handleCancel = () => {
+        if (applying) return;
+        setApplyError(null);
+        setOmLat(null);
+        setOmLon(null);
+        onClose();
     };
 
     const noMowAreas = (summary?.mowing_areas ?? 0) === 0;
@@ -50,15 +93,11 @@ export function ImportOpenMowerModal({preview, onApply, onClose}: ImportOpenMowe
         <Modal
             title={t('mapImportOpenMower.title')}
             open={open}
-            onCancel={() => {
-                if (applying) return;
-                setApplyError(null);
-                onClose();
-            }}
+            onCancel={handleCancel}
             onOk={handleOk}
             okText={applying ? t('mapImportOpenMower.applying') : t('mapImportOpenMower.applyReplaces')}
             okButtonProps={{
-                disabled: applying || noMowAreas,
+                disabled: applying || reprojecting || noMowAreas,
                 loading: applying,
                 danger: true,
             }}
@@ -76,6 +115,37 @@ export function ImportOpenMowerModal({preview, onApply, onClose}: ImportOpenMowe
                         message={t('mapImportOpenMower.replaceWarningMessage')}
                         description={t('mapImportOpenMower.replaceWarningDescription')}
                     />
+
+                    <div>
+                        <Typography.Text strong>{t('mapImportOpenMower.omDatumTitle')}</Typography.Text>
+                        <Typography.Paragraph type="secondary" style={{marginTop: 4, marginBottom: 8}}>
+                            {t('mapImportOpenMower.omDatumHelp')}
+                        </Typography.Paragraph>
+                        <Space wrap>
+                            <InputNumber
+                                addonBefore={t('mapImportOpenMower.omDatumLat')}
+                                value={omLat}
+                                onChange={(v) => setOmLat(typeof v === "number" ? v : null)}
+                                onBlur={handleReproject}
+                                onPressEnter={handleReproject}
+                                disabled={applying || reprojecting}
+                                step={0.000001}
+                                style={{width: 280}}
+                                placeholder="OM_DATUM_LAT"
+                            />
+                            <InputNumber
+                                addonBefore={t('mapImportOpenMower.omDatumLon')}
+                                value={omLon}
+                                onChange={(v) => setOmLon(typeof v === "number" ? v : null)}
+                                onBlur={handleReproject}
+                                onPressEnter={handleReproject}
+                                disabled={applying || reprojecting}
+                                step={0.000001}
+                                style={{width: 280}}
+                                placeholder="OM_DATUM_LONG"
+                            />
+                        </Space>
+                    </div>
 
                     <div style={{display: "flex", gap: 32, flexWrap: "wrap"}}>
                         <Statistic title={t('mapImportOpenMower.mowingAreas')} value={summary.mowing_areas} />

--- a/gui/web/src/pages/map/hooks/useMapFiles.ts
+++ b/gui/web/src/pages/map/hooks/useMapFiles.ts
@@ -315,24 +315,70 @@ export function useMapFiles({
     };
 
     /**
+     * Re-run the preview for an already-stashed map.json, this time
+     * supplying the OpenMower datum (OM_DATUM_LAT/LONG). The server
+     * reprojects every vertex from the OM datum into the MowgliNext map
+     * frame; without it the import lands at a constant offset (and a slight
+     * skew). Called by the modal when the user fills in / clears the datum
+     * fields. Returns the fresh summary so the modal can re-render the
+     * preview (datum-shift alert, dock pose, warnings).
+     */
+    const handleReprojectOpenMowerPreview = async (
+        importFileText: string,
+        omDatumLat?: number,
+        omDatumLon?: number,
+    ): Promise<ImportOpenMowerSummary> => {
+        if (!importFileText) {
+            throw new Error("no stashed map text — pick a file before re-projecting");
+        }
+        const body: Record<string, unknown> = {map: JSON.parse(importFileText)};
+        if (omDatumLat !== undefined && omDatumLon !== undefined) {
+            body.om_datum_lat = omDatumLat;
+            body.om_datum_lon = omDatumLon;
+        }
+        const res = await fetch("/api/import/openmower", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+            const errBody = await res.text();
+            throw new Error(`HTTP ${res.status}: ${errBody}`);
+        }
+        return (await res.json()) as ImportOpenMowerSummary;
+    };
+
+    /**
      * Confirm step of the OpenMower import. Re-POSTs the stashed file
      * body with `apply: true` so the server runs the same parse +
      * validate pipeline the user already saw in the preview modal, then
      * fires clear_map → add_area×N → save_areas → set_docking_point.
+     *
+     * The OpenMower datum (when the user supplied it) is sent again so the
+     * applied geometry matches the previewed, reprojected geometry exactly.
      *
      * On success the modal closes; `/map` will refresh on its own via
      * the existing websocket stream — no manual refetch needed. We do
      * drop the dirty / editMap flags so a previous in-progress local
      * edit doesn't reappear over the freshly imported areas.
      */
-    const handleApplyOpenMowerImport = async (importFileText: string): Promise<void> => {
+    const handleApplyOpenMowerImport = async (
+        importFileText: string,
+        omDatumLat?: number,
+        omDatumLon?: number,
+    ): Promise<void> => {
         if (!importFileText) {
             throw new Error("no stashed map text — preview must run before apply");
+        }
+        const body: Record<string, unknown> = {map: JSON.parse(importFileText), apply: true};
+        if (omDatumLat !== undefined && omDatumLon !== undefined) {
+            body.om_datum_lat = omDatumLat;
+            body.om_datum_lon = omDatumLon;
         }
         const res = await fetch("/api/import/openmower", {
             method: "POST",
             headers: {"Content-Type": "application/json"},
-            body: JSON.stringify({map: JSON.parse(importFileText), apply: true}),
+            body: JSON.stringify(body),
         });
         if (!res.ok) {
             const errBody = await res.text();
@@ -425,6 +471,7 @@ export function useMapFiles({
         handleDownloadGeoJSON,
         handleUploadGeoJSON,
         handleImportOpenMower,
+        handleReprojectOpenMowerPreview,
         handleApplyOpenMowerImport,
     };
 }

--- a/ros2/Dockerfile
+++ b/ros2/Dockerfile
@@ -214,10 +214,14 @@ RUN git clone --filter=blob:none --sparse ${NAV2_URL} navigation2 \
 # patching is a fail-fast guard so a future silent miss breaks the build
 # instead of regressing MPPI to corner-cutting behaviour.
 COPY patches/nav2_mppi_controller-findPathFurthestReachedPoint-arclength.patch /tmp/mppi.patch
+COPY patches/nav2_mppi_controller-turn-in-place-injection.patch /tmp/mppi-tip.patch
 RUN cd /ws/src/navigation2/nav2_mppi_controller \
  && patch -p1 < /tmp/mppi.patch \
  && grep -q 'path_integrated_dists' include/nav2_mppi_controller/tools/utils.hpp \
- && echo "Applied + verified nav2_mppi_controller arc-length patch"
+ && echo "Applied + verified nav2_mppi_controller arc-length patch" \
+ && patch -p1 < /tmp/mppi-tip.patch \
+ && grep -q 'injectTurnInPlacePrimitives' src/optimizer.cpp \
+ && echo "Applied + verified nav2_mppi_controller turn-in-place-injection patch"
 
 # Build the single patched package into a standalone overlay prefix. The
 # resulting libmppi_controller.so + plugin manifest live under

--- a/ros2/patches/README.md
+++ b/ros2/patches/README.md
@@ -18,6 +18,47 @@ feasible) so it re-bases trivially when the upstream ref is bumped.
 
 ---
 
+## `nav2_mppi_controller-turn-in-place-injection.patch`
+
+- **Upstream:** same pinned ref as below (`71a1d84`, nav2_mppi_controller 1.4.2).
+  Applied AFTER the arc-length patch in the same builder stage.
+- **STATUS: EXPERIMENTAL SPIKE — off by default.** With
+  `turn_in_place_samples: 0` (the default) the controller is byte-for-byte
+  stock MPPI. This is NOT carried because upstream lacks a fix; it is a local
+  experiment to see whether MPPI can do the hard ~180° coverage swath flips
+  itself instead of via per-segment RotationShim re-dispatch.
+- **WHY this is a patch, not a plugin:** upstream PR #6076 pluginized only the
+  *motion models*; for a diff-drive the DiffDrive model already permits a pivot
+  (vx=0, wz≠0) — the blocker is that Gaussian control sampling (`NoiseGenerator`)
+  almost never *proposes* a near-stationary pivot, and that path is not
+  pluginizable. So the only MPPI-native route is to inject candidates directly.
+  See nav2 issue #6032 (control-set generation) — the maintainer's recommended
+  alternative is RotationShim / Spin, which is why this stays a spike.
+- **WHAT:** Adds `Optimizer::injectTurnInPlacePrimitives()`, called in
+  `generateNoisedTrajectories()` between `setNoisedControls()` and the motion
+  rollout. When `turn_in_place_samples (K) > 0` AND the robot is near-stationary
+  (`< turn_in_place_max_speed`) AND grossly mis-headed vs the path
+  `turn_in_place_lookahead` m ahead (`|yaw_err| > turn_in_place_min_yaw`), it
+  overwrites the last K of the `batch_size` sampled trajectories with a
+  deterministic **pivot-then-advance** primitive (spin toward the path heading,
+  then drive forward along it). The critics then score it like any other
+  candidate — a pivot is only chosen if it actually wins the softmax. A pure
+  spin is deliberately NOT used (it makes no progress and the path-follow critic
+  would reject it).
+- **Params** (under the MPPI controller, e.g. `FollowCoveragePath.*`):
+  `turn_in_place_samples` (int, **0=disabled**), `turn_in_place_min_yaw` (rad,
+  1.2), `turn_in_place_max_speed` (m/s, 0.1), `turn_in_place_lookahead` (m, 0.5).
+- **OPEN QUESTION the spike answers:** whether the critics actually select the
+  injected pivot at a swath flip, or whether forward candidates still out-score
+  it (Steve Macenski's caveat in #6032). Measure with the monitor's
+  `cross_checks.rotation` / `pivot_stall` telemetry on a coverage run with
+  `turn_in_place_samples: ~100` vs `0`.
+- **REMOVE** if the spike fails or once the per-segment RotationShim path is
+  chosen: delete this `.patch`, the second `COPY`/`patch`/`grep` lines in the
+  `nav2-mppi-patched-builder` Dockerfile stage.
+
+---
+
 ## `nav2_mppi_controller-findPathFurthestReachedPoint-arclength.patch`
 
 - **Upstream:** `ros-navigation/navigation2`, branch `kilted`

--- a/ros2/patches/nav2_mppi_controller-turn-in-place-injection.patch
+++ b/ros2/patches/nav2_mppi_controller-turn-in-place-injection.patch
@@ -1,0 +1,161 @@
+diff --git a/include/nav2_mppi_controller/optimizer.hpp b/include/nav2_mppi_controller/optimizer.hpp
+index 2ced1fe2..0aa377c9 100644
+--- a/include/nav2_mppi_controller/optimizer.hpp
++++ b/include/nav2_mppi_controller/optimizer.hpp
+@@ -175,6 +175,15 @@ protected:
+    */
+   void generateNoisedTrajectories();
+ 
++  /**
++   * @brief Overwrite the last turn_in_place_samples_ trajectories with a
++   * deterministic pivot-then-advance primitive when the robot is (near)
++   * stationary and grossly mis-headed vs the path ahead. No-op when
++   * turn_in_place_samples_ == 0. Called between setNoisedControls() and
++   * the motion-model rollout in generateNoisedTrajectories().
++   */
++  void injectTurnInPlacePrimitives();
++
+   /**
+    * @brief Apply hard vehicle constraints on control sequence
+    */
+@@ -277,6 +286,13 @@ protected:
+     std::nullopt, std::nullopt};  /// Caution, keep references
+ 
+   rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
++
++  // Turn-in-place primitive injection (spike). turn_in_place_samples_ == 0
++  // (default) disables it and reproduces stock MPPI exactly.
++  int turn_in_place_samples_{0};
++  float turn_in_place_min_yaw_{1.2f};
++  float turn_in_place_max_speed_{0.1f};
++  float turn_in_place_lookahead_{0.5f};
+ };
+ 
+ }  // namespace mppi
+diff --git a/src/optimizer.cpp b/src/optimizer.cpp
+index 6e63361e..f989962e 100644
+--- a/src/optimizer.cpp
++++ b/src/optimizer.cpp
+@@ -22,6 +22,7 @@
+ #include <vector>
+ #include <cmath>
+ #include <chrono>
++#include <algorithm>
+ 
+ #include "nav2_core/controller_exceptions.hpp"
+ #include "nav2_costmap_2d/costmap_filters/filter_values.hpp"
+@@ -83,6 +84,18 @@ void Optimizer::getParams()
+   getParam(s.sampling_std.wz, "wz_std", 0.4f);
+   getParam(s.retry_attempt_limit, "retry_attempt_limit", 1);
+ 
++  // Turn-in-place primitive injection (mowglinext spike, off by default).
++  // When turn_in_place_samples > 0, the last K sampled trajectories are
++  // overwritten each cycle with a deterministic pivot-then-advance maneuver
++  // whenever the robot is (near) stationary AND grossly mis-headed vs the path
++  // ahead — giving the optimizer the OPTION to rotate in place at hard turns
++  // (e.g. coverage swath flips) that Gaussian sampling almost never proposes.
++  // K=0 reproduces stock MPPI exactly.
++  getParam(turn_in_place_samples_, "turn_in_place_samples", 0);
++  getParam(turn_in_place_min_yaw_, "turn_in_place_min_yaw", 1.2f);
++  getParam(turn_in_place_max_speed_, "turn_in_place_max_speed", 0.1f);
++  getParam(turn_in_place_lookahead_, "turn_in_place_lookahead", 0.5f);
++
+   s.base_constraints.ax_max = fabs(s.base_constraints.ax_max);
+   if (s.base_constraints.ax_min > 0.0) {
+     s.base_constraints.ax_min = -1.0 * s.base_constraints.ax_min;
+@@ -248,10 +261,95 @@ void Optimizer::generateNoisedTrajectories()
+ {
+   noise_generator_.setNoisedControls(state_, control_sequence_);
+   noise_generator_.generateNextNoises();
++  // Overwrite the last K candidates with a turn-in-place primitive (no-op when
++  // turn_in_place_samples == 0). Must run AFTER setNoisedControls (which writes
++  // cvx/cwz) and BEFORE updateStateVelocities (whose predict() rolls cvx/cwz
++  // into the trajectories and accel-clamps them). Single-threaded here.
++  injectTurnInPlacePrimitives();
+   updateStateVelocities(state_);
+   integrateStateVelocities(generated_trajectories_, state_);
+ }
+ 
++void Optimizer::injectTurnInPlacePrimitives()
++{
++  const int K = turn_in_place_samples_;
++  if (K <= 0) {
++    return;  // disabled — stock MPPI behaviour
++  }
++  auto & s = settings_;
++  const int n_path = static_cast<int>(path_.x.size());
++  if (n_path < 2) {
++    return;
++  }
++
++  // Gate 1: only when (near) stationary. A pivot from speed is infeasible and
++  // predict() would warp it anyway.
++  const double cur_speed = std::hypot(state_.speed.linear.x, state_.speed.linear.y);
++  if (cur_speed > turn_in_place_max_speed_) {
++    return;
++  }
++
++  // Heading the path wants ~turn_in_place_lookahead_ metres ahead of the
++  // nearest path point to the robot.
++  const double rx = state_.pose.pose.position.x;
++  const double ry = state_.pose.pose.position.y;
++  int nearest = 0;
++  float best = std::numeric_limits<float>::max();
++  for (int i = 0; i < n_path; ++i) {
++    const float dx = path_.x(i) - static_cast<float>(rx);
++    const float dy = path_.y(i) - static_cast<float>(ry);
++    const float d2 = dx * dx + dy * dy;
++    if (d2 < best) {
++      best = d2;
++      nearest = i;
++    }
++  }
++  int ahead = nearest;
++  double acc = 0.0;
++  for (int i = nearest + 1; i < n_path; ++i) {
++    acc += std::hypot(path_.x(i) - path_.x(i - 1), path_.y(i) - path_.y(i - 1));
++    ahead = i;
++    if (acc >= turn_in_place_lookahead_) {
++      break;
++    }
++  }
++  const double cur_yaw = tf2::getYaw(state_.pose.pose.orientation);
++  const double path_yaw = path_.yaws(ahead);
++
++  // Gate 2: only when grossly mis-headed (e.g. a swath flip ~ pi). Shortest
++  // signed angular distance, no <angles> dependency.
++  const double yaw_err =
++    std::atan2(std::sin(path_yaw - cur_yaw), std::cos(path_yaw - cur_yaw));
++  if (std::fabs(yaw_err) < turn_in_place_min_yaw_) {
++    return;
++  }
++
++  // Pivot-then-advance: spin toward the path heading for rot_steps, then drive
++  // forward along it for the rest of the horizon — so the candidate both
++  // ALIGNS and makes PROGRESS (a pure spin scores poorly on the path-follow
++  // critic and would never be selected).
++  const float wz_cmd = (yaw_err >= 0.0 ? 1.0f : -1.0f) * s.constraints.wz;
++  const int steps = s.time_steps;
++  const float denom = std::max(1e-3f, s.constraints.wz * s.model_dt);
++  int rot_steps = static_cast<int>(std::ceil(std::fabs(yaw_err) / denom));
++  rot_steps = std::min(rot_steps, steps);
++
++  const int batch = s.batch_size;
++  const int kk = std::min(K, batch);
++  const int start = batch - kk;
++
++  state_.cvx.block(start, 0, kk, rot_steps).setZero();
++  state_.cwz.block(start, 0, kk, rot_steps).setConstant(wz_cmd);
++  if (rot_steps < steps) {
++    const int fwd = steps - rot_steps;
++    state_.cvx.block(start, rot_steps, kk, fwd).setConstant(s.constraints.vx_max);
++    state_.cwz.block(start, rot_steps, kk, fwd).setZero();
++  }
++  if (isHolonomic()) {
++    state_.cvy.bottomRows(kk).setZero();
++  }
++}
++
+ void Optimizer::applyControlSequenceConstraints()
+ {
+   auto & s = settings_;

--- a/ros2/scripts/mow_session_monitor.py
+++ b/ros2/scripts/mow_session_monitor.py
@@ -128,6 +128,26 @@ RTK_COV_WINDOW_SEC = 0.30
 
 
 # -----------------------------------------------------------------------------
+# Rotation tracking (RotationShim / closed_loop diagnosis)
+#
+# The controllers command an angular rate (cmd_vel.nav.wz); the gyro
+# (imu.gyro.z) is the ground truth of what the chassis actually did. Comparing
+# the two reveals two failure modes this robot has hit:
+#   * pivot stall  — the RotationShim closed_loop=true "pins at one accel step
+#     below the firmware deadband": a sustained angular COMMAND with near-zero
+#     ACTUAL rotation while the robot is NOT driving forward (in-place pivot).
+#   * tracking error — large |cmd_wz - gyro_z| during motion (lag / overshoot).
+# -----------------------------------------------------------------------------
+
+# A pivot is "commanding rotation" when |cmd_wz| exceeds this (rad/s).
+ROT_PIVOT_CMD_THRESHOLD = 0.20
+# ...but the chassis is "not actually rotating" when |gyro_z| is below this.
+ROT_STALL_ACTUAL_THRESHOLD = 0.05
+# ...and it's an in-place pivot (not a moving arc) when |cmd_vx| is below this.
+ROT_PIVOT_FWD_THRESHOLD = 0.05
+
+
+# -----------------------------------------------------------------------------
 # Sample record — each subscription updates a slot; the periodic timer
 # snapshots the whole state into a JSON line.
 # -----------------------------------------------------------------------------
@@ -247,6 +267,12 @@ class MowSessionMonitor(Node):
         self.start_fusion_xy: Optional[tuple[float, float]] = None
         self.peak_fusion_gps_err = 0.0
         self.peak_wheel_gyro_yaw_drift = 0.0
+
+        # --- Rotation tracking aggregates (see ROT_* constants) ---
+        self.rot_err_sum = 0.0          # Σ|cmd_wz - gyro_z| over samples with both
+        self.rot_err_n = 0
+        self.peak_rot_track_err = 0.0   # worst |cmd_wz - gyro_z|
+        self.pivot_stall_samples = 0    # samples flagged as a pivot stall
 
         # --- RTK covariance-drop check state ---
         # See the comment block above RTK_FIXED_GPS_COV_THRESHOLD for why this
@@ -587,6 +613,29 @@ class MowSessionMonitor(Node):
                     s.fusion_x - s.plan_goal_x, s.fusion_y - s.plan_goal_y
                 )
 
+            # --- Rotation tracking: commanded ω vs gyro (actual) ---
+            cmd_wz = s.cmd_vel_nav_wz
+            act_wz = s.imu_gyro_z          # gyro is the chassis truth
+            rot_err = None
+            pivot_stall = False
+            if cmd_wz is not None and act_wz is not None:
+                rot_err = cmd_wz - act_wz
+                self.rot_err_sum += abs(rot_err)
+                self.rot_err_n += 1
+                self.peak_rot_track_err = max(
+                    self.peak_rot_track_err, abs(rot_err)
+                )
+                # Closed-loop-pin / deadband signature: commanding a pivot but
+                # the chassis isn't turning and isn't driving forward.
+                if (
+                    abs(cmd_wz) > ROT_PIVOT_CMD_THRESHOLD
+                    and abs(act_wz) < ROT_STALL_ACTUAL_THRESHOLD
+                    and (s.cmd_vel_nav_vx is None
+                         or abs(s.cmd_vel_nav_vx) < ROT_PIVOT_FWD_THRESHOLD)
+                ):
+                    pivot_stall = True
+                    self.pivot_stall_samples += 1
+
             record: dict[str, Any] = {
                 "type": "sample",
                 "t": now_unix,
@@ -736,6 +785,18 @@ class MowSessionMonitor(Node):
                     ),
                     "fusion_carto_yaw_diff_deg": fusion_carto_yaw_diff,
                     "wheel_gyro_yaw_drift_deg": wheel_gyro_drift,
+                    # Rotation tracking — commanded ω vs gyro (actual chassis
+                    # rotation), the signal for RotationShim / closed_loop
+                    # diagnosis. track_err_wz is per-sample; pivot_stall flags
+                    # the closed-loop-pin / deadband signature (commanding a
+                    # pivot the chassis isn't executing).
+                    "rotation": {
+                        "cmd_wz": cmd_wz,
+                        "actual_wz_gyro": act_wz,
+                        "actual_wz_wheel": s.wheel_wz,
+                        "track_err_wz": rot_err,
+                        "pivot_stall": pivot_stall,
+                    },
                     # RTK covariance-drop health (see file-top constants).
                     # violations > 0 ⇒ outlier gate rejecting RTK fixes.
                     "rtk_cov_check": {
@@ -804,6 +865,16 @@ class MowSessionMonitor(Node):
                 "session_straight_line_displacement_m": fusion_xy_travel,
                 "peak_fusion_gps_error_m": self.peak_fusion_gps_err,
                 "peak_wheel_gyro_yaw_drift_deg": self.peak_wheel_gyro_yaw_drift,
+                "rotation_tracking": {
+                    "mean_abs_track_err_wz": (
+                        self.rot_err_sum / self.rot_err_n
+                        if self.rot_err_n > 0
+                        else None
+                    ),
+                    "peak_track_err_wz": self.peak_rot_track_err,
+                    "pivot_stall_samples": self.pivot_stall_samples,
+                    "pivot_stall_sec": self.pivot_stall_samples / self.args.rate,
+                },
                 "rtk_cov_check": {
                     "rtk_fixed_arrivals": self.rtk_fixed_arrivals,
                     "ok": self.rtk_cov_checks_ok,

--- a/ros2/src/fusion_graph/src/fusion_graph_node_publish.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_publish.cpp
@@ -163,6 +163,14 @@ void FusionGraphNode::PublishOutputs(const TickOutput& out)
   odom.pose.covariance[14] = 1e-9;
   odom.pose.covariance[21] = 1e-9;
   odom.pose.covariance[28] = 1e-9;
+  // Body-frame twist is frame-invariant, so the map-frame odom carries the
+  // same velocities as the local /odometry/filtered above (wheel vx + the
+  // bias-corrected gyro yaw rate). Without this the twist stayed all-zero,
+  // which is misleading for any consumer reading the fused estimate's
+  // velocity (e.g. the session monitor's rotation view).
+  odom.twist.twist.linear.x = wheel_vx_;
+  odom.twist.twist.linear.y = 0.0;
+  odom.twist.twist.angular.z = dr_last_gz_;
   pub_odom_->publish(odom);
 
   // Rebaseline the high-rate extrapolator (item #15). The fast

--- a/ros2/src/fusion_graph/src/fusion_graph_node_publish.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_publish.cpp
@@ -102,6 +102,14 @@ void FusionGraphNode::PublishLocalOdom()
   odom.pose.pose.orientation = q_msg;
   odom.twist.twist.linear.x = wheel_vx_;
   odom.twist.twist.linear.y = 0.0;
+  // Bias-corrected gyro yaw rate (the same gz that integrated dr_yaw_). Nav2's
+  // controller_server reads this as its angular velocity feedback — MPPI seeds
+  // its rollouts from it, RPP scales lookahead by it. Leaving it unset (it used
+  // to default to 0) made /odometry/filtered unusable for the controllers, which
+  // is why they had to fall back to raw /wheel_odom; the gyro is the honest
+  // source during pivots, so publish it here and let the controllers use the
+  // fused odom.
+  odom.twist.twist.angular.z = dr_last_gz_;
   // Dead reckoning has unbounded drift — leave pose covariance loose
   // and let Nav2 trust the graph's /odometry/filtered_map for absolute
   // positioning. Tight roll/pitch/z so 2D consumers don't see NaN.

--- a/ros2/src/mowgli_behavior/CMakeLists.txt
+++ b/ros2/src/mowgli_behavior/CMakeLists.txt
@@ -186,6 +186,38 @@ if(BUILD_TESTING)
     action_msgs
   )
 
+  # ---- test_get_next_unmowed_area ----
+  # Regression: the mow-selection path SKIPS navigation-only areas. Stands up a
+  # real in-process get_mowing_area service returning a nav-only area + a mowing
+  # area and ticks GetNextUnmowedArea to confirm the nav-only zone is never
+  # selected for coverage.
+  ament_add_gtest(test_get_next_unmowed_area
+    test/test_get_next_unmowed_area.cpp
+    src/coverage_nodes.cpp
+  )
+
+  target_include_directories(test_get_next_unmowed_area PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+
+  ament_target_dependencies(test_get_next_unmowed_area
+    rclcpp
+    rclcpp_action
+    behaviortree_cpp
+    mowgli_interfaces
+    nav2_msgs
+    nav_msgs
+    geometry_msgs
+    std_msgs
+    std_srvs
+    tf2
+    tf2_ros
+    tf2_geometry_msgs
+    rcl_interfaces
+    action_msgs
+  )
+
 endif()
 
 ament_package()

--- a/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
@@ -799,6 +799,25 @@ BT::NodeStatus GetNextUnmowedArea::processResponse()
 
   areas_queried_++;
 
+  // Navigation-only areas are transit corridors, NOT mowing targets — they
+  // carry is_navigation_area=true and must never be selected for coverage (the
+  // blades would run inside a zone the operator marked nav-only). map_server
+  // still returns these (success=true) because the obstacle tracker needs their
+  // geometry, so the skip lives here on the selection side. Mark the area
+  // attempted so subsequent probes don't re-evaluate it, then advance.
+  if (response->area.is_navigation_area)
+  {
+    {
+      std::lock_guard<std::mutex> lock(ctx->context_mutex);
+      ctx->attempted_areas.insert(current_area_idx_);
+    }
+    RCLCPP_INFO(ctx->node->get_logger(),
+                "GetNextUnmowedArea: area %u is navigation-only ('%s') — skipping (not mowed)",
+                current_area_idx_,
+                response->area.name.c_str());
+    return advanceAndProbe();
+  }
+
   // Completion is now the swath-completion model: an area is done when
   // FollowStrip has mowed every swath F2C produced for it (recorded in
   // ctx->completed_areas). The onStart/advance skip-loops already exclude
@@ -1010,6 +1029,16 @@ BT::NodeStatus PlanCoverageArea::onRunning()
     {
       RCLCPP_ERROR(ctx->node->get_logger(),
                    "PlanCoverageArea: get_mowing_area failed for the requested area");
+      return BT::NodeStatus::FAILURE;
+    }
+    // Defensive: never plan coverage for a navigation-only zone (the blades
+    // would run inside a transit corridor). GetNextUnmowedArea already skips
+    // these on the selection side; this guards a directly-selected nav index.
+    if (resp->area.is_navigation_area)
+    {
+      RCLCPP_WARN(ctx->node->get_logger(),
+                  "PlanCoverageArea: area '%s' is navigation-only — refusing to plan coverage",
+                  resp->area.name.c_str());
       return BT::NodeStatus::FAILURE;
     }
     // Plan the FULL area (outer ring + obstacle holes) ONCE. Resume is

--- a/ros2/src/mowgli_behavior/test/test_get_next_unmowed_area.cpp
+++ b/ros2/src/mowgli_behavior/test/test_get_next_unmowed_area.cpp
@@ -1,0 +1,223 @@
+// Copyright 2026 Mowgli Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * @file test_get_next_unmowed_area.cpp
+ * @brief Regression test: the mow-selection path SKIPS navigation-only areas.
+ *
+ * GetNextUnmowedArea iterates the map's areas via get_mowing_area. A
+ * navigation-only zone (is_navigation_area=true) is a transit corridor, not a
+ * mowing target — the blades must never run inside it. map_server still returns
+ * these areas (success=true) because the obstacle tracker needs their geometry,
+ * so the skip lives on the BT selection side. These tests stand up a REAL
+ * in-process get_mowing_area service (no robot, no mocked interfaces) and tick
+ * the StatefulActionNode to verify a nav-only area is never selected.
+ */
+
+#include <chrono>
+#include <map>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "behaviortree_cpp/bt_factory.h"
+#include "mowgli_behavior/bt_context.hpp"
+#include "mowgli_behavior/coverage_nodes.hpp"
+#include "mowgli_interfaces/srv/get_mowing_area.hpp"
+#include <gtest/gtest.h>
+
+using mowgli_behavior::BTContext;
+using mowgli_behavior::GetNextUnmowedArea;
+using GetMowingArea = mowgli_interfaces::srv::GetMowingArea;
+
+// ---------------------------------------------------------------------------
+// Global ROS2 init/shutdown
+// ---------------------------------------------------------------------------
+
+class RclcppEnvironment : public ::testing::Environment
+{
+public:
+  void SetUp() override
+  {
+    if (!rclcpp::ok())
+    {
+      rclcpp::init(0, nullptr);
+    }
+  }
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+  }
+};
+
+::testing::Environment* const rclcpp_env =
+    ::testing::AddGlobalTestEnvironment(new RclcppEnvironment());
+
+// ---------------------------------------------------------------------------
+// One entry the fake map_server returns per index: name + nav-only flag.
+// index past the last entry → success=false (matches real map_server).
+// ---------------------------------------------------------------------------
+struct AreaEntry
+{
+  std::string name;
+  bool is_navigation_area;
+};
+
+class GetNextUnmowedAreaTest : public ::testing::Test
+{
+protected:
+  std::shared_ptr<BTContext> ctx;
+  BT::Blackboard::Ptr blackboard;
+  BT::BehaviorTreeFactory factory;
+  rclcpp::Node::SharedPtr server_node;
+  rclcpp::Service<GetMowingArea>::SharedPtr service;
+  rclcpp::executors::SingleThreadedExecutor executor;
+  std::map<uint32_t, AreaEntry> areas;
+
+  void SetUp() override
+  {
+    ctx = std::make_shared<BTContext>();
+    ctx->node = rclcpp::Node::make_shared("test_get_next_unmowed_area");
+    ctx->helper_node = rclcpp::Node::make_shared("test_get_next_unmowed_area_helper");
+
+    blackboard = BT::Blackboard::create();
+    blackboard->set("context", ctx);
+
+    factory.registerNodeType<GetNextUnmowedArea>("GetNextUnmowedArea");
+
+    server_node = rclcpp::Node::make_shared("fake_map_server");
+    service = server_node->create_service<GetMowingArea>(
+        "/map_server_node/get_mowing_area",
+        [this](const std::shared_ptr<GetMowingArea::Request> req,
+               std::shared_ptr<GetMowingArea::Response> resp)
+        {
+          auto it = areas.find(req->index);
+          if (it == areas.end())
+          {
+            resp->success = false;  // index past the last defined area
+            return;
+          }
+          resp->area.name = it->second.name;
+          resp->area.is_navigation_area = it->second.is_navigation_area;
+          resp->success = true;
+        });
+
+    executor.add_node(ctx->helper_node);
+    executor.add_node(server_node);
+  }
+
+  /// Wait for the helper-side client to discover the fake service.
+  void waitForService()
+  {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      executor.spin_some();
+      auto client =
+          ctx->helper_node->create_client<GetMowingArea>("/map_server_node/get_mowing_area");
+      if (client->service_is_ready())
+      {
+        return;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    FAIL() << "fake get_mowing_area service was never discovered";
+  }
+
+  /// Tick the node to completion, spinning the executor between ticks so the
+  /// async service round-trips complete. Returns the terminal status.
+  BT::NodeStatus tickToCompletion(BT::Tree& tree)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    BT::NodeStatus status = BT::NodeStatus::RUNNING;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      status = tree.tickOnce();
+      if (status != BT::NodeStatus::RUNNING)
+      {
+        break;
+      }
+      executor.spin_some();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return status;
+  }
+
+  BT::Tree makeTree(uint32_t max_areas)
+  {
+    const std::string xml =
+        "<root BTCPP_format=\"4\"><BehaviorTree ID=\"MainTree\">"
+        "<GetNextUnmowedArea max_areas=\"" +
+        std::to_string(max_areas) +
+        "\" area_index=\"{area_index}\"/>"
+        "</BehaviorTree></root>";
+    return factory.createTreeFromText(xml, blackboard);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// A navigation-only area at index 0 followed by a mowing area at index 1: the
+// selection must SKIP index 0 and pick index 1.
+TEST_F(GetNextUnmowedAreaTest, SkipsNavigationOnlyAreaAndSelectsMowingArea)
+{
+  areas[0] = {"front_path", /*is_navigation_area=*/true};
+  areas[1] = {"lawn", /*is_navigation_area=*/false};
+  waitForService();
+
+  auto tree = makeTree(/*max_areas=*/5);
+  EXPECT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+
+  uint32_t selected = 99;
+  ASSERT_TRUE(blackboard->get("area_index", selected));
+  EXPECT_EQ(selected, 1u) << "must skip the nav-only area 0 and select mowing area 1";
+  EXPECT_EQ(ctx->current_area, 1);
+  // The skipped nav area is marked attempted so it is not re-evaluated.
+  EXPECT_GT(ctx->attempted_areas.count(0u), 0u);
+}
+
+// The ONLY area is navigation-only: nothing is mowable → FAILURE, and the nav
+// area is never selected.
+TEST_F(GetNextUnmowedAreaTest, NavigationOnlyAreaIsNeverMowed)
+{
+  areas[0] = {"perimeter_corridor", /*is_navigation_area=*/true};
+  waitForService();
+
+  auto tree = makeTree(/*max_areas=*/5);
+  EXPECT_EQ(tickToCompletion(tree), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->current_area, -1) << "no area should have been selected for mowing";
+  EXPECT_GT(ctx->attempted_areas.count(0u), 0u);
+}
+
+// Control: an ordinary mowing area at index 0 is selected as before (the skip
+// must not regress normal selection).
+TEST_F(GetNextUnmowedAreaTest, SelectsMowingAreaAtIndexZero)
+{
+  areas[0] = {"lawn", /*is_navigation_area=*/false};
+  waitForService();
+
+  auto tree = makeTree(/*max_areas=*/5);
+  EXPECT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+
+  uint32_t selected = 99;
+  ASSERT_TRUE(blackboard->get("area_index", selected));
+  EXPECT_EQ(selected, 0u);
+  EXPECT_EQ(ctx->current_area, 0);
+}

--- a/ros2/src/mowgli_bringup/config/nav2_params_base.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params_base.yaml
@@ -63,6 +63,15 @@ controller_server:
   ros__parameters:
     use_sim_time: false
     enable_stamped_cmd_vel: true
+    # Velocity-feedback source for the controllers — MPPI reads current speed
+    # from here to seed its trajectory rollouts, RPP for its velocity-scaled
+    # lookahead. MUST be set: the nav2 default is "odom", but nothing publishes
+    # /odom on this robot, so leaving the default gave both controllers ZERO
+    # velocity feedback — MPPI planned every cycle as if stationary (circling on
+    # tight coverage) and RPP's lookahead collapsed to its minimum (transit
+    # weaving). Use the fused /odometry/filtered, same source bt_navigator uses;
+    # fusion_graph now publishes twist.angular.z (bias-corrected gyro rate) on it.
+    odom_topic: /odometry/filtered
     # 10 Hz: 0.3 m/s × 100 ms = 3 cm of motion between decisions, matches
     # the 5-10 Hz upstream costmap / GPS refresh. Dropped from 20 Hz
     # because the ARM host was chronically missing the 20 Hz loop rate

--- a/ros2/src/mowgli_bringup/test/test_nav2_params.py
+++ b/ros2/src/mowgli_bringup/test/test_nav2_params.py
@@ -138,6 +138,34 @@ def test_followcoveragepath_uses_rotation_shim_mppi() -> None:
     )
 
 
+# Topics that actually have a publisher on this robot. The nav2 default
+# odom_topic is "odom", which NOTHING publishes here — leaving the default
+# silently gave the controllers zero velocity feedback (MPPI circled on tight
+# coverage, RPP's velocity-scaled lookahead collapsed to its minimum and the
+# robot wove in transit). bt_navigator and controller_server must both point at
+# a real, published source. /odometry/filtered (fusion_graph local odom) now
+# carries twist.angular.z (bias-corrected gyro rate), so it is usable.
+_PUBLISHED_ODOM_TOPICS = {"/odometry/filtered", "/odometry/filtered_map", "/wheel_odom"}
+
+
+def test_controller_odom_topic_is_published() -> None:
+    """controller_server.odom_topic MUST be set to a published topic.
+
+    Regression for the silent-default bug: nav2 defaults odom_topic to "odom",
+    which has no publisher on this robot, so MPPI/RPP ran with zero velocity
+    feedback. Pin it to a real source (fused /odometry/filtered).
+    """
+    cfg = _controller_section(_load_params())
+    assert "odom_topic" in cfg, (
+        "controller_server.odom_topic is unset → falls back to the nav2 default "
+        "'odom', which nothing publishes; the controllers get no velocity feedback."
+    )
+    assert cfg["odom_topic"] in _PUBLISHED_ODOM_TOPICS, (
+        f"controller_server.odom_topic={cfg['odom_topic']!r} is not a published "
+        f"topic on this robot (expected one of {_PUBLISHED_ODOM_TOPICS})."
+    )
+
+
 # ── 2026-05-08 field bug: launch override + per-site yaml + no-lidar variant
 # all default coverage_xy_tolerance back to 0.5 m, silently re-breaking
 # coverage. The nav2_params.yaml fix above is necessary but not sufficient

--- a/ros2/src/mowgli_coverage/include/mowgli_coverage/coverage_planning.hpp
+++ b/ros2/src/mowgli_coverage/include/mowgli_coverage/coverage_planning.hpp
@@ -25,6 +25,7 @@
 #define MOWGLI_COVERAGE__COVERAGE_PLANNING_HPP_
 
 #include <cstddef>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -34,6 +35,27 @@
 
 namespace mowgli_coverage
 {
+
+// Visibility into what planBoustrophedon dropped and how much of the polygon
+// it ended up planning. Coverage gaps were previously silent (slivers, tiny
+// rings, micro-cells, and whole-area F2C failures all just vanished from the
+// plan); these counters/strings let the next iteration SEE the loss without
+// changing any drop threshold. Pure accounting — cheap to populate.
+struct PlanDiagnostics
+{
+  // One human-readable line per dropped piece, with its measured dimension and
+  // the threshold it failed (e.g. "dropped swath len=0.1200<0.1500",
+  // "dropped ring perim=0.7000<1.0000"). The server logs these verbatim.
+  std::vector<std::string> drops;
+  // Planned-coverage fraction in [0, 1]: (sum of swath-strip areas at op_width +
+  // ring-strip areas at op_width) / polygon area. A coarse estimate (strips can
+  // overlap at corners and the rings/swaths butt rather than overlap), so it can
+  // slightly exceed the true mowed fraction — it is a visibility metric, not a
+  // guarantee. Stays 0 when the field area is non-positive.
+  double planned_fraction = 0.0;
+  double field_area = 0.0;  // m² — the polygon area the fraction is taken over
+  double planned_area = 0.0;  // m² — strip-area numerator (rings + swaths)
+};
 
 // One planned coverage, as explicit drivable segments.
 struct BoustrophedonPlan
@@ -48,6 +70,8 @@ struct BoustrophedonPlan
   std::vector<std::pair<std::pair<double, double>, std::pair<double, double>>> swaths;
   // Swath heading actually used (rad, map frame) — for logging.
   double swath_angle_rad = 0.0;
+  // Drop reasons + planned-coverage fraction (instrumentation only — see above).
+  PlanDiagnostics diagnostics;
 };
 
 // Plan boustrophedon coverage of `field_cell` (outer ring + optional holes).
@@ -65,7 +89,14 @@ struct BoustrophedonPlan
 // n_rings * op_width) so the swaths butt against the innermost ring's cut.
 //
 // Returns a plan whose rings/swaths may BOTH be empty (field too small after
-// insets — the caller reports failure). Throws on internal F2C errors.
+// insets — the caller reports failure). Throws on internal F2C errors. The
+// returned plan's `diagnostics` records every dropped piece (slivers, tiny
+// rings, micro-cells) and the planned-coverage fraction — instrumentation the
+// caller logs; no drop threshold is altered.
+//
+// chassis_safety_inset is taken as-is here: the caller is responsible for
+// flooring it at robot_width/2 (a SAFETY margin — blades must not cross the
+// boundary) before calling, so this function plans against the effective inset.
 BoustrophedonPlan planBoustrophedon(const f2c::types::Cell& field_cell,
                                     double op_width,
                                     double headland_width,

--- a/ros2/src/mowgli_coverage/include/mowgli_coverage/coverage_server.hpp
+++ b/ros2/src/mowgli_coverage/include/mowgli_coverage/coverage_server.hpp
@@ -67,6 +67,11 @@ private:
   // Drop straight swaths shorter than this (m) — a sliver clip from a concave
   // notch isn't worth an in-place pivot. Read live (field-tunable).
   double min_swath_length_{0.15};
+
+  // One-shot guard so the "configured chassis_safety_inset below the robot
+  // half-width floor" WARNING is logged once, not on every plan (field tuning
+  // can leave the inset below the floor for a whole session).
+  bool inset_floor_warned_{false};
 };
 
 }  // namespace mowgli_coverage

--- a/ros2/src/mowgli_coverage/src/coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_planning.cpp
@@ -8,7 +8,9 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
 #include <limits>
+#include <string>
 
 namespace mowgli_coverage
 {
@@ -17,6 +19,16 @@ namespace
 {
 
 constexpr double kDensifyStep = 0.10;  // m between ring polyline points
+
+// Format a "dropped <what> <val><cmp><thresh>" diagnostics line without pulling
+// in <sstream>/<iomanip>. Values are short distances/areas, so 4 decimals is
+// plenty of resolution for a log line.
+std::string fmtDrop(const char* what, double value, const char* cmp, double thresh)
+{
+  char buf[128];
+  std::snprintf(buf, sizeof(buf), "dropped %s%.4f%s%.4f", what, value, cmp, thresh);
+  return std::string(buf);
+}
 
 // Append the densified [a, b) segment to `out` (b exclusive: the next segment
 // starts at b, so shared vertices are emitted once and segments chain).
@@ -552,6 +564,9 @@ BoustrophedonPlan planBoustrophedon(const f2c::types::Cell& field_cell,
                                     double min_swath_length)
 {
   BoustrophedonPlan plan;
+  // Polygon area the planned-coverage fraction is taken over (the operator's
+  // authorised area, before any inset). Instrumentation only.
+  plan.diagnostics.field_area = field_cell.area();
 
   f2c::hg::ConstHL hl;
   f2c::types::Cells cells;
@@ -582,6 +597,7 @@ BoustrophedonPlan planBoustrophedon(const f2c::types::Cell& field_cell,
   // Drop degenerate micro-loops (a near-consumed tiny field can yield a
   // centimetre-scale innermost ring that isn't worth driving).
   constexpr double kMinRingPerimeter = 1.0;  // m
+  double ring_strip_area = 0.0;  // Σ perimeter·op_width of KEPT rings (for the fraction)
   for (const auto& pass_lines : headland_passes)
   {
     auto loops = ringPassToLoops(pass_lines);
@@ -594,8 +610,10 @@ BoustrophedonPlan planBoustrophedon(const f2c::types::Cell& field_cell,
       }
       if (perim < kMinRingPerimeter)
       {
+        plan.diagnostics.drops.push_back(fmtDrop("ring perim=", perim, "<", kMinRingPerimeter));
         continue;
       }
+      ring_strip_area += perim * op_width;
       plan.rings.push_back(std::move(loop));
     }
   }
@@ -605,6 +623,10 @@ BoustrophedonPlan planBoustrophedon(const f2c::types::Cell& field_cell,
   f2c::types::Cells mainland = hl.generateHeadlands(safe_cells, n_rings * op_width);
   if (mainland.size() == 0 || mainland.area() < 1e-6)
   {
+    // Rings-only is a valid plan — still report the planned fraction it covers.
+    plan.diagnostics.planned_area = ring_strip_area;
+    plan.diagnostics.planned_fraction =
+        (plan.diagnostics.field_area > 1e-9) ? ring_strip_area / plan.diagnostics.field_area : 0.0;
     return plan;
   }
 
@@ -619,11 +641,13 @@ BoustrophedonPlan planBoustrophedon(const f2c::types::Cell& field_cell,
   f2c::sg::BruteForce bf;
   f2c::obj::NSwath n_swath_obj;
   f2c::rp::BoustrophedonOrder order;
+  double swath_strip_area = 0.0;  // Σ length·op_width of KEPT swaths (for the fraction)
   for (std::size_t i = 0; i < mainland.size(); ++i)
   {
     const auto cell = mainland.getGeometry(i);
     if (cell.area() < 1e-6)
     {
+      plan.diagnostics.drops.push_back(fmtDrop("mainland cell area=", cell.area(), "<", 1e-6));
       continue;
     }
     f2c::types::Swaths swaths = (mow_angle_rad >= 0.0)
@@ -647,15 +671,28 @@ BoustrophedonPlan planBoustrophedon(const f2c::types::Cell& field_cell,
       const double len = std::hypot(p1.getX() - p0.getX(), p1.getY() - p0.getY());
       if (len < min_swath_length)
       {
+        plan.diagnostics.drops.push_back(fmtDrop("swath len=", len, "<", min_swath_length));
         continue;  // sliver clip — not worth a pivot
       }
       if (plan.swaths.empty())
       {
         plan.swath_angle_rad = std::atan2(p1.getY() - p0.getY(), p1.getX() - p0.getX());
       }
+      swath_strip_area += len * op_width;
       plan.swaths.push_back({{p0.getX(), p0.getY()}, {p1.getX(), p1.getY()}});
     }
   }
+
+  // Planned-coverage fraction: strip areas of the kept rings + swaths over the
+  // polygon area. Coarse (strips butt rather than overlap; corners double-count
+  // slightly), so it is a visibility metric, not a guarantee — but it makes a
+  // partially-planned area (slivers/rings/cells silently dropped above) VISIBLE
+  // in the server log so the next iteration can decide.
+  plan.diagnostics.planned_area = ring_strip_area + swath_strip_area;
+  plan.diagnostics.planned_fraction =
+      (plan.diagnostics.field_area > 1e-9)
+          ? plan.diagnostics.planned_area / plan.diagnostics.field_area
+          : 0.0;
 
   return plan;
 }

--- a/ros2/src/mowgli_coverage/src/coverage_server.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_server.cpp
@@ -357,10 +357,31 @@ void CoverageServer::planCoverage()
   {
     // Geometry knobs read LIVE so they're `ros2 param set`-tunable between
     // plans (field iteration without a node restart).
-    const double chassis_safety_inset = get_parameter("chassis_safety_inset").as_double();
+    const double configured_inset = get_parameter("chassis_safety_inset").as_double();
     const double min_swath_length = get_parameter("min_swath_length").as_double();
     const double mow_angle_rad =
         (goal->mow_angle_deg < 0.0) ? -1.0 : goal->mow_angle_deg * M_PI / 180.0;
+
+    // SAFETY FLOOR: the boundary buffer must be at least the chassis half-width,
+    // or worst-case tracking error pushes a spinning blade past the operator
+    // polygon. chassis_safety_inset is field-tunable and has drifted to 0.0/0.08
+    // on deployed configs, which (with a 0.40 m chassis) let the robot excurse
+    // 0.32-0.39 m outside a concave boundary. Floor the planning inset at
+    // robot_width/2 regardless of the configured value.
+    const double inset_floor = robot_width_ * 0.5;
+    const double effective_inset = std::max(configured_inset, inset_floor);
+    if (effective_inset > configured_inset + 1e-9 && !inset_floor_warned_)
+    {
+      inset_floor_warned_ = true;
+      RCLCPP_WARN(get_logger(),
+                  "chassis_safety_inset=%.3fm is below the safety floor robot_width/2=%.3fm "
+                  "(robot_width=%.2fm) — planning at %.3fm so the chassis cannot cross the "
+                  "boundary. The chassis half-width is governing the boundary margin.",
+                  configured_inset,
+                  inset_floor,
+                  robot_width_,
+                  effective_inset);
+    }
 
     f2c::types::Cell cell = buildCellFromGoal(*goal);
 
@@ -368,15 +389,30 @@ void CoverageServer::planCoverage()
                                                operation_width_,
                                                default_headland_width_,
                                                num_headland_passes_,
-                                               chassis_safety_inset,
+                                               effective_inset,
                                                mow_angle_rad,
                                                min_swath_length);
+
+    // Instrumentation (no behaviour change): surface every piece the planner
+    // dropped (slivers, tiny rings, micro-cells) and the planned-coverage
+    // fraction, so partial coverage is visible in the log instead of silent.
+    for (const auto& d : plan.diagnostics.drops)
+    {
+      RCLCPP_INFO(get_logger(), "PlanCoverage: %s", d.c_str());
+    }
+    RCLCPP_INFO(get_logger(),
+                "PlanCoverage: planned coverage ~%.1f%% (%.2f/%.2f m² as op_width strips), "
+                "%zu piece(s) dropped",
+                100.0 * plan.diagnostics.planned_fraction,
+                plan.diagnostics.planned_area,
+                plan.diagnostics.field_area,
+                plan.diagnostics.drops.size());
 
     if (plan.rings.empty() && plan.swaths.empty())
     {
       result->success = false;
       result->message = "field too small after insets (chassis_safety_inset=" +
-                        std::to_string(chassis_safety_inset) +
+                        std::to_string(effective_inset) +
                         "m, headland=" + std::to_string(default_headland_width_) + "m)";
       RCLCPP_WARN(get_logger(),
                   "PlanCoverage: %s (field area=%.2fm²)",

--- a/ros2/src/mowgli_coverage/src/coverage_server.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_server.cpp
@@ -411,9 +411,9 @@ void CoverageServer::planCoverage()
     if (plan.rings.empty() && plan.swaths.empty())
     {
       result->success = false;
-      result->message = "field too small after insets (chassis_safety_inset=" +
-                        std::to_string(effective_inset) +
-                        "m, headland=" + std::to_string(default_headland_width_) + "m)";
+      result->message =
+          "field too small after insets (chassis_safety_inset=" + std::to_string(effective_inset) +
+          "m, headland=" + std::to_string(default_headland_width_) + "m)";
       RCLCPP_WARN(get_logger(),
                   "PlanCoverage: %s (field area=%.2fm²)",
                   result->message.c_str(),

--- a/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
@@ -6,6 +6,7 @@
 // catch a broken plan (empty / out-of-bounds / non-serpentine / hole-crossing)
 // in CI instead of on the robot.
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <limits>
@@ -389,6 +390,78 @@ TEST(CoveragePlanning, HeadlandPassOverride)
                                       -1.0,
                                       0.15);
   EXPECT_EQ(plan.rings.size(), 3u);
+}
+
+// SAFETY FLOOR (Bug C1): the coverage server floors the planning inset at
+// robot_width/2 before calling planBoustrophedon, so a too-small configured
+// chassis_safety_inset can't let a blade cross the boundary. The floor itself
+// lives in coverage_server.cpp; here we assert the GEOMETRIC GUARANTEE it
+// provides — given the floored inset, NO planned ring point or swath endpoint
+// sits closer than robot_width/2 to the boundary. We mirror the server's floor
+// expression (max(configured, robot_width/2)) so the planner is exercised with
+// exactly the value the server would pass.
+TEST(CoveragePlanning, InsetFloorKeepsBladesInsideHalfWidth)
+{
+  constexpr double kRobotWidth = 0.40;  // 0.40 m chassis (the field excursion case)
+  constexpr double kOpWidth = 0.16;
+  constexpr double kHeadland = 0.18;
+  constexpr double kMinSwath = 0.15;
+  // The deployed-drift value that caused the 0.32-0.39 m boundary excursion:
+  // configured well below the chassis half-width.
+  constexpr double kConfiguredInset = 0.0;
+  // Server's floor: max(configured, robot_width/2).
+  const double effective_inset = std::max(kConfiguredInset, kRobotWidth * 0.5);
+  ASSERT_NEAR(effective_inset, 0.20, 1e-9) << "floor must be robot_width/2 = 0.20 m";
+
+  const auto cell = makeSquare(6.0);  // big enough to still plan after a 0.20 m inset
+  const auto plan =
+      planBoustrophedon(cell, kOpWidth, kHeadland, 0, effective_inset, -1.0, kMinSwath);
+  ASSERT_FALSE(plan.rings.empty()) << "no rings after the floored inset";
+  ASSERT_FALSE(plan.swaths.empty()) << "no swaths after the floored inset";
+
+  const auto boundary = squareRing(6.0);
+  // Densification (kDensifyStep ~0.10 m) and floating point can place a sampled
+  // ring point a few cm shy of the analytic centerline; allow a small slack but
+  // keep it well under the inset so a real breach (which would be ~0.20 m) fails.
+  constexpr double kSlack = 0.03;
+  const double min_clearance = kRobotWidth * 0.5 - kSlack;
+
+  for (const auto& loop : plan.rings)
+  {
+    for (const auto& p : loop)
+    {
+      ASSERT_TRUE(pointInRing(p.first, p.second, boundary))
+          << "ring point (" << p.first << ", " << p.second << ") is outside the boundary";
+      EXPECT_GE(distanceToRing(p.first, p.second, boundary), min_clearance)
+          << "ring point (" << p.first << ", " << p.second
+          << ") is closer than robot_width/2 to the boundary";
+    }
+  }
+  for (const auto& s : plan.swaths)
+  {
+    for (const auto& pt : {s.first, s.second})
+    {
+      ASSERT_TRUE(pointInRing(pt.first, pt.second, boundary))
+          << "swath endpoint (" << pt.first << ", " << pt.second << ") is outside the boundary";
+      EXPECT_GE(distanceToRing(pt.first, pt.second, boundary), min_clearance)
+          << "swath endpoint (" << pt.first << ", " << pt.second
+          << ") is closer than robot_width/2 to the boundary";
+    }
+  }
+}
+
+// INSTRUMENTATION (Bug A): planBoustrophedon reports a planned-coverage fraction
+// and a non-empty plan over a healthy field. The fraction is a coarse strip-area
+// estimate (visibility, not a guarantee), so we only bound it loosely.
+TEST(CoveragePlanning, DiagnosticsReportPlannedFraction)
+{
+  const auto cell = makeSquare(6.0);
+  const auto plan = planDefault(cell);
+  ASSERT_FALSE(plan.swaths.empty());
+  EXPECT_NEAR(plan.diagnostics.field_area, 36.0, 1e-6);
+  EXPECT_GT(plan.diagnostics.planned_area, 0.0);
+  // A 6 m square at 0.16 m spacing tiles densely — most of the field is planned.
+  EXPECT_GT(plan.diagnostics.planned_fraction, 0.5);
 }
 
 // pointInRing / distanceToRing handle a concave notch (kept from the previous


### PR DESCRIPTION
## Summary

The root cause behind a lot of the coverage circling / transit weaving: `controller_server` never set `odom_topic`, so it fell back to the nav2 default `"odom"` — **a topic nothing publishes on this robot**. Both MPPI and RPP ran with **zero velocity feedback**. This PR fixes that at the source and adds the telemetry + an experimental spike to tackle the remaining hard-turn problem.

(Supersedes the approach in #308, which pointed the controller at raw `/wheel_odom`; here we fix the *fused* source instead so both controllers ride `/odometry/filtered`.)

## What's in it

### 1. The fix — `fix(nav2)` (`4f5f9cde`)
- `controller_server.odom_topic: /odometry/filtered` (was silently the unpublished `/odom`).
- `fusion_graph` now publishes `twist.angular.z` on `/odometry/filtered` (it set `linear.x/y` but left `angular.z` at 0, making the fused odom unusable for angular feedback). Source = `dr_last_gz_`, the bias-corrected gyro rate that already integrates `dr_yaw_`.
- Regression test pins `controller_server.odom_topic` to a published topic so the silent default can't return.

**Hardware-validated:** `/odometry/filtered` `angular.z` now non-zero; clean coverage tracking on the headland rings with **0 pivot-stalls** and sustained forward motion.

### 2. Monitor rotation view + honest map twist — `feat(monitor)` (`b0026052`)
- `/odometry/filtered_map` now carries `twist` too (was all-zero; body twist is frame-invariant).
- `mow_session_monitor` gains a `cross_checks.rotation` block (commanded ω vs gyro vs wheel, per-sample tracking error) and a `pivot_stall` flag + summary aggregates — the telemetry needed to judge RotationShim pivots and the spike below.

### 3. Cherry-picked orthogonal fixes from `feat/ftc-revive`
- `fix(gui)`: reproject OpenMower map import across datums (`60b6dcd2`).
- `fix(coverage)`: skip nav-only zones, floor inset at robot half-width, log dropped pieces (`a5e7e571` + clang-format `626d16c5`).
- *Deliberately excluded* the FTC-revival commits — they revert MPPI→FTC for coverage and contradict this branch.

### 4. Turn-in-place injection — `feat(mppi)` SPIKE, **off by default** (`db670bf7`)
MPPI can't do the hard ~180° swath flips (Gaussian sampling never proposes a near-stationary pivot; RotationShim only re-engages on a new `setPlan()`, and we feed one continuous path). Upstream has no hook (PR #6076 pluginized only motion models; the blocker is sampling). So, as an overlay patch (same mechanism as the #6055 arc-length backport), `Optimizer::injectTurnInPlacePrimitives()` overwrites the last K sampled trajectories with a deterministic **pivot-then-advance** primitive when near-stationary + grossly mis-headed vs the path ahead. Critics score it like any other candidate.

- `turn_in_place_samples: 0` (default) = **byte-for-byte stock MPPI**; runtime-tunable via Foxglove.
- Compiles clean against the pinned Kilted ref.
- **Open question this spike answers:** do the critics actually select the pivot at a swath flip (Steve Macenski's caveat in nav2 #6032)? Measure with the new `rotation`/`pivot_stall` telemetry at `turn_in_place_samples` 100 vs 0.

## Testing
- Deployed `feat-mppi-fix` on the Yardforce; `COMMAND_START` → undock → coverage. Confirmed odom feedback live, clean ring tracking, 0 pivot-stalls. (Run stopped before the serpentine swath phase, so the hard-turn A/B is still pending.)
- `test_nav2_params.py` + coverage/behavior unit tests included.

## Safety
No change to blade/e-stop paths. The turn-in-place patch is inert at its default (`turn_in_place_samples: 0`).