### PR TITLE
fix(import): map-import timeout on huge maps + rotation without datum

### DIFF
--- a/gui/pkg/api/openmower_import.go
+++ b/gui/pkg/api/openmower_import.go
@@ -545,11 +545,21 @@ func (r datumReprojector) projectYaw(yaw, eOM, nOM float64) float64 {
 //     both offset and rotated by the UTM meridian convergence.
 func resolveReprojection(omLat, omLon *float64, mnLat, mnLon float64, mnDatumErr error) (datumReprojector, string) {
 	if omLat == nil || omLon == nil {
-		warn := "Datum OpenMower non fourni — l'import sera décalé et pivoté (convergence du méridien UTM, ~1–2°). Renseignez le datum OpenMower (OM_DATUM_LAT/LONG) pour un géoréférencement correct."
 		if mnDatumErr != nil {
-			warn = "Datum OpenMower non fourni et datum MowgliNext absent — l'import est copié tel quel (décalé et pivoté du fait de la convergence UTM). Renseignez le datum OpenMower (OM_DATUM_LAT/LONG) pour un géoréférencement correct."
+			// No OpenMower datum AND no MowgliNext datum — nothing to anchor the
+			// UTM inversion against, so copy OM coordinates straight through
+			// (offset + rotated). The operator must set a datum to georeference.
+			return datumReprojector{}, "Datum OpenMower non fourni et datum MowgliNext absent — l'import est copié tel quel (décalé et pivoté du fait de la convergence UTM). Renseignez le datum OpenMower (OM_DATUM_LAT/LONG) pour un géoréférencement correct."
 		}
-		return datumReprojector{}, warn
+		// No OpenMower datum, but the MowgliNext datum is known. OpenMower stores
+		// grid offsets relative to ITS datum; assume it's the same site as the
+		// MowgliNext datum (the usual case — same garden) and anchor the UTM
+		// inversion there. This removes the grid-north meridian-convergence
+		// ROTATION (the "imported map is rotated without datum" report); only a
+		// residual TRANSLATION remains if the two datums actually differed.
+		dn, de, zone, north := llToUTM(mnLat, mnLon)
+		r := datumReprojector{reproject: true, omDatumE: de, omDatumN: dn, omZone: zone, omNorth: north, mnLat: mnLat, mnLon: mnLon}
+		return r, "Datum OpenMower non fourni — le datum MowgliNext est utilisé comme référence : la rotation (convergence UTM) est corrigée, mais une translation résiduelle peut subsister si le datum OpenMower différait. Renseignez OM_DATUM_LAT/LONG pour un géoréférencement exact."
 	}
 
 	dn, de, zone, north := llToUTM(*omLat, *omLon)
@@ -803,11 +813,18 @@ func applyImport(c *gin.Context, rosProvider types.IRosProvider, replaceReq *mow
 	if replaceReq == nil {
 		return errors.New("apply: nil replace request")
 	}
-	// Reuse the gin request context for cancellation propagation, but
-	// give the whole sequence its own 30 s budget — same envelope as
-	// ReplaceMapRoute's timeout. save_areas does disk IO; add_area on a
-	// large polygon walk can take ~1 s each.
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+	// Reuse the gin request context for cancellation propagation, but give the
+	// whole sequence its own budget. clear_map + save_areas are fixed-cost, but
+	// each add_area rasterises its polygon into the map_server grid, which on a
+	// large area can take seconds. A fixed 30 s timed out on huge multi-area
+	// maps, so scale the budget: a 60 s base plus per-area headroom, capped at
+	// 6 min (imports are rare and one-shot — a generous ceiling beats a false
+	// timeout that leaves the map half-written).
+	budget := 60*time.Second + time.Duration(len(replaceReq.Areas))*5*time.Second
+	if budget > 6*time.Minute {
+		budget = 6 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), budget)
 	defer cancel()
 
 	logImportf("import/openmower applying: %d areas, dock=%v", len(replaceReq.Areas), dockReq != nil)

--- a/gui/pkg/api/openmower_import_test.go
+++ b/gui/pkg/api/openmower_import_test.go
@@ -289,6 +289,46 @@ func TestReproject_OnCentralMeridianHasNoRotation(t *testing.T) {
 	assert.InDelta(t, 20, n, 0.05, "north magnitude")
 }
 
+// TestResolveReprojection_NoOmDatum_UsesMnDatumToDeRotate covers the
+// "imported map rotated without datum" report: when the OpenMower datum is
+// omitted but the MowgliNext datum is known, the importer must anchor the UTM
+// inversion at the MN datum (assuming the same site) and de-rotate, NOT copy
+// the grid-north coordinates through unchanged.
+func TestResolveReprojection_NoOmDatum_UsesMnDatumToDeRotate(t *testing.T) {
+	const M = metersPerDegreeLat
+	mnLat, mnLon := 48.5, 11.5 // 2.5° off zone 32's central meridian → real convergence
+	reproj, warn := resolveReprojection(nil, nil, mnLat, mnLon, nil)
+	require.True(t, reproj.reproject, "no OM datum + known MN datum must still reproject")
+	require.NotEmpty(t, warn, "should warn that the MN datum is used as the reference")
+
+	// OM-grid coords as OpenMower stores them, anchored at the MN datum (the
+	// assumption the fix makes); project() must recover true-north ENU to ~mm.
+	dN, dE, _, _ := llToUTM(mnLat, mnLon)
+	for _, off := range [][2]float64{{0, 0}, {15, 0}, {0, 15}, {-7, 9}} {
+		lat := mnLat + off[1]/M
+		lon := mnLon + off[0]/(M*math.Cos(mnLat*math.Pi/180.0))
+		n, e, _, _ := llToUTM(lat, lon)
+		eOM, nOM := e-dE, n-dN
+		wantE := (lon - mnLon) * M * math.Cos(mnLat*math.Pi/180.0)
+		wantN := (lat - mnLat) * M
+		gotE, gotN := reproj.project(eOM, nOM)
+		assert.InDelta(t, wantE, gotE, 3e-3, "east for OM offset %v", off)
+		assert.InDelta(t, wantN, gotN, 3e-3, "north for OM offset %v", off)
+	}
+}
+
+// TestResolveReprojection_NoDatumsAtAll_PassesThrough: with neither datum there
+// is no UTM anchor, so coordinates are copied straight through (offset+rotated)
+// and the operator is warned.
+func TestResolveReprojection_NoDatumsAtAll_PassesThrough(t *testing.T) {
+	r, warn := resolveReprojection(nil, nil, 0, 0, errors.New("no datum"))
+	assert.False(t, r.reproject, "no anchor → copy through")
+	assert.NotEmpty(t, warn)
+	e, n := r.project(12.3, -4.5)
+	assert.Equal(t, 12.3, e)
+	assert.Equal(t, -4.5, n)
+}
+
 // TestReproject_SameDatumOffCentralMeridianRemovesConvergence is the core
 // regression for the "imported map rotated 1–2°" bug: even with identical OM
 // and MN datums, OpenMower's UTM grid-north coordinates must be de-rotated by


### PR DESCRIPTION
Fixes two OpenMower map-import bugs reported from the field:

**1. Huge maps time out.** `applyImport` budgeted the whole `clear_map → add_area* → save_areas` at a fixed **30 s**, but each `add_area` rasterises its polygon in map_server (seconds for a large area). Multi-area / large maps blew it and left the map half-written. Now the budget scales: **60 s base + 5 s/area, capped 6 min**.

**2. Import without a datum is rotated.** `resolveReprojection` fell back to an identity copy, leaving the map in OpenMower's **UTM grid-north** frame — rotated from MowgliNext's true-north ENU by the meridian convergence (~1–2°). When the **MowgliNext datum is known**, anchor the UTM inversion there (same-site assumption) → rotation removed; only a small residual translation remains if the datums differed (warned in the summary).

+2 unit tests. No behaviour change when an OM datum *is* supplied.